### PR TITLE
fix: Close recall scope escape hatch + add concurrency test (#9)

### DIFF
--- a/src/Eidet.Core/Services/LayerService.cs
+++ b/src/Eidet.Core/Services/LayerService.cs
@@ -103,8 +103,9 @@ public class LayerService
     }
 
     /// <summary>
-    /// Resolve a <see cref="LayerScope"/> snapshot — the value transports pass into
-    /// <see cref="MemoryService.RecallAsync(LayerScope, MemoryQuery, CancellationToken)"/>.
+    /// Resolve a <see cref="LayerScope"/> snapshot — the set of repos a recall fans out
+    /// across, used internally by <see cref="MemoryService"/> when resolving scope for
+    /// <see cref="MemoryService.RecallAsync(string, RecallOptions, CancellationToken)"/>.
     /// </summary>
     public async Task<LayerScope> ResolveScopeAsync(
         string repoId, bool crossRepo = true, CancellationToken ct = default)

--- a/src/Eidet.Core/Services/MemoryService.cs
+++ b/src/Eidet.Core/Services/MemoryService.cs
@@ -332,21 +332,6 @@ public sealed class MemoryService
         return await RecallInternalAsync(scope, query, ct);
     }
 
-    /// <summary>
-    /// Recall with a caller-resolved <see cref="LayerScope"/>. Kept for backward compat;
-    /// new callers should use <see cref="RecallAsync(string, RecallOptions, CancellationToken)"/>
-    /// which resolves scope internally.
-    /// </summary>
-    public Task<List<MemorySearchResult>> RecallAsync(LayerScope scope, MemoryQuery query, CancellationToken ct = default) =>
-        RecallInternalAsync(scope, query, ct);
-
-    /// <summary>Backward-compatible recall that takes a <see cref="MemoryQuery"/>.</summary>
-    public async Task<List<MemorySearchResult>> RecallAsync(string repoId, MemoryQuery query, CancellationToken ct = default)
-    {
-        var scope = await ResolveScopeAsync(repoId, query.CrossRepo, ct);
-        return await RecallInternalAsync(scope, query, ct);
-    }
-
     private async Task<LayerScope> ResolveScopeAsync(string repoId, bool crossRepo, CancellationToken ct)
     {
         var normalized = RepoIdNormalizer.Normalize(repoId);

--- a/tests/Eidet.Core.Tests/Services/MemoryServiceBoundaryTests.cs
+++ b/tests/Eidet.Core.Tests/Services/MemoryServiceBoundaryTests.cs
@@ -138,6 +138,67 @@ public class MemoryServiceBoundaryTests
         var after = await svc.RecallAsync("repo-a", "deployment");
         Assert.Contains(after, r => r.Id == entry.Id);
     }
+
+    [Fact]
+    public async Task Concurrent_StoreDuringRecall_NoStaleResult()
+    {
+        // The seam the friction doc named: a recall that snapshots an empty result, then a
+        // store lands (bumping the scope generation) before the recall writes its result to
+        // the cache. The recall must NOT poison the cache with the now-stale empty result.
+        var store = new GatedSearchStore();
+        var svc = new MemoryService(store);
+
+        // R1 enters the store query — having already snapshotted the scope generation — and
+        // blocks there, holding the pre-store (empty) result.
+        var recallTask = svc.RecallAsync("repo-a", "deployment");
+        await store.SearchEntered;
+
+        // A concurrent store completes fully (including the cache-generation bump in
+        // RunMutationAsync's finally) while R1 is still in flight.
+        var stored = await svc.StoreAsync("repo-a", "deployment uses kubernetes", MemoryType.Insight);
+        Assert.True(stored.Success);
+
+        // Release R1. It returns the empty snapshot it legitimately observed pre-store; its
+        // attempt to cache that result must be discarded because the generation moved.
+        store.ReleaseSearch();
+        var r1 = await recallTask;
+        Assert.Empty(r1);
+
+        // R2 must observe the concurrently-stored entry — proof that R1 did not serve a
+        // stale empty result from the cache for the TTL window.
+        var r2 = await svc.RecallAsync("repo-a", "deployment");
+        Assert.Single(r2);
+        Assert.Equal(stored.Id, r2[0].Id);
+    }
+}
+
+/// <summary>
+/// In-memory store that blocks the first full-text search after it has read the store,
+/// letting a test interleave a concurrent store between a recall's generation snapshot
+/// and its cache write. Later searches run unblocked.
+/// </summary>
+internal sealed class GatedSearchStore : InMemoryEidetStore
+{
+    private readonly TaskCompletionSource _entered = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource _released = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private int _calls;
+
+    public Task SearchEntered => _entered.Task;
+    public void ReleaseSearch() => _released.TrySetResult();
+
+    public override async Task<List<MemoryEntry>> FullTextSearchAsync(
+        IReadOnlyList<string> repoIds, MemoryQuery query, CancellationToken ct = default)
+    {
+        // Capture the result against the current store state, THEN gate — so the blocked
+        // recall returns the pre-store snapshot rather than data written while it waited.
+        var snapshot = await base.FullTextSearchAsync(repoIds, query, ct);
+        if (Interlocked.Increment(ref _calls) == 1)
+        {
+            _entered.TrySetResult();
+            await _released.Task;
+        }
+        return snapshot;
+    }
 }
 
 /// <summary>
@@ -181,7 +242,7 @@ internal class InMemoryEidetStore : IEidetStore
         }
     }
 
-    public Task<List<MemoryEntry>> FullTextSearchAsync(IReadOnlyList<string> repoIds, MemoryQuery query, CancellationToken ct = default)
+    public virtual Task<List<MemoryEntry>> FullTextSearchAsync(IReadOnlyList<string> repoIds, MemoryQuery query, CancellationToken ct = default)
     {
         lock (_lock)
         {


### PR DESCRIPTION
Audit of issue #9's shipped implementation (it's fully implemented on `main` but still open) surfaced several conformance gaps. This PR fixes the two highest-value ones.

## Changes

**1. Close the recall scope escape hatch** (`MemoryService.cs`)
Removed both public `MemoryQuery` overloads of `RecallAsync`:
- `RecallAsync(LayerScope, MemoryQuery)` — the caller-supplied-scope bypass that #9's "Out of scope" explicitly voted to drop ("bypassing internal resolution would re-open the coherence escape hatch").
- `RecallAsync(string, MemoryQuery)` — dead public surface.

Both had **zero callers** (verified across `src` + tests; all real callers use `RecallOptions`). The private `RecallInternalAsync`/`ResolveScopeAsync` path is unchanged. Fixed a dangling `<see>` doc reference in `LayerService.cs`.

> `MemoryQuery` itself stays `public`: the public `IEidetStore` port exposes it (`FullTextSearchAsync`/`VectorSearchAsync`), so full internalization would cascade into the storage port — out of scope here.

**2. Add `Concurrent_StoreDuringRecall_NoStaleResult`** (`MemoryServiceBoundaryTests.cs`)
The boundary test #9 promised but never wrote — the regression guard for the generation-token mechanism. A `GatedSearchStore` lands a store (bumping the scope generation) between a recall's generation snapshot and its cache write, and asserts the stale empty result is never served to a later recall. Pure boundary test, no internals named.

## Verification
- Core: **385 passed** (+1), Service: **164 passed**, 0 failures
- Core + Service build clean (no caller breakage)

## Not included (follow-up)
The audit also found cache-coherence leaks of the same class #9 fixed, in background paths it never enumerated: maintenance pipeline stages, `EnrichmentWorker`, and `DedupSweepStage` write without invalidating the recall cache (`MaintenanceContext` has no way to invalidate). Bounded by the 5-min cache TTL. Candidate for #10 (phase 2) or a sibling issue.

Relates to #9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
