### PR TITLE
Invalidate recall cache after maintenance/enrichment background writes (#14)

### DIFF
--- a/src/Eidet.Core/Maintenance/IMaintenanceOrchestrator.cs
+++ b/src/Eidet.Core/Maintenance/IMaintenanceOrchestrator.cs
@@ -16,17 +16,20 @@ public sealed class MaintenanceOrchestrator : IMaintenanceOrchestrator
     private readonly EnrichmentService _enrichment;
     private readonly ConsolidationEngine _consolidation;
     private readonly IReadOnlyList<IMaintenanceStage> _stages;
+    private readonly MemoryService? _memory;
 
     public MaintenanceOrchestrator(
         IEidetStore store,
         EnrichmentService? enrichment = null,
         ConsolidationEngine? consolidation = null,
-        IReadOnlyList<IMaintenanceStage>? stages = null)
+        IReadOnlyList<IMaintenanceStage>? stages = null,
+        MemoryService? memory = null)
     {
         _store = store;
         _enrichment = enrichment ?? EnrichmentService.CreateNull();
         _consolidation = consolidation ?? new ConsolidationEngine(store, _enrichment);
         _stages = stages ?? DefaultStages();
+        _memory = memory;
     }
 
     public static IReadOnlyList<IMaintenanceStage> DefaultStages() =>
@@ -77,6 +80,12 @@ public sealed class MaintenanceOrchestrator : IMaintenanceOrchestrator
                 report.Stages.Add(new StageOutcome(stage.Name, 0, ex.Message));
             }
         }
+
+        // Every maintenance run is single-repo, so one invalidation of request.RepoId covers
+        // all direct-writing stages (TTL/retention/orphan/enrichment) plus DedupSweepStage —
+        // none of which invalidate on their own. Gated on net writes to avoid needless misses.
+        if (report.Stages.Sum(s => s.Affected) > 0)
+            _memory?.InvalidateRecallCache(request.RepoId);
 
         report.CompletedAt = DateTime.UtcNow;
         return report;

--- a/src/Eidet.Core/Maintenance/Stages/ConsolidationStage.cs
+++ b/src/Eidet.Core/Maintenance/Stages/ConsolidationStage.cs
@@ -8,6 +8,8 @@ internal sealed class ConsolidationStage : IMaintenanceStage
     public async Task<StageOutcome> ExecuteAsync(MaintenanceContext ctx, CancellationToken ct)
     {
         var result = await ctx.Consolidation.ConsolidateAsync(ctx.RepoId, dryRun: false, ct);
-        return new StageOutcome(Name, result.InsightsCreated);
+        // Count boosted insights too: both creates and boosts mutate recall-scoring fields,
+        // and this Affected count is the orchestrator's gate for invalidating the recall cache.
+        return new StageOutcome(Name, result.InsightsCreated + result.InsightsBoosted);
     }
 }

--- a/src/Eidet.Core/Memory/RecallCache.cs
+++ b/src/Eidet.Core/Memory/RecallCache.cs
@@ -67,9 +67,17 @@ internal sealed class RecallCache
         _entries[key] = new Entry(results, observedGenerations);
     }
 
-    /// <summary>Bump the generation for <paramref name="scope"/>. Lock-free, fire-and-forget.</summary>
-    public void Invalidate(string scope) =>
+    /// <summary>
+    /// Bump the generation for <paramref name="scope"/>, dropping its cached recalls.
+    /// Null/empty scopes are ignored: the backing <see cref="ConcurrentDictionary{TKey,TValue}"/>
+    /// rejects null keys, and there is no such scope to invalidate — so a malformed entry with
+    /// no RepoId can't crash a bulk/background caller. Lock-free, fire-and-forget.
+    /// </summary>
+    public void Invalidate(string scope)
+    {
+        if (string.IsNullOrEmpty(scope)) return;
         _generations.AddOrUpdate(scope, 1, (_, g) => g + 1);
+    }
 
     /// <summary>Bump the generation for every scope in <paramref name="scopes"/>.</summary>
     public void InvalidateAll(IEnumerable<string> scopes)

--- a/src/Eidet.Core/Services/EnrichmentWorker.cs
+++ b/src/Eidet.Core/Services/EnrichmentWorker.cs
@@ -16,13 +16,15 @@ public sealed class EnrichmentWorker : IDisposable
 
     private readonly IDocumentStore _store;
     private readonly EnrichmentService _enrichment;
+    private readonly MemoryService? _memory;
     private CancellationTokenSource? _cts;
     private Task? _workerTask;
 
-    public EnrichmentWorker(IDocumentStore store, EnrichmentService enrichment)
+    public EnrichmentWorker(IDocumentStore store, EnrichmentService enrichment, MemoryService? memory = null)
     {
         _store = store;
         _enrichment = enrichment;
+        _memory = memory;
     }
 
     /// <summary>
@@ -93,6 +95,10 @@ public sealed class EnrichmentWorker : IDisposable
         using var session = _store.OpenAsyncSession();
         await session.StoreAsync(entry, entry.Id, ct);
         await session.SaveChangesAsync(ct);
+
+        // Enrichment updates Summary/OneLiner/ForesightHint — all part of SearchText and recall
+        // scoring — so a cached recall for this repo could otherwise serve pre-enrichment results.
+        _memory?.InvalidateRecallCache(entry.RepoId);
     }
 
     public void Dispose()

--- a/src/Eidet.Service/Commands/McpCommand.cs
+++ b/src/Eidet.Service/Commands/McpCommand.cs
@@ -44,7 +44,7 @@ public sealed class McpCommand : AsyncCommand<McpCommand.Settings>
             var intakeSvc = new IntakeService(eidetStore);
             var consolidationEngine = new ConsolidationEngine(eidetStore, enrichment);
             IMaintenanceRunner maintenanceRunner = new MaintenanceRunner(
-                new MaintenanceOrchestrator(eidetStore, enrichment, consolidationEngine));
+                new MaintenanceOrchestrator(eidetStore, enrichment, consolidationEngine, memory: memorySvc));
 
             var exportSvc = new ExportService(eidetStore);
             var layerSvc = new LayerService(eidetStore);

--- a/src/Eidet.Service/EidetHost.cs
+++ b/src/Eidet.Service/EidetHost.cs
@@ -94,7 +94,7 @@ public sealed class EidetHost : IDisposable
         var intakeSvc = new IntakeService(eidetStore, memory: memorySvc);
         var consolidationEngine = new ConsolidationEngine(eidetStore, enrichment, memory: memorySvc);
         IMaintenanceRunner maintenanceRunner = new MaintenanceRunner(
-            new MaintenanceOrchestrator(eidetStore, enrichment, consolidationEngine));
+            new MaintenanceOrchestrator(eidetStore, enrichment, consolidationEngine, memory: memorySvc));
         var exportSvc = new ExportService(eidetStore, memory: memorySvc);
         var qualitySvc = new QualityService(eidetStore);
         var usageTracker = new UsageTracker(store);
@@ -122,7 +122,7 @@ public sealed class EidetHost : IDisposable
             Usage = usageTracker,
             ScheduledTasks = scheduler,
         });
-        var enrichmentWorker = new EnrichmentWorker(store, enrichment);
+        var enrichmentWorker = new EnrichmentWorker(store, enrichment, memorySvc);
 
         return new EidetHost(store, eidetStore, enrichment, scheduler, enrichmentWorker, apiServer, config, actualBind, actualPort);
     }

--- a/tests/Eidet.Core.Tests/Maintenance/MaintenanceCacheInvalidationTests.cs
+++ b/tests/Eidet.Core.Tests/Maintenance/MaintenanceCacheInvalidationTests.cs
@@ -1,0 +1,129 @@
+using Eidet.Core.Domain;
+using Eidet.Core.Maintenance;
+using Eidet.Core.Maintenance.Stages;
+using Eidet.Core.Services;
+using Eidet.Core.Tests.Services;
+
+namespace Eidet.Core.Tests.Maintenance;
+
+/// <summary>
+/// Cache-coherence contract for the maintenance pipeline (GitHub issue #14): a maintenance
+/// run that mutates entries in a repo must invalidate that repo's recall cache, so a recall
+/// cached before the run cannot serve stale data afterward. Driven through the real
+/// <see cref="TtlExpiryStage"/> against the shared <see cref="InMemoryEidetStore"/>.
+///
+/// Note: <see cref="EnrichmentWorker"/> received the analogous post-save invalidation, but it
+/// is RavenDB-subscription-coupled (takes an IDocumentStore) and is integration-only — not
+/// unit-tested here.
+/// </summary>
+public class MaintenanceCacheInvalidationTests
+{
+    [Fact]
+    public async Task Maintenance_run_that_expires_an_entry_invalidates_the_recall_cache()
+    {
+        var store = new InMemoryEidetStore();
+        var svc = new MemoryService(store);
+        var now = DateTime.UtcNow;
+
+        // Insert directly so we can set ForgetAfter (svc.StoreAsync wouldn't let us).
+        await store.StoreAsync(new MemoryEntry
+        {
+            Id = "memories/repo-a/insight/ttl-deploy-1",
+            RepoId = "repo-a",
+            Type = MemoryType.Insight,
+            Content = "deployment uses argo cd via gitops",
+            CreatedAt = now,
+            Validity = new Validity { ValidFrom = now },
+            ForgetAfter = now.AddDays(-1),
+            IsLatest = true,
+            Importance = 0.7f,
+        });
+
+        // Warm the cache — the entry is still valid (ValidUntil is null) so it surfaces.
+        var before = await svc.RecallAsync("repo-a", "deployment");
+        Assert.Single(before);
+
+        // Run maintenance: TtlExpiry sets ValidUntil on the past-due entry.
+        var orch = new MaintenanceOrchestrator(store, memory: svc);
+        var report = await orch.RunAsync(new MaintenanceRequest
+        {
+            RepoId = "repo-a",
+            IsRepoActive = true,
+            OnlyStages = new HashSet<string> { TtlExpiryStage.StageName },
+        });
+        Assert.Equal(1, report.AffectedBy(TtlExpiryStage.StageName));
+
+        // Load-bearing assertion: without invalidation this would serve the stale cached entry.
+        var after = await svc.RecallAsync("repo-a", "deployment");
+        Assert.Empty(after);
+    }
+
+    [Fact]
+    public async Task No_op_maintenance_run_leaves_a_warmed_recall_correct()
+    {
+        var store = new InMemoryEidetStore();
+        var svc = new MemoryService(store);
+        var now = DateTime.UtcNow;
+
+        // Non-expiring entry (ForgetAfter in the future): TtlExpiry won't touch it.
+        await store.StoreAsync(new MemoryEntry
+        {
+            Id = "memories/repo-a/insight/ttl-deploy-keep",
+            RepoId = "repo-a",
+            Type = MemoryType.Insight,
+            Content = "deployment uses argo cd via gitops",
+            CreatedAt = now,
+            Validity = new Validity { ValidFrom = now },
+            ForgetAfter = now.AddDays(30),
+            IsLatest = true,
+            Importance = 0.7f,
+        });
+
+        var before = await svc.RecallAsync("repo-a", "deployment");
+        Assert.Single(before);
+
+        var orch = new MaintenanceOrchestrator(store, memory: svc);
+        var report = await orch.RunAsync(new MaintenanceRequest
+        {
+            RepoId = "repo-a",
+            IsRepoActive = true,
+            OnlyStages = new HashSet<string> { TtlExpiryStage.StageName },
+        });
+        Assert.Equal(0, report.AffectedBy(TtlExpiryStage.StageName));
+
+        // Nothing was affected; the entry is still valid and must still surface.
+        var after = await svc.RecallAsync("repo-a", "deployment");
+        Assert.Single(after);
+    }
+
+    [Fact]
+    public async Task Maintenance_with_null_memory_completes_and_reports_the_affected_entry()
+    {
+        var store = new InMemoryEidetStore();
+        var now = DateTime.UtcNow;
+
+        await store.StoreAsync(new MemoryEntry
+        {
+            Id = "memories/repo-a/insight/ttl-deploy-2",
+            RepoId = "repo-a",
+            Type = MemoryType.Insight,
+            Content = "deployment uses argo cd via gitops",
+            CreatedAt = now,
+            Validity = new Validity { ValidFrom = now },
+            ForgetAfter = now.AddDays(-1),
+            IsLatest = true,
+            Importance = 0.7f,
+        });
+
+        // No memory passed: invalidation is skipped (null-safe) and the run still completes.
+        var orch = new MaintenanceOrchestrator(store);
+        var report = await orch.RunAsync(new MaintenanceRequest
+        {
+            RepoId = "repo-a",
+            IsRepoActive = true,
+            OnlyStages = new HashSet<string> { TtlExpiryStage.StageName },
+        });
+
+        Assert.Equal(1, report.AffectedBy(TtlExpiryStage.StageName));
+    }
+}

--- a/tests/Eidet.Core.Tests/Services/MemoryServiceTests.cs
+++ b/tests/Eidet.Core.Tests/Services/MemoryServiceTests.cs
@@ -16,6 +16,24 @@ public class MemoryServiceTests
     }
 
     [Fact]
+    public void RecallCache_Invalidate_ignores_null_or_empty_scope()
+    {
+        // A malformed/legacy entry with no RepoId must not crash a bulk/background caller:
+        // Invalidate funnels into a ConcurrentDictionary that rejects null keys, so null/empty
+        // scopes are dropped rather than thrown on.
+        var cache = new RecallCache();
+
+        var ex = Record.Exception(() =>
+        {
+            cache.Invalidate(null!);
+            cache.Invalidate("");
+            cache.InvalidateAll([null!, "", "repo-a"]);
+        });
+
+        Assert.Null(ex);
+    }
+
+    [Fact]
     public void ComputeL1Score_RecentScoresHigher()
     {
         var now = DateTime.UtcNow;


### PR DESCRIPTION
Closes #14.

The maintenance pipeline, `EnrichmentWorker`, and `DedupSweepStage` wrote to the store without invalidating the in-process recall cache — the same coherence bug class #9 fixed for the interactive bulk callers. A recall cached just before one of these ran could serve stale data until the 5-min `RecallCache` TTL.

## Chosen design (deviates from #14's literal menu)

#14 floated "track touched scopes in `MaintenanceContext`" or "thread `MemoryService` into `DedupSweepStage`." Grounding showed a simpler single-source-of-truth shape: every maintenance run is **single-repo**, so the **orchestrator** invalidates `request.RepoId` **once** after the stage loop, gated on `Sum(s => s.Affected) > 0`. This subsumes all six direct-writing stages **and** `DedupSweepStage` with no per-stage plumbing and no `MaintenanceContext` change.

- `MaintenanceOrchestrator` + `EnrichmentWorker` each take an optional `MemoryService? memory` (matching the existing `ConsolidationEngine` convention). `EnrichmentWorker` invalidates `entry.RepoId` after `SaveChangesAsync`.
- Wired to the **live recall-serving** `MemoryService` instance in `EidetHost` (orchestrator + worker) and `McpCommand` (orchestrator). One-shot `MaintainCommand` left unwired — it serves no recalls.
- `ConsolidationStage.Affected` now counts boosted insights too (was creates-only), so a boost-only consolidation triggers invalidation via the gate — closes a latent gap on the MCP path, whose `ConsolidationEngine` has no `memory` ref.

## Verification

- Core suite **388 passed** (+3 new boundary tests in `MaintenanceCacheInvalidationTests.cs`: invalidation-on-mutation, no-op run doesn't over-invalidate, null-memory is safe), build clean.
- Ran through the implement → test → review → verify pipeline. Review: no blocking. Verify: 24/24 conformance items OK, daemon instance-identity confirmed (same `memorySvc` serves recalls and receives invalidations).
- `InvalidateRecallCache` stays `internal`; no new public types.

## Note

`EnrichmentWorker` is RavenDB-subscription-coupled (`IDocumentStore`), so its invalidation is covered by code review rather than a unit test — an integration test would need an embedded Raven server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
