### PR TITLE
feat(memory): route bulk callers through MemoryService gate (#10)

### DIFF
--- a/src/Eidet.Core/Maintenance/ConsolidationEngine.cs
+++ b/src/Eidet.Core/Maintenance/ConsolidationEngine.cs
@@ -15,9 +15,9 @@ public sealed class ConsolidationEngine
 {
     private readonly IEidetStore _store;
     private readonly EnrichmentService _enrichment;
-    private readonly MemoryService? _memory;
+    private readonly MemoryService _memory;
 
-    public ConsolidationEngine(IEidetStore store, EnrichmentService? enrichment = null, MemoryService? memory = null)
+    public ConsolidationEngine(IEidetStore store, EnrichmentService? enrichment, MemoryService memory)
     {
         _store = store;
         _enrichment = enrichment ?? EnrichmentService.CreateNull();
@@ -37,74 +37,72 @@ public sealed class ConsolidationEngine
 
         var groups = TagOverlapGrouper.Group(observations);
 
-        foreach (var group in groups.Where(g => g.Count >= 3))
+        await _memory.RunBulkAsync(async ctx =>
         {
-            var unionTags = group.SelectMany(o => o.Tags).Distinct().ToList();
-            var meanImportance = group.Average(o => o.Importance);
-            var proposedImportance = Math.Min(1.0f, (float)(meanImportance * 1.2));
-            var representative = group.OrderByDescending(o => o.Importance).First();
-
-            var candidate = new ConsolidationCandidate
+            foreach (var group in groups.Where(g => g.Count >= 3))
             {
-                ObservationIds = group.Select(o => o.Id).ToList(),
-                Tags = unionTags,
-                ProposedContent = representative.Content,
-                ProposedImportance = proposedImportance,
-            };
-            result.Candidates.Add(candidate);
+                var unionTags = group.SelectMany(o => o.Tags).Distinct().ToList();
+                var meanImportance = group.Average(o => o.Importance);
+                var proposedImportance = Math.Min(1.0f, (float)(meanImportance * 1.2));
+                var representative = group.OrderByDescending(o => o.Importance).First();
 
-            if (dryRun) continue;
-
-            var existingInsight = await _store.FindDuplicateAsync(repoId, representative.Content, 0.85f, ct);
-            if (existingInsight is not null && existingInsight.Type == MemoryType.Insight)
-            {
-                existingInsight.Importance = Math.Min(1.0f, existingInsight.Importance + 0.05f * group.Count);
-                existingInsight.DerivedFrom = existingInsight.DerivedFrom
-                    .Concat(candidate.ObservationIds)
-                    .Distinct()
-                    .ToList();
-                await _store.UpdateAsync(existingInsight, ct);
-                result.InsightsBoosted++;
-            }
-            else
-            {
-                var mergedContent = representative.Content;
-                if (group.Count > 5 && _enrichment.IsAvailable)
+                var candidate = new ConsolidationCandidate
                 {
-                    var merged = await _enrichment.MergeObservationsAsync(
-                        group.Select(o => o.Content).ToList(), ct);
-                    if (!string.IsNullOrEmpty(merged))
-                        mergedContent = merged;
-                }
-
-                var now = DateTime.UtcNow;
-                var insight = new MemoryEntry
-                {
-                    Id = MemoryIdGenerator.Generate(repoId, MemoryType.Insight, mergedContent, now),
-                    RepoId = repoId,
-                    Type = MemoryType.Insight,
-                    Content = mergedContent,
+                    ObservationIds = group.Select(o => o.Id).ToList(),
                     Tags = unionTags,
-                    Importance = proposedImportance,
-                    Source = "consolidation",
-                    Provenance = MemoryProvenance.Consolidation,
-                    Confidence = 0.7f,
-                    CreatedAt = now,
-                    Validity = new Validity { ValidFrom = now },
-                    DerivedFrom = candidate.ObservationIds,
-                    Entities = EntityExtractor.Extract(mergedContent),
-                    OneLiner = EntityExtractor.GenerateHeuristicOneLiner(mergedContent),
+                    ProposedContent = representative.Content,
+                    ProposedImportance = proposedImportance,
                 };
-                await _store.StoreAsync(insight, ct);
-                result.InsightsCreated++;
-            }
-        }
+                result.Candidates.Add(candidate);
 
-        // PHASE-2: migrate onto MemoryService gate — see #10. Consolidation creates / boosts
-        // insights and updates importance scores; both affect recall scoring, so the cache
-        // for this repo must be invalidated.
-        if (!dryRun && (result.InsightsCreated > 0 || result.InsightsBoosted > 0))
-            _memory?.InvalidateRecallCache(repoId);
+                if (dryRun) continue;
+
+                var existingInsight = await _store.FindDuplicateAsync(repoId, representative.Content, 0.85f, ct);
+                if (existingInsight is not null && existingInsight.Type == MemoryType.Insight)
+                {
+                    existingInsight.Importance = Math.Min(1.0f, existingInsight.Importance + 0.05f * group.Count);
+                    existingInsight.DerivedFrom = existingInsight.DerivedFrom
+                        .Concat(candidate.ObservationIds)
+                        .Distinct()
+                        .ToList();
+                    await ctx.WriteAsync(existingInsight, ct);
+                    result.InsightsBoosted++;
+                }
+                else
+                {
+                    var mergedContent = representative.Content;
+                    if (group.Count > 5 && _enrichment.IsAvailable)
+                    {
+                        var merged = await _enrichment.MergeObservationsAsync(
+                            group.Select(o => o.Content).ToList(), ct);
+                        if (!string.IsNullOrEmpty(merged))
+                            mergedContent = merged;
+                    }
+
+                    var now = DateTime.UtcNow;
+                    var insight = new MemoryEntry
+                    {
+                        Id = MemoryIdGenerator.Generate(repoId, MemoryType.Insight, mergedContent, now),
+                        RepoId = repoId,
+                        Type = MemoryType.Insight,
+                        Content = mergedContent,
+                        Tags = unionTags,
+                        Importance = proposedImportance,
+                        Source = "consolidation",
+                        Provenance = MemoryProvenance.Consolidation,
+                        Confidence = 0.7f,
+                        CreatedAt = now,
+                        Validity = new Validity { ValidFrom = now },
+                        DerivedFrom = candidate.ObservationIds,
+                        Entities = EntityExtractor.Extract(mergedContent),
+                        OneLiner = EntityExtractor.GenerateHeuristicOneLiner(mergedContent),
+                    };
+                    await ctx.StoreNewAsync(insight, ct);
+                    result.InsightsCreated++;
+                }
+            }
+            return 0;
+        }, new BulkOptions { OperationName = "consolidate" }, ct);
 
         return result;
     }
@@ -113,8 +111,8 @@ public sealed class ConsolidationEngine
     {
         if (!isRepoActive) return 0;
 
-        var updated = 0;
         var now = DateTime.UtcNow;
+        var changed = new List<MemoryEntry>();
 
         foreach (var type in Enum.GetValues<MemoryType>())
         {
@@ -132,17 +130,12 @@ public sealed class ConsolidationEngine
                     continue;
 
                 entry.Importance = decayed;
-                await _store.UpdateAsync(entry, ct);
-                updated++;
+                changed.Add(entry);
             }
         }
 
-        // PHASE-2: migrate onto MemoryService gate — see #10. Importance changes affect
-        // recall scoring; bulk decay invalidates this repo's recall cache once at the end.
-        if (updated > 0)
-            _memory?.InvalidateRecallCache(repoId);
-
-        return updated;
+        await _memory.UpdateManyAsync(changed, ct);
+        return changed.Count;
     }
 }
 

--- a/src/Eidet.Core/Maintenance/ConsolidationEngine.cs
+++ b/src/Eidet.Core/Maintenance/ConsolidationEngine.cs
@@ -134,6 +134,7 @@ public sealed class ConsolidationEngine
             }
         }
 
+        if (changed.Count == 0) return 0;
         await _memory.UpdateManyAsync(changed, ct);
         return changed.Count;
     }

--- a/src/Eidet.Core/Maintenance/IMaintenanceOrchestrator.cs
+++ b/src/Eidet.Core/Maintenance/IMaintenanceOrchestrator.cs
@@ -27,9 +27,12 @@ public sealed class MaintenanceOrchestrator : IMaintenanceOrchestrator
     {
         _store = store;
         _enrichment = enrichment ?? EnrichmentService.CreateNull();
-        _consolidation = consolidation ?? new ConsolidationEngine(store, _enrichment);
-        _stages = stages ?? DefaultStages();
         _memory = memory;
+        // The default consolidation engine shares this orchestrator's MemoryService so recall and
+        // consolidation writes hit one cache; the throwaway fallback is only reached when no memory
+        // was supplied (CLI one-shots / tests), where no long-lived recall cache exists to keep coherent.
+        _consolidation = consolidation ?? new ConsolidationEngine(store, _enrichment, _memory ?? new MemoryService(store));
+        _stages = stages ?? DefaultStages();
     }
 
     public static IReadOnlyList<IMaintenanceStage> DefaultStages() =>

--- a/src/Eidet.Core/Services/ExportService.cs
+++ b/src/Eidet.Core/Services/ExportService.cs
@@ -17,9 +17,9 @@ public class ExportService
     };
 
     private readonly IEidetStore _store;
-    private readonly MemoryService? _memory;
+    private readonly MemoryService _memory;
 
-    public ExportService(IEidetStore store, MemoryService? memory = null)
+    public ExportService(IEidetStore store, MemoryService memory)
     {
         _store = store;
         _memory = memory;
@@ -135,21 +135,8 @@ public class ExportService
 
     public async Task<int> ImportPackAsync(EidetPack pack, CancellationToken ct = default)
     {
-        var imported = 0;
-        var touchedRepos = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        foreach (var entry in pack.Entries)
-        {
-            var existing = await _store.GetAsync(entry.Id, ct);
-            if (existing != null) continue;
-
-            await _store.StoreAsync(entry, ct);
-            touchedRepos.Add(entry.RepoId);
-            imported++;
-        }
-        // PHASE-2: migrate onto MemoryService gate — see #10. Bulk-imports bypass MutationCtx,
-        // so we invalidate explicitly here to keep the recall cache coherent.
-        _memory?.InvalidateRecallCache(touchedRepos);
-        return imported;
+        var result = await _memory.WriteManyAsync(pack.Entries, new BulkWriteOptions { SkipIfExists = true }, ct);
+        return result.Added;
     }
 
     /// <summary>

--- a/src/Eidet.Core/Services/IntakeService.cs
+++ b/src/Eidet.Core/Services/IntakeService.cs
@@ -21,20 +21,20 @@ namespace Eidet.Core.Services;
 public class IntakeService
 {
     private readonly IEidetStore _store;
-    private readonly MemoryService? _memory;
+    private readonly MemoryService _memory;
     private readonly IReadOnlyList<IIntakeExtractor> _extractors;
 
     /// <summary>
     /// Constructs a service with the default extractor list. Tests and SDK consumers
-    /// that want a custom registry should use the <see cref="IntakeService(IEidetStore, IEnumerable{IIntakeExtractor}, MemoryService?)"/>
+    /// that want a custom registry should use the <see cref="IntakeService(IEidetStore, IEnumerable{IIntakeExtractor}, MemoryService)"/>
     /// overload.
     /// </summary>
-    public IntakeService(IEidetStore store, MemoryService? memory = null)
+    public IntakeService(IEidetStore store, MemoryService memory)
         : this(store, DefaultExtractors(), memory)
     {
     }
 
-    public IntakeService(IEidetStore store, IEnumerable<IIntakeExtractor> extractors, MemoryService? memory = null)
+    public IntakeService(IEidetStore store, IEnumerable<IIntakeExtractor> extractors, MemoryService memory)
     {
         _store = store;
         _memory = memory;
@@ -88,31 +88,29 @@ public class IntakeService
         return RunPipelineAsync(ctx, ct);
     }
 
-    private async Task<IntakeResult> RunPipelineAsync(IntakeContext ctx, CancellationToken ct)
-    {
-        var sink = new OrchestratorSink(_store, ctx);
-        foreach (var extractor in _extractors)
+    private Task<IntakeResult> RunPipelineAsync(IntakeContext ctx, CancellationToken ct) =>
+        _memory.RunBulkAsync(async bulk =>
         {
-            if (!extractor.AppliesTo(ctx)) continue;
-            await extractor.ExtractAsync(ctx, sink, ct);
-        }
-        var result = sink.Build();
-        // PHASE-2: migrate onto MemoryService gate — see #10. Bulk intake bypasses MutationCtx,
-        // so we invalidate the affected repo's recall cache once after all extractors run.
-        if (!ctx.DryRun && result.NewCount > 0)
-            _memory?.InvalidateRecallCache(ctx.RepoId);
-        return result;
-    }
+            var sink = new OrchestratorSink(_store, bulk, ctx);
+            foreach (var extractor in _extractors)
+            {
+                if (!extractor.AppliesTo(ctx)) continue;
+                await extractor.ExtractAsync(ctx, sink, ct);
+            }
+            return sink.Build();
+        }, new BulkOptions { OperationName = "intake" }, ct);
 
     private sealed class OrchestratorSink : IIntakeSink
     {
         private readonly IEidetStore _store;
+        private readonly BulkMutationCtx _bulk;
         private readonly IntakeContext _ctx;
         private readonly IntakeResult _result = new();
 
-        public OrchestratorSink(IEidetStore store, IntakeContext ctx)
+        public OrchestratorSink(IEidetStore store, BulkMutationCtx bulk, IntakeContext ctx)
         {
             _store = store;
+            _bulk = bulk;
             _ctx = ctx;
         }
 
@@ -162,7 +160,7 @@ public class IntakeService
                     Entities = EntityExtractor.Extract(candidate.Content),
                     OneLiner = EntityExtractor.GenerateHeuristicOneLiner(candidate.Content),
                 };
-                await _store.StoreAsync(entry, ct);
+                await _bulk.StoreNewAsync(entry, ct);
             }
 
             _result.Items.Add(item);

--- a/src/Eidet.Core/Services/LayerSyncService.cs
+++ b/src/Eidet.Core/Services/LayerSyncService.cs
@@ -19,12 +19,12 @@ public class LayerSyncService
 {
     private readonly IEidetStore _store;
     private readonly LayerService _layers;
-    private readonly MemoryService? _memory;
+    private readonly MemoryService _memory;
     private readonly Dictionary<string, ILayerSource> _sources;
 
     public LayerSyncService(
-        IEidetStore store, LayerService layers,
-        IEnumerable<ILayerSource>? sources = null, MemoryService? memory = null)
+        IEidetStore store, LayerService layers, MemoryService memory,
+        IEnumerable<ILayerSource>? sources = null)
     {
         _store = store;
         _layers = layers;
@@ -85,43 +85,34 @@ public class LayerSyncService
 
         var preview = await DiffAsync(pack, layerId, ct);
         var packEntryMap = pack.Entries.ToDictionary(e => e.Id, StringComparer.OrdinalIgnoreCase);
-        var touchedScopes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-        // Apply additions
-        foreach (var entry in preview.Entries.Where(e => e.Action == SyncAction.Add))
+        await _memory.RunBulkAsync(async ctx =>
         {
-            var packEntry = packEntryMap[entry.Id];
-            packEntry.LayerId = layerId;
-            await _store.StoreAsync(packEntry, ct);
-            touchedScopes.Add(packEntry.RepoId);
-        }
-
-        // Apply updates (overwrite stored entry with pack version)
-        foreach (var entry in preview.Entries.Where(e => e.Action == SyncAction.Update))
-        {
-            var packEntry = packEntryMap[entry.Id];
-            packEntry.LayerId = layerId;
-            await _store.UpdateAsync(packEntry, ct);
-            touchedScopes.Add(packEntry.RepoId);
-        }
-
-        // Apply removals
-        if (removeStale)
-        {
-            foreach (var entry in preview.Entries.Where(e => e.Action == SyncAction.Remove))
+            // Apply additions
+            foreach (var entry in preview.Entries.Where(e => e.Action == SyncAction.Add))
             {
-                await _store.HardDeleteAsync(entry.Id, ct);
-                // The entry's RepoId is captured by its layer membership; invalidating the
-                // layerId-as-scope is sufficient because recall scopes that include this layer
-                // resolve via LayerService and will track the layer's bumped generation.
-                touchedScopes.Add(layerId);
+                var packEntry = packEntryMap[entry.Id];
+                packEntry.LayerId = layerId;
+                await ctx.StoreNewAsync(packEntry, ct);
             }
-        }
 
-        // PHASE-2: migrate onto MemoryService gate — see #10. Layer sync touches many entries
-        // across potentially many repos; one invalidation per affected scope keeps the recall
-        // cache coherent without firing per-entry hooks.
-        _memory?.InvalidateRecallCache(touchedScopes);
+            // Apply updates (overwrite stored entry with pack version)
+            foreach (var entry in preview.Entries.Where(e => e.Action == SyncAction.Update))
+            {
+                var packEntry = packEntryMap[entry.Id];
+                packEntry.LayerId = layerId;
+                await ctx.WriteAsync(packEntry, ct);
+            }
+
+            // Apply removals. The deleted entry's RepoId is captured by its layer membership;
+            // recording the layerId-as-scope is sufficient because recall scopes that include
+            // this layer resolve via LayerService and will track the layer's bumped generation.
+            if (removeStale)
+                foreach (var entry in preview.Entries.Where(e => e.Action == SyncAction.Remove))
+                    await ctx.HardDeleteAsync(entry.Id, layerId, ct);
+
+            return 0;
+        }, new BulkOptions { OperationName = "layer-sync" }, ct);
 
         // Ensure layer is mounted, update its version
         var layer = await _store.GetLayerAsync(layerId, ct);

--- a/src/Eidet.Core/Services/MemoryService.cs
+++ b/src/Eidet.Core/Services/MemoryService.cs
@@ -580,17 +580,100 @@ public sealed class MemoryService
     public bool IsRepoActive(string repoId, int withinDays = 7) =>
         _activity.IsActive(repoId, withinDays);
 
-    // ─── Bulk-write coherence assist (PHASE-2: migrate onto BulkMutationCtx — see #10) ───
+    // ─── Bulk-write coherence assist ─────────────────────────────────
 
     /// <summary>
-    /// Bumps the recall-cache generation for <paramref name="scope"/>. Used by bulk-write
-    /// services (Export, Intake, LayerSync, Consolidation) until phase 2 routes them
-    /// through a structural <c>BulkMutationCtx</c>. See issue #10.
+    /// Bumps the recall-cache generation for <paramref name="scope"/>. Serves the bulk paths
+    /// that have not yet been migrated onto <see cref="RunBulkAsync"/> — the Enrichment worker,
+    /// the Dedup engine, and the Maintenance stages, which still write through <see cref="IEidetStore"/>
+    /// directly and invalidate by hand.
     /// </summary>
     internal void InvalidateRecallCache(string scope) => _cache.Invalidate(scope);
 
-    /// <summary>Bumps the recall-cache generation for every scope. Bulk-path helper.</summary>
+    /// <summary>
+    /// Bumps the recall-cache generation for every scope. Serves the not-yet-migrated bulk
+    /// paths (Enrichment / Dedup / Maintenance stages).
+    /// </summary>
     internal void InvalidateRecallCache(IEnumerable<string> scopes) => _cache.InvalidateAll(scopes);
+
+    // ─── Bulk mutations ──────────────────────────────────────────────
+
+    /// <summary>
+    /// Bulk-stores a sequence of pre-built entries. Each entry's <see cref="MemoryEntry.RepoId"/>
+    /// is recorded as a touched scope and invalidated exactly once when the loop completes (even
+    /// on throw). With <see cref="BulkWriteOptions.SkipIfExists"/>, entries whose id already exists
+    /// are counted as skipped rather than overwritten.
+    /// </summary>
+    public Task<BulkWriteResult> WriteManyAsync(
+        IEnumerable<MemoryEntry> entries, BulkWriteOptions? options = null, CancellationToken ct = default)
+    {
+        options ??= new BulkWriteOptions();
+        var bulkOpts = new BulkOptions
+        {
+            OperationName = "write-many",
+            FireHooks = options.FireHooks,
+            Validate = options.Validate,
+        };
+        return RunBulkAsync(async ctx =>
+        {
+            var added = 0;
+            var skipped = 0;
+            foreach (var entry in entries)
+            {
+                if (options.SkipIfExists && await ctx.GetAsync(entry.Id, ct) is not null)
+                {
+                    skipped++;
+                    continue;
+                }
+                await ctx.StoreNewAsync(entry, ct);
+                added++;
+            }
+            return new BulkWriteResult(added, skipped);
+        }, bulkOpts, ct);
+    }
+
+    /// <summary>
+    /// Bulk-updates a sequence of existing entries in place. Each entry's scope is recorded and
+    /// invalidated once. Returns the number of entries written.
+    /// </summary>
+    public Task<int> UpdateManyAsync(IEnumerable<MemoryEntry> entries, CancellationToken ct = default) =>
+        RunBulkAsync(async ctx =>
+        {
+            var count = 0;
+            foreach (var entry in entries)
+            {
+                await ctx.WriteAsync(entry, ct);
+                count++;
+            }
+            return count;
+        }, new BulkOptions { OperationName = "update-many" }, ct);
+
+    /// <summary>
+    /// Escape hatch for mixed-op bulk bodies (store + update + delete). Hands the body a
+    /// <see cref="BulkMutationCtx"/> whose write methods each record the touched scope; the
+    /// surrounding pipeline invalidates each touched scope exactly once in a <c>finally</c>,
+    /// including when the body throws. This is the structural guarantee callers used to provide
+    /// by hand-calling <c>InvalidateRecallCache</c>.
+    /// </summary>
+    /// <remarks>
+    /// The touched-scope set is shared by reference and is not thread-safe; writes within a body
+    /// must run sequentially (no <c>Task.WhenAll</c> over <see cref="BulkMutationCtx"/> writes).
+    /// </remarks>
+    public async Task<T> RunBulkAsync<T>(
+        Func<BulkMutationCtx, Task<T>> body, BulkOptions? options = null, CancellationToken ct = default)
+    {
+        options ??= new BulkOptions();
+        var touched = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var ctx = new BulkMutationCtx(_store, touched, _hooks, options);
+        try
+        {
+            return await body(ctx);
+        }
+        finally
+        {
+            _cache.InvalidateAll(touched);
+        }
+    }
 
     // ─── Internal gate ────────────────────────────────────────────────
 
@@ -655,6 +738,80 @@ internal readonly struct MutationCtx
     public Task<string> StoreNewAsync(MemoryEntry entry, CancellationToken ct) => _store.StoreAsync(entry, ct);
     public Task WriteAsync(MemoryEntry entry, CancellationToken ct) => _store.UpdateAsync(entry, ct);
     public Task<bool> ForgetAsync(string id, CancellationToken ct) => _store.ForgetAsync(id, ct);
+}
+
+/// <summary>
+/// Bulk-mutation gate handed to a <see cref="MemoryService.RunBulkAsync{T}"/> body. Every write
+/// records its scope into a set shared with the surrounding pipeline, which invalidates each
+/// touched scope exactly once (including on throw). Public because it appears in the public
+/// <c>RunBulkAsync</c> signature; the constructor is internal so only <see cref="MemoryService"/>
+/// can hand one out. A <c>readonly struct</c> (not a <c>ref struct</c>): it lives inside the async
+/// state machine produced by <c>Func&lt;BulkMutationCtx, Task&lt;T&gt;&gt;</c>.
+/// </summary>
+public readonly struct BulkMutationCtx
+{
+    private readonly IEidetStore _store;
+    private readonly HashSet<string> _touched;
+    private readonly IHookRunner _hooks;
+    private readonly BulkOptions _options;
+
+    internal BulkMutationCtx(IEidetStore store, HashSet<string> touched, IHookRunner hooks, BulkOptions options)
+    {
+        _store = store;
+        _touched = touched;
+        _hooks = hooks;
+        _options = options;
+    }
+
+    public async Task<string> StoreNewAsync(MemoryEntry entry, CancellationToken ct)
+    {
+        if (_options.Validate)
+        {
+            var result = WriteValidator.Validate(entry.Content, entry.Type);
+            if (!result.Passed)
+                throw new InvalidOperationException($"Bulk write rejected: {result.Reason}");
+        }
+
+        var id = await _store.StoreAsync(entry, ct);
+        _touched.Add(entry.RepoId);
+
+        // Pre-store hook gating is intentionally unsupported in bulk; only the post-store
+        // notification fires (opt-in, fire-and-forget).
+        if (_options.FireHooks)
+            _ = _hooks.RunPostHooksAsync(HookEvent.PostStore, new HookContext
+            {
+                Event = "post-store",
+                Repo = entry.RepoId,
+                Data = new { id, type = entry.Type.ToString().ToLowerInvariant() },
+            }, default);
+
+        return id;
+    }
+
+    public async Task WriteAsync(MemoryEntry entry, CancellationToken ct)
+    {
+        await _store.UpdateAsync(entry, ct);
+        _touched.Add(entry.RepoId);
+    }
+
+    public async Task<bool> ForgetAsync(string id, CancellationToken ct)
+    {
+        var existing = await _store.GetAsync(id, ct);
+        var forgotten = await _store.ForgetAsync(id, ct);
+        if (forgotten && existing is not null)
+            _touched.Add(existing.RepoId);
+        return forgotten;
+    }
+
+    public async Task<bool> HardDeleteAsync(string id, string scope, CancellationToken ct)
+    {
+        var deleted = await _store.HardDeleteAsync(id, ct);
+        if (deleted)
+            _touched.Add(scope);
+        return deleted;
+    }
+
+    public Task<MemoryEntry?> GetAsync(string id, CancellationToken ct) => _store.GetAsync(id, ct);
 }
 
 /// <summary>

--- a/src/Eidet.Core/Services/MemoryServiceOptions.cs
+++ b/src/Eidet.Core/Services/MemoryServiceOptions.cs
@@ -35,3 +35,22 @@ public sealed record EditOptions
     public string? Summary { get; init; }
     public string? ForesightHint { get; init; }
 }
+
+/// <summary>Options for <see cref="MemoryService.RunBulkAsync{T}"/>. Hooks and validation are off by default — bulk paths opt in.</summary>
+public sealed record BulkOptions
+{
+    public string OperationName { get; init; } = "bulk";
+    public bool FireHooks { get; init; }
+    public bool Validate { get; init; }
+}
+
+/// <summary>Options for <see cref="MemoryService.WriteManyAsync"/>.</summary>
+public sealed record BulkWriteOptions
+{
+    public bool SkipIfExists { get; init; }
+    public bool FireHooks { get; init; }
+    public bool Validate { get; init; }
+}
+
+/// <summary>Outcome of a <see cref="MemoryService.WriteManyAsync"/> call.</summary>
+public sealed record BulkWriteResult(int Added, int Skipped);

--- a/src/Eidet.Service/Commands/ExportCommand.cs
+++ b/src/Eidet.Service/Commands/ExportCommand.cs
@@ -51,7 +51,7 @@ public sealed class ExportCommand : AsyncCommand<ExportCommand.Settings>
         var config = ConfigManager.Load();
         var store = DocumentStoreFactory.CreateFromConfig(config);
         var eidetStore = new RavenEidetStore(store);
-        var exportSvc = new ExportService(eidetStore);
+        var exportSvc = new ExportService(eidetStore, new MemoryService(eidetStore));
 
         var repoId = Eidet.Core.Domain.RepoIdNormalizer.Normalize(settings.Repo ?? Directory.GetCurrentDirectory());
 

--- a/src/Eidet.Service/Commands/IntakeCommand.cs
+++ b/src/Eidet.Service/Commands/IntakeCommand.cs
@@ -25,7 +25,7 @@ public sealed class IntakeCommand : AsyncCommand<IntakeCommand.Settings>
         var config = ConfigManager.Load();
         var store = DocumentStoreFactory.CreateFromConfig(config);
         var eidetStore = new RavenEidetStore(store);
-        var intakeSvc = new IntakeService(eidetStore);
+        var intakeSvc = new IntakeService(eidetStore, new MemoryService(eidetStore));
 
         var projectPath = settings.Path ?? Directory.GetCurrentDirectory();
         var repoId = projectPath;

--- a/src/Eidet.Service/Commands/LayerCommand.cs
+++ b/src/Eidet.Service/Commands/LayerCommand.cs
@@ -41,7 +41,7 @@ public sealed class LayerSyncCommand : AsyncCommand<LayerSyncCommand.Settings>
         var store = DocumentStoreFactory.CreateFromConfig(config);
         var eidetStore = new RavenEidetStore(store);
         var layerSvc = new LayerService(eidetStore);
-        var syncSvc = new LayerSyncService(eidetStore, layerSvc);
+        var syncSvc = new LayerSyncService(eidetStore, layerSvc, new MemoryService(eidetStore));
 
         try
         {

--- a/src/Eidet.Service/Commands/MaintainCommand.cs
+++ b/src/Eidet.Service/Commands/MaintainCommand.cs
@@ -27,9 +27,10 @@ public sealed class MaintainCommand : AsyncCommand<MaintainCommand.Settings>
         using var enrichment = config.Enrichment.OllamaEnabled
             ? EnrichmentService.CreateOllama(config.Enrichment.OllamaUrl, config.Enrichment.OllamaModel)
             : EnrichmentService.CreateNull();
-        var consolidationEngine = new ConsolidationEngine(eidetStore, enrichment);
+        var memorySvc = new MemoryService(eidetStore);
+        var consolidationEngine = new ConsolidationEngine(eidetStore, enrichment, memorySvc);
         IMaintenanceRunner runner = new MaintenanceRunner(
-            new MaintenanceOrchestrator(eidetStore, enrichment, consolidationEngine));
+            new MaintenanceOrchestrator(eidetStore, enrichment, consolidationEngine, memory: memorySvc));
 
         var repoId = Eidet.Core.Domain.RepoIdNormalizer.Normalize(settings.Repo ?? Directory.GetCurrentDirectory());
 

--- a/src/Eidet.Service/Commands/McpCommand.cs
+++ b/src/Eidet.Service/Commands/McpCommand.cs
@@ -41,12 +41,12 @@ public sealed class McpCommand : AsyncCommand<McpCommand.Settings>
                 ? new HookRunner(config.Hooks)
                 : NullHookRunner.Instance;
             var memorySvc = new MemoryService(eidetStore, hooks: hookRunner);
-            var intakeSvc = new IntakeService(eidetStore);
-            var consolidationEngine = new ConsolidationEngine(eidetStore, enrichment);
+            var intakeSvc = new IntakeService(eidetStore, memorySvc);
+            var consolidationEngine = new ConsolidationEngine(eidetStore, enrichment, memorySvc);
             IMaintenanceRunner maintenanceRunner = new MaintenanceRunner(
                 new MaintenanceOrchestrator(eidetStore, enrichment, consolidationEngine, memory: memorySvc));
 
-            var exportSvc = new ExportService(eidetStore);
+            var exportSvc = new ExportService(eidetStore, memorySvc);
             var layerSvc = new LayerService(eidetStore);
             var usageTracker = new UsageTracker(store);
             var workDir = settings.Repo ?? settings.WorkDir ?? Directory.GetCurrentDirectory();

--- a/tests/Eidet.Core.Tests/Maintenance/MaintenanceOrchestratorTests.cs
+++ b/tests/Eidet.Core.Tests/Maintenance/MaintenanceOrchestratorTests.cs
@@ -1,6 +1,7 @@
 using Eidet.Core.Domain;
 using Eidet.Core.Enrichment;
 using Eidet.Core.Maintenance;
+using Eidet.Core.Services;
 using Eidet.Core.Storage;
 
 namespace Eidet.Core.Tests.Maintenance;
@@ -25,7 +26,7 @@ public class MaintenanceOrchestratorTests
     {
         IEidetStore store = null!; // stub stages don't touch the store
         return new MaintenanceOrchestrator(store, EnrichmentService.CreateNull(),
-            new ConsolidationEngine(store), stages);
+            new ConsolidationEngine(store, enrichment: null, memory: new MemoryService(store)), stages);
     }
 
     [Fact]

--- a/tests/Eidet.Core.Tests/Services/MemoryServiceBoundaryTests.cs
+++ b/tests/Eidet.Core.Tests/Services/MemoryServiceBoundaryTests.cs
@@ -139,6 +139,215 @@ public class MemoryServiceBoundaryTests
         Assert.Contains(after, r => r.Id == entry.Id);
     }
 
+    // ─── Bulk-write gate (#10) ──────────────────────────────────────
+
+    private static MemoryEntry MakeEntry(string repoId, string id, string content) => new()
+    {
+        Id = id,
+        RepoId = repoId,
+        Type = MemoryType.Insight,
+        Content = content,
+        CreatedAt = DateTime.UtcNow,
+        Validity = new Validity { ValidFrom = DateTime.UtcNow },
+        IsLatest = true,
+        Importance = 0.7f,
+    };
+
+    [Fact]
+    public async Task RunBulkAsync_StoresMany_InvalidatesEachScopeOnce()
+    {
+        var store = new InMemoryEidetStore();
+        var svc = new MemoryService(store);
+
+        // Warm an empty cache for every scope the bulk will touch.
+        Assert.Empty(await svc.RecallAsync("repo-a", "kubernetes"));
+        Assert.Empty(await svc.RecallAsync("repo-b", "kubernetes"));
+        Assert.Empty(await svc.RecallAsync("repo-c", "kubernetes"));
+
+        await svc.RunBulkAsync(async ctx =>
+        {
+            await ctx.StoreNewAsync(MakeEntry("repo-a", "memories/repo-a/insight/1", "deploys to kubernetes via argo"), CancellationToken.None);
+            await ctx.StoreNewAsync(MakeEntry("repo-a", "memories/repo-a/insight/2", "kubernetes ingress is nginx"), CancellationToken.None);
+            await ctx.StoreNewAsync(MakeEntry("repo-b", "memories/repo-b/insight/1", "kubernetes cluster is gke"), CancellationToken.None);
+            await ctx.StoreNewAsync(MakeEntry("repo-c", "memories/repo-c/insight/1", "kubernetes nodes autoscale"), CancellationToken.None);
+            return 0;
+        });
+
+        // Each touched scope must observe its own new entries after the bulk. The "exactly
+        // once" bump count isn't observable through the public API; per-scope coherence is
+        // the strongest invariant we can assert from here.
+        Assert.Equal(2, (await svc.RecallAsync("repo-a", "kubernetes")).Count);
+        Assert.Single(await svc.RecallAsync("repo-b", "kubernetes"));
+        Assert.Single(await svc.RecallAsync("repo-c", "kubernetes"));
+    }
+
+    [Fact]
+    public async Task RunBulkAsync_BodyThrows_StillInvalidatesTouchedScopes()
+    {
+        var store = new InMemoryEidetStore();
+        var svc = new MemoryService(store);
+
+        // Warm repo-a's empty cache so a stale read would be observable.
+        Assert.Empty(await svc.RecallAsync("repo-a", "kubernetes"));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            svc.RunBulkAsync<int>(async ctx =>
+            {
+                await ctx.StoreNewAsync(MakeEntry("repo-a", "memories/repo-a/insight/1", "deploys to kubernetes"), CancellationToken.None);
+                throw new InvalidOperationException("boom");
+            }));
+
+        // The finally must have invalidated repo-a despite the throw — the entry written
+        // before the exception is now visible rather than masked by the stale empty cache.
+        Assert.Single(await svc.RecallAsync("repo-a", "kubernetes"));
+    }
+
+    [Fact]
+    public async Task RunBulkAsync_HardDelete_UsesExplicitScope()
+    {
+        var store = new InMemoryEidetStore();
+        var svc = new MemoryService(store);
+
+        // Entry living in scope "layer-x" — the scope we will pass to HardDeleteAsync.
+        var inLayer = MakeEntry("layer-x", "memories/layer-x/insight/1", "redis caching layer");
+        await store.StoreAsync(inLayer);
+        // Entry living in repo-a — its RepoId differs from the scope we will pass.
+        var inRepoA = MakeEntry("repo-a", "memories/repo-a/insight/1", "redis caching repo");
+        await store.StoreAsync(inRepoA);
+
+        // Warm both caches so a missed invalidation is observable as a stale hit.
+        Assert.Single(await svc.RecallAsync("layer-x", "redis"));
+        Assert.Single(await svc.RecallAsync("repo-a", "redis"));
+
+        // Delete BOTH entries but always pass the explicit scope "layer-x".
+        await svc.RunBulkAsync(async ctx =>
+        {
+            await ctx.HardDeleteAsync(inLayer.Id, "layer-x", CancellationToken.None);
+            await ctx.HardDeleteAsync(inRepoA.Id, "layer-x", CancellationToken.None);
+            return 0;
+        });
+
+        // Both entries are physically gone from the store.
+        Assert.Null(await store.GetAsync(inLayer.Id));
+        Assert.Null(await store.GetAsync(inRepoA.Id));
+
+        // The explicit scope "layer-x" was invalidated: its recall reflects the deletion.
+        Assert.Empty(await svc.RecallAsync("layer-x", "redis"));
+
+        // repo-a's scope was NOT invalidated — proving the SCOPE PARAMETER ("layer-x"), not
+        // the deleted entry's RepoId ("repo-a"), is what gets recorded. repo-a still serves
+        // its warmed (now physically stale) cache, so the recall still returns the entry.
+        Assert.Single(await svc.RecallAsync("repo-a", "redis"));
+    }
+
+    [Fact]
+    public async Task RunBulkAsync_WithFireHooks_FiresPerEntry()
+    {
+        var store = new InMemoryEidetStore();
+        var hooks = new CountingHookRunner();
+        var svc = new MemoryService(store, hooks: hooks);
+
+        await svc.RunBulkAsync(async ctx =>
+        {
+            await ctx.StoreNewAsync(MakeEntry("repo-a", "memories/repo-a/insight/1", "one"), CancellationToken.None);
+            await ctx.StoreNewAsync(MakeEntry("repo-a", "memories/repo-a/insight/2", "two"), CancellationToken.None);
+            await ctx.StoreNewAsync(MakeEntry("repo-a", "memories/repo-a/insight/3", "three"), CancellationToken.None);
+            return 0;
+        }, new BulkOptions { FireHooks = true });
+
+        Assert.Equal(3, hooks.PostStoreCount);
+
+        // Default options (FireHooks = false) must fire no post-store hooks.
+        var hooks2 = new CountingHookRunner();
+        var svc2 = new MemoryService(store, hooks: hooks2);
+        await svc2.RunBulkAsync(async ctx =>
+        {
+            await ctx.StoreNewAsync(MakeEntry("repo-b", "memories/repo-b/insight/1", "one"), CancellationToken.None);
+            await ctx.StoreNewAsync(MakeEntry("repo-b", "memories/repo-b/insight/2", "two"), CancellationToken.None);
+            return 0;
+        });
+
+        Assert.Equal(0, hooks2.PostStoreCount);
+    }
+
+    [Fact]
+    public async Task RunBulkAsync_WithValidate_RejectsBadEntry_FailsFast()
+    {
+        var store = new InMemoryEidetStore();
+        var svc = new MemoryService(store);
+
+        // Warm repo-a so we can observe whether the pre-throw good store landed + invalidated.
+        Assert.Empty(await svc.RecallAsync("repo-a", "deployment"));
+
+        var good = MakeEntry("repo-a", "memories/repo-a/insight/good", "deployment uses argo cd");
+        var bad = MakeEntry("repo-a", "memories/repo-a/observation/bad", "AWS access key: AKIAIOSFODNN7EXAMPLE");
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            svc.RunBulkAsync<int>(async ctx =>
+            {
+                await ctx.StoreNewAsync(good, CancellationToken.None);
+                await ctx.StoreNewAsync(bad, CancellationToken.None); // secret → fail-fast
+                return 0;
+            }, new BulkOptions { Validate = true }));
+
+        // Fail-fast does not roll back: the good entry stored before the bad one persists,
+        // and the finally invalidated repo-a so the recall sees it.
+        Assert.Single(await svc.RecallAsync("repo-a", "deployment"));
+        // The rejected entry was never stored.
+        Assert.Null(await store.GetAsync(bad.Id));
+    }
+
+    [Fact]
+    public async Task WriteManyAsync_SkipIfExists_SkipsExisting()
+    {
+        var store = new InMemoryEidetStore();
+        var svc = new MemoryService(store);
+
+        var a = MakeEntry("repo-a", "memories/repo-a/insight/a", "alpha deployment notes");
+        var b = MakeEntry("repo-a", "memories/repo-a/insight/b", "bravo deployment notes");
+        await store.StoreAsync(a);
+
+        var result = await svc.WriteManyAsync([a, b], new BulkWriteOptions { SkipIfExists = true });
+        Assert.Equal(1, result.Added);
+        Assert.Equal(1, result.Skipped);
+
+        // B is now searchable, A is still present — recall sees both.
+        Assert.Equal(2, (await svc.RecallAsync("repo-a", "deployment")).Count);
+
+        // Without SkipIfExists, a pre-existing id is overwritten rather than skipped.
+        var store2 = new InMemoryEidetStore();
+        var svc2 = new MemoryService(store2);
+        var a2 = MakeEntry("repo-b", "memories/repo-b/insight/a", "alpha");
+        var b2 = MakeEntry("repo-b", "memories/repo-b/insight/b", "bravo");
+        await store2.StoreAsync(a2);
+        var result2 = await svc2.WriteManyAsync([a2, b2]);
+        Assert.Equal(2, result2.Added);
+        Assert.Equal(0, result2.Skipped);
+    }
+
+    [Fact]
+    public async Task UpdateManyAsync_InvalidatesOncePerScope()
+    {
+        var store = new InMemoryEidetStore();
+        var svc = new MemoryService(store);
+
+        var e1 = MakeEntry("repo-a", "memories/repo-a/insight/1", "original alpha");
+        var e2 = MakeEntry("repo-a", "memories/repo-a/insight/2", "original bravo");
+        await store.StoreAsync(e1);
+        await store.StoreAsync(e2);
+
+        // Warm repo-a; "rewritten" matches nothing yet.
+        Assert.Empty(await svc.RecallAsync("repo-a", "rewritten"));
+
+        e1.Content = "rewritten alpha";
+        e2.Content = "rewritten bravo";
+        var written = await svc.UpdateManyAsync([e1, e2]);
+        Assert.Equal(2, written);
+
+        // repo-a's cache was invalidated — the updated content is now observable.
+        Assert.Equal(2, (await svc.RecallAsync("repo-a", "rewritten")).Count);
+    }
+
     [Fact]
     public async Task Concurrent_StoreDuringRecall_NoStaleResult()
     {
@@ -199,6 +408,27 @@ internal sealed class GatedSearchStore : InMemoryEidetStore
         }
         return snapshot;
     }
+}
+
+/// <summary>
+/// Counts post-store hook invocations. Increments synchronously so the fire-and-forget
+/// <c>_ = RunPostHooksAsync(...)</c> in the bulk path is observable without an await race.
+/// </summary>
+internal sealed class CountingHookRunner : IHookRunner
+{
+    private int _postStore;
+    public int PostStoreCount => _postStore;
+
+    public Task<HookResult> RunPreHooksAsync(HookEvent evt, HookContext context, CancellationToken ct) =>
+        Task.FromResult(HookResult.Ok());
+
+    public Task RunPostHooksAsync(HookEvent evt, HookContext context, CancellationToken ct)
+    {
+        if (evt == HookEvent.PostStore) Interlocked.Increment(ref _postStore);
+        return Task.CompletedTask;
+    }
+
+    public bool HasHooks(HookEvent evt) => true;
 }
 
 /// <summary>

--- a/tests/Eidet.Integration.Tests/Fixtures/EidetApiFixture.cs
+++ b/tests/Eidet.Integration.Tests/Fixtures/EidetApiFixture.cs
@@ -40,7 +40,7 @@ public class EidetApiFixture : IAsyncLifetime
             var layerSvc = new LayerService(eidetStore);
             var memorySvc = new MemoryService(eidetStore, layerSvc);
             var intakeSvc = new IntakeService(eidetStore, memory: memorySvc);
-            var consolidationEngine = new ConsolidationEngine(eidetStore, memory: memorySvc);
+            var consolidationEngine = new ConsolidationEngine(eidetStore, enrichment: null, memory: memorySvc);
             IMaintenanceRunner maintenanceRunner = new MaintenanceRunner(
                 new MaintenanceOrchestrator(eidetStore, consolidation: consolidationEngine));
             var exportSvc = new ExportService(eidetStore, memory: memorySvc);

--- a/tests/Eidet.Service.Tests/Mcp/AutoIntakeOnContextTests.cs
+++ b/tests/Eidet.Service.Tests/Mcp/AutoIntakeOnContextTests.cs
@@ -70,7 +70,7 @@ public class AutoIntakeOnContextTests
     {
         var store = new FakeStore();
         var svc = new MemoryService(store);
-        var intake = new IntakeService(store);
+        var intake = new IntakeService(store, svc);
         var auto = new AutoIntakeOnContext(svc, intake, "test-repo", triggerTool: "custom_trigger");
 
         await auto.OnToolCalledAsync("eidet_context", CancellationToken.None);
@@ -95,7 +95,7 @@ public class AutoIntakeOnContextTests
     private static AutoIntakeOnContext NewAutoIntake(FakeStore store, string repoId)
     {
         var svc = new MemoryService(store);
-        var intake = new IntakeService(store);
+        var intake = new IntakeService(store, svc);
         return new AutoIntakeOnContext(svc, intake, repoId);
     }
 

--- a/tests/Eidet.Service.Tests/Mcp/McpToolDefinitionsTests.cs
+++ b/tests/Eidet.Service.Tests/Mcp/McpToolDefinitionsTests.cs
@@ -112,8 +112,8 @@ public class McpToolDefinitionsTests
     {
         var store = new StubStore();
         var svc = new MemoryService(store);
-        var consolidation = new ConsolidationEngine(store);
-        var intake = new IntakeService(store);
+        var consolidation = new ConsolidationEngine(store, enrichment: null, memory: svc);
+        var intake = new IntakeService(store, svc);
         var maintenance = new StubMaintenanceRunner();
 
         return

--- a/tests/Eidet.Service.Tests/Tools/ConsolidateToolHandlerTests.cs
+++ b/tests/Eidet.Service.Tests/Tools/ConsolidateToolHandlerTests.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Eidet.Core.Domain;
 using Eidet.Core.Maintenance;
+using Eidet.Core.Services;
 using Eidet.Core.Storage;
 using Eidet.Service.Tools;
 using Eidet.Service.Tools.Handlers;
@@ -31,8 +32,11 @@ public class ConsolidateToolHandlerTests
         Assert.Equal(ToolStatus.Ok, result.Status);
     }
 
-    private static ConsolidateToolHandler NewHandler() =>
-        new(new ConsolidationEngine(new EmptyStore()));
+    private static ConsolidateToolHandler NewHandler()
+    {
+        var store = new EmptyStore();
+        return new(new ConsolidationEngine(store, enrichment: null, memory: new MemoryService(store)));
+    }
 
     private static Task<ToolResult> Invoke(ConsolidateToolHandler handler, object args) =>
         handler.ExecuteAsync(new ToolRequest(

--- a/tests/Eidet.Service.Tests/Tools/IntakeToolHandlerTests.cs
+++ b/tests/Eidet.Service.Tests/Tools/IntakeToolHandlerTests.cs
@@ -42,8 +42,11 @@ public class IntakeToolHandlerTests
         }
     }
 
-    private static IntakeToolHandler NewHandler() =>
-        new(new IntakeService(new EmptyStore()));
+    private static IntakeToolHandler NewHandler()
+    {
+        var store = new EmptyStore();
+        return new(new IntakeService(store, new MemoryService(store)));
+    }
 
     private static Task<ToolResult> Invoke(IntakeToolHandler handler, object args) =>
         InvokeWithRepo(handler, "test-repo", args);


### PR DESCRIPTION
Closes #10. Phase 2 of #9 — makes the bulk-write cache-coherence invariant **structural** instead of a set of tactical, hand-maintained `InvalidateRecallCache` calls.

## What changed

**New bulk API on `MemoryService`**
- `RunBulkAsync<T>(Func<BulkMutationCtx, Task<T>>, BulkOptions?, ct)` — escape hatch for mixed-op bodies.
- `WriteManyAsync(...)` (pure-store, with `SkipIfExists`) and `UpdateManyAsync(...)` (pure-update) — thin shortcuts over `RunBulkAsync`.
- `public readonly struct BulkMutationCtx` (internal ctor): `StoreNewAsync` / `WriteAsync` / `ForgetAsync` / `HardDeleteAsync(id, scope)` / `GetAsync`. Scopes are inferred from `entry.RepoId` (explicit `scope` arg for hard-delete); every touched scope is invalidated **exactly once in a `finally`, including when the body throws**. `readonly struct` (not `ref struct`) so it survives the async state machine.
- `BulkOptions` / `BulkWriteOptions` / `BulkWriteResult` records. Hooks + validation are opt-in (off by default); `Validate=true` is fail-fast.

**Four callers migrated** off direct `IEidetStore` writes — every tactical `InvalidateRecallCache` call and `touchedScopes`/`touchedRepos` set deleted:
- `ExportService.ImportPackAsync` → `WriteManyAsync(SkipIfExists)`
- `IntakeService` → sink writes via the ctx (dedup read still on the store)
- `LayerSyncService.SyncAsync` → `RunBulkAsync` (Add/Update/HardDelete-with-explicit-`layerId`)
- `ConsolidationEngine` → `ConsolidateAsync` via `RunBulkAsync`; `ApplyImportanceDecayAsync` via `UpdateManyAsync`

`MemoryService` is now a **required** constructor dependency on those four (compile-time guarantee that bulk writes route through the gate); the ~11 construction sites were updated.

## Scope notes / deviations from the RFC
- **`InvalidateRecallCache` stays `internal`, not `private`** (the RFC's stated end-state). It's still called by `EnrichmentWorker`, `DedupEngine`, and `MaintenanceOrchestrator` — all outside this issue's four-caller scope. Going private is a clean follow-up once those are migrated too.
- `MaintenanceOrchestrator` and the maintenance stages are untouched (a separate out-of-scope bulk path); its default `ConsolidationEngine` shares the orchestrator's `MemoryService` (documented invariant).

## Quality gates
- Build: `dotnet build Eidet.slnx` — **0 warnings, 0 errors**.
- Tests: **396 Core + 164 Service pass**, 0 skipped — including **7 new boundary tests** (per-scope invalidation, throw-still-invalidates, explicit-scope delete, opt-in per-entry hooks, fail-fast validate, the two shortcuts).
- Independent code-review + spec-conformance audit: review found **no blocking issues**; conformance audit reports **20/20 checklist items conform**. The two should-fix items raised (a dead `IntakeService` ctor param and a throwaway-`MemoryService` invariant comment) are applied in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)