### PR TITLE
refactor(memory): route last bulk writers through the gate (#17)

### DIFF
--- a/src/Eidet.Core/Maintenance/ConsolidationEngine.cs
+++ b/src/Eidet.Core/Maintenance/ConsolidationEngine.cs
@@ -24,7 +24,8 @@ public sealed class ConsolidationEngine
         _memory = memory;
     }
 
-    public async Task<ConsolidationResult> ConsolidateAsync(string repoId, bool dryRun = false, CancellationToken ct = default)
+    public async Task<ConsolidationResult> ConsolidateAsync(
+        string repoId, bool dryRun = false, CancellationToken ct = default, BulkMutationCtx? write = null)
     {
         var result = new ConsolidationResult();
 
@@ -37,77 +38,88 @@ public sealed class ConsolidationEngine
 
         var groups = TagOverlapGrouper.Group(observations);
 
-        await _memory.RunBulkAsync(async ctx =>
-        {
-            foreach (var group in groups.Where(g => g.Count >= 3))
-            {
-                var unionTags = group.SelectMany(o => o.Tags).Distinct().ToList();
-                var meanImportance = group.Average(o => o.Importance);
-                var proposedImportance = Math.Min(1.0f, (float)(meanImportance * 1.2));
-                var representative = group.OrderByDescending(o => o.Importance).First();
-
-                var candidate = new ConsolidationCandidate
-                {
-                    ObservationIds = group.Select(o => o.Id).ToList(),
-                    Tags = unionTags,
-                    ProposedContent = representative.Content,
-                    ProposedImportance = proposedImportance,
-                };
-                result.Candidates.Add(candidate);
-
-                if (dryRun) continue;
-
-                var existingInsight = await _store.FindDuplicateAsync(repoId, representative.Content, 0.85f, ct);
-                if (existingInsight is not null && existingInsight.Type == MemoryType.Insight)
-                {
-                    existingInsight.Importance = Math.Min(1.0f, existingInsight.Importance + 0.05f * group.Count);
-                    existingInsight.DerivedFrom = existingInsight.DerivedFrom
-                        .Concat(candidate.ObservationIds)
-                        .Distinct()
-                        .ToList();
-                    await ctx.WriteAsync(existingInsight, ct);
-                    result.InsightsBoosted++;
-                }
-                else
-                {
-                    var mergedContent = representative.Content;
-                    if (group.Count > 5 && _enrichment.IsAvailable)
-                    {
-                        var merged = await _enrichment.MergeObservationsAsync(
-                            group.Select(o => o.Content).ToList(), ct);
-                        if (!string.IsNullOrEmpty(merged))
-                            mergedContent = merged;
-                    }
-
-                    var now = DateTime.UtcNow;
-                    var insight = new MemoryEntry
-                    {
-                        Id = MemoryIdGenerator.Generate(repoId, MemoryType.Insight, mergedContent, now),
-                        RepoId = repoId,
-                        Type = MemoryType.Insight,
-                        Content = mergedContent,
-                        Tags = unionTags,
-                        Importance = proposedImportance,
-                        Source = "consolidation",
-                        Provenance = MemoryProvenance.Consolidation,
-                        Confidence = 0.7f,
-                        CreatedAt = now,
-                        Validity = new Validity { ValidFrom = now },
-                        DerivedFrom = candidate.ObservationIds,
-                        Entities = EntityExtractor.Extract(mergedContent),
-                        OneLiner = EntityExtractor.GenerateHeuristicOneLiner(mergedContent),
-                    };
-                    await ctx.StoreNewAsync(insight, ct);
-                    result.InsightsCreated++;
-                }
-            }
-            return 0;
-        }, new BulkOptions { OperationName = "consolidate" }, ct);
+        // Join the caller's bulk scope when handed one (maintenance stage); otherwise open our own.
+        if (write is { } w)
+            await ConsolidateGroupsAsync(w, repoId, groups, dryRun, result, ct);
+        else
+            await _memory.RunBulkAsync(
+                ctx => ConsolidateGroupsAsync(ctx, repoId, groups, dryRun, result, ct),
+                new BulkOptions { OperationName = "consolidate" }, ct);
 
         return result;
     }
 
-    public async Task<int> ApplyImportanceDecayAsync(string repoId, bool isRepoActive = true, CancellationToken ct = default)
+    private async Task<int> ConsolidateGroupsAsync(
+        BulkMutationCtx ctx, string repoId, IReadOnlyList<List<MemoryEntry>> groups,
+        bool dryRun, ConsolidationResult result, CancellationToken ct)
+    {
+        foreach (var group in groups.Where(g => g.Count >= 3))
+        {
+            var unionTags = group.SelectMany(o => o.Tags).Distinct().ToList();
+            var meanImportance = group.Average(o => o.Importance);
+            var proposedImportance = Math.Min(1.0f, (float)(meanImportance * 1.2));
+            var representative = group.OrderByDescending(o => o.Importance).First();
+
+            var candidate = new ConsolidationCandidate
+            {
+                ObservationIds = group.Select(o => o.Id).ToList(),
+                Tags = unionTags,
+                ProposedContent = representative.Content,
+                ProposedImportance = proposedImportance,
+            };
+            result.Candidates.Add(candidate);
+
+            if (dryRun) continue;
+
+            var existingInsight = await _store.FindDuplicateAsync(repoId, representative.Content, 0.85f, ct);
+            if (existingInsight is not null && existingInsight.Type == MemoryType.Insight)
+            {
+                existingInsight.Importance = Math.Min(1.0f, existingInsight.Importance + 0.05f * group.Count);
+                existingInsight.DerivedFrom = existingInsight.DerivedFrom
+                    .Concat(candidate.ObservationIds)
+                    .Distinct()
+                    .ToList();
+                await ctx.WriteAsync(existingInsight, ct);
+                result.InsightsBoosted++;
+            }
+            else
+            {
+                var mergedContent = representative.Content;
+                if (group.Count > 5 && _enrichment.IsAvailable)
+                {
+                    var merged = await _enrichment.MergeObservationsAsync(
+                        group.Select(o => o.Content).ToList(), ct);
+                    if (!string.IsNullOrEmpty(merged))
+                        mergedContent = merged;
+                }
+
+                var now = DateTime.UtcNow;
+                var insight = new MemoryEntry
+                {
+                    Id = MemoryIdGenerator.Generate(repoId, MemoryType.Insight, mergedContent, now),
+                    RepoId = repoId,
+                    Type = MemoryType.Insight,
+                    Content = mergedContent,
+                    Tags = unionTags,
+                    Importance = proposedImportance,
+                    Source = "consolidation",
+                    Provenance = MemoryProvenance.Consolidation,
+                    Confidence = 0.7f,
+                    CreatedAt = now,
+                    Validity = new Validity { ValidFrom = now },
+                    DerivedFrom = candidate.ObservationIds,
+                    Entities = EntityExtractor.Extract(mergedContent),
+                    OneLiner = EntityExtractor.GenerateHeuristicOneLiner(mergedContent),
+                };
+                await ctx.StoreNewAsync(insight, ct);
+                result.InsightsCreated++;
+            }
+        }
+        return 0;
+    }
+
+    public async Task<int> ApplyImportanceDecayAsync(
+        string repoId, bool isRepoActive = true, CancellationToken ct = default, BulkMutationCtx? write = null)
     {
         if (!isRepoActive) return 0;
 
@@ -135,7 +147,17 @@ public sealed class ConsolidationEngine
         }
 
         if (changed.Count == 0) return 0;
-        await _memory.UpdateManyAsync(changed, ct);
+
+        // Join the caller's bulk scope when handed one (maintenance stage); otherwise own one.
+        if (write is { } w)
+        {
+            foreach (var entry in changed)
+                await w.WriteAsync(entry, ct);
+        }
+        else
+        {
+            await _memory.UpdateManyAsync(changed, ct);
+        }
         return changed.Count;
     }
 }

--- a/src/Eidet.Core/Maintenance/DedupEngine.cs
+++ b/src/Eidet.Core/Maintenance/DedupEngine.cs
@@ -17,19 +17,30 @@ public sealed class DedupEngine
 {
     private readonly IEidetStore _store;
     private readonly EnrichmentService _enrichment;
-    private readonly MemoryService? _memory;
+    private readonly MemoryService _memory;
 
-    public DedupEngine(IEidetStore store, EnrichmentService? enrichment = null, MemoryService? memory = null)
+    public DedupEngine(IEidetStore store, MemoryService memory, EnrichmentService? enrichment = null)
     {
         _store = store;
-        _enrichment = enrichment ?? EnrichmentService.CreateNull();
         _memory = memory;
+        _enrichment = enrichment ?? EnrichmentService.CreateNull();
     }
 
-    public Task<DedupResult> DedupAsync(string repoId, bool dryRun = false, CancellationToken ct = default) =>
-        DedupAsync(repoId, new DedupOptions(), dryRun, ct);
+    public Task<DedupResult> DedupAsync(
+        string repoId, bool dryRun = false, CancellationToken ct = default, BulkMutationCtx? write = null) =>
+        DedupAsync(repoId, new DedupOptions(), dryRun, ct, write);
 
-    public async Task<DedupResult> DedupAsync(string repoId, DedupOptions options, bool dryRun = false, CancellationToken ct = default)
+    public Task<DedupResult> DedupAsync(
+        string repoId, DedupOptions options, bool dryRun = false, CancellationToken ct = default, BulkMutationCtx? write = null) =>
+        // Join the caller's bulk scope when handed one (maintenance stage); otherwise open our own
+        // so standalone API / MCP / scheduler runs still invalidate the recall cache exactly once.
+        write is { } w
+            ? DedupCoreAsync(repoId, options, dryRun, w, ct)
+            : _memory.RunBulkAsync(w2 => DedupCoreAsync(repoId, options, dryRun, w2, ct),
+                                   new BulkOptions { OperationName = "dedup" }, ct);
+
+    private async Task<DedupResult> DedupCoreAsync(
+        string repoId, DedupOptions options, bool dryRun, BulkMutationCtx write, CancellationToken ct)
     {
         var result = new DedupResult();
         var types = options.Types ?? Enum.GetValues<MemoryType>();
@@ -51,7 +62,7 @@ public sealed class DedupEngine
                     if (claimed.Contains(entry.Id)) break;   // entry itself was folded away — stop merging into a tombstone
                     if (cand.Id == entry.Id || claimed.Contains(cand.Id)) continue;
                     if (!byId.TryGetValue(cand.Id, out var local)) continue;
-                    await MergeAsync(entry, local, claimed, result, dryRun, ct);
+                    await MergeAsync(entry, local, claimed, result, dryRun, write, ct);
                 }
             }
 
@@ -63,19 +74,16 @@ public sealed class DedupEngine
                 {
                     if (claimed.Contains(entries[j].Id)) continue;
                     if (WordSimilarity.Compute(entries[i].Content, entries[j].Content) < LexicalThreshold) continue;
-                    await MergeAsync(entries[i], entries[j], claimed, result, dryRun, ct);
+                    await MergeAsync(entries[i], entries[j], claimed, result, dryRun, write, ct);
                 }
             }
         }
-
-        if (!dryRun && result.Merges.Count > 0)
-            _memory?.InvalidateRecallCache(repoId);
 
         return result;
     }
 
     private async Task MergeAsync(
-        MemoryEntry a, MemoryEntry b, HashSet<string> claimed, DedupResult result, bool dryRun, CancellationToken ct)
+        MemoryEntry a, MemoryEntry b, HashSet<string> claimed, DedupResult result, bool dryRun, BulkMutationCtx write, CancellationToken ct)
     {
         var (keep, discard) = a.Importance >= b.Importance ? (a, b) : (b, a);
 
@@ -94,8 +102,8 @@ public sealed class DedupEngine
 
         if (!dryRun)
         {
-            await _store.UpdateAsync(keep, ct);
-            await _store.UpdateAsync(discard, ct);
+            await write.WriteAsync(keep, ct);
+            await write.WriteAsync(discard, ct);
         }
     }
 

--- a/src/Eidet.Core/Maintenance/IMaintenanceOrchestrator.cs
+++ b/src/Eidet.Core/Maintenance/IMaintenanceOrchestrator.cs
@@ -13,25 +13,24 @@ public interface IMaintenanceOrchestrator
 public sealed class MaintenanceOrchestrator : IMaintenanceOrchestrator
 {
     private readonly IEidetStore _store;
+    private readonly MemoryService _memory;
     private readonly EnrichmentService _enrichment;
     private readonly ConsolidationEngine _consolidation;
     private readonly IReadOnlyList<IMaintenanceStage> _stages;
-    private readonly MemoryService? _memory;
 
     public MaintenanceOrchestrator(
         IEidetStore store,
+        MemoryService memory,
         EnrichmentService? enrichment = null,
         ConsolidationEngine? consolidation = null,
-        IReadOnlyList<IMaintenanceStage>? stages = null,
-        MemoryService? memory = null)
+        IReadOnlyList<IMaintenanceStage>? stages = null)
     {
         _store = store;
-        _enrichment = enrichment ?? EnrichmentService.CreateNull();
         _memory = memory;
+        _enrichment = enrichment ?? EnrichmentService.CreateNull();
         // The default consolidation engine shares this orchestrator's MemoryService so recall and
-        // consolidation writes hit one cache; the throwaway fallback is only reached when no memory
-        // was supplied (CLI one-shots / tests), where no long-lived recall cache exists to keep coherent.
-        _consolidation = consolidation ?? new ConsolidationEngine(store, _enrichment, _memory ?? new MemoryService(store));
+        // consolidation writes hit one cache.
+        _consolidation = consolidation ?? new ConsolidationEngine(store, _enrichment, _memory);
         _stages = stages ?? DefaultStages();
     }
 
@@ -48,49 +47,51 @@ public sealed class MaintenanceOrchestrator : IMaintenanceOrchestrator
         new ConsolidationStage(),
     ];
 
-    public async Task<MaintenanceReport> RunAsync(MaintenanceRequest request, CancellationToken ct = default)
-    {
-        var ctx = new MaintenanceContext
+    public Task<MaintenanceReport> RunAsync(MaintenanceRequest request, CancellationToken ct = default) =>
+        // One bulk scope per run: every direct-writing stage and both dual-use engines write
+        // through `write`, so the touched scopes are invalidated exactly once in the finally.
+        _memory.RunBulkAsync(async write =>
         {
-            Store = _store,
-            Enrichment = _enrichment,
-            Consolidation = _consolidation,
-            RepoId = request.RepoId,
-            IsRepoActive = request.IsRepoActive,
-            ObservationRetentionDays = request.ObservationRetentionDays,
-        };
+            var dedup = new DedupEngine(_store, _memory, _enrichment);
+            var report = new MaintenanceReport { RepoId = request.RepoId };
 
-        var report = new MaintenanceReport { RepoId = request.RepoId };
-
-        foreach (var stage in _stages)
-        {
-            if (ct.IsCancellationRequested) break;
-
-            if (request.OnlyStages is { Count: > 0 } only && !only.Contains(stage.Name)) continue;
-            if (request.SkipStages is { Count: > 0 } skip && skip.Contains(stage.Name)) continue;
-
-            try
+            // Built once per run: every field is run-constant, and stages share one Now and one
+            // Items scratch dictionary (the documented stage-to-stage contract).
+            var ctx = new MaintenanceContext
             {
-                var outcome = await stage.ExecuteAsync(ctx, ct);
-                report.Stages.Add(outcome);
-            }
-            catch (OperationCanceledException) when (ct.IsCancellationRequested)
-            {
-                break;
-            }
-            catch (Exception ex)
-            {
-                report.Stages.Add(new StageOutcome(stage.Name, 0, ex.Message));
-            }
-        }
+                Store = _store,
+                Write = write,
+                Enrichment = _enrichment,
+                Consolidation = _consolidation,
+                Dedup = dedup,
+                RepoId = request.RepoId,
+                IsRepoActive = request.IsRepoActive,
+                ObservationRetentionDays = request.ObservationRetentionDays,
+            };
 
-        // Every maintenance run is single-repo, so one invalidation of request.RepoId covers
-        // all direct-writing stages (TTL/retention/orphan/enrichment) plus DedupSweepStage —
-        // none of which invalidate on their own. Gated on net writes to avoid needless misses.
-        if (report.Stages.Sum(s => s.Affected) > 0)
-            _memory?.InvalidateRecallCache(request.RepoId);
+            foreach (var stage in _stages)
+            {
+                if (ct.IsCancellationRequested) break;
 
-        report.CompletedAt = DateTime.UtcNow;
-        return report;
-    }
+                if (request.OnlyStages is { Count: > 0 } only && !only.Contains(stage.Name)) continue;
+                if (request.SkipStages is { Count: > 0 } skip && skip.Contains(stage.Name)) continue;
+
+                try
+                {
+                    var outcome = await stage.ExecuteAsync(ctx, ct);
+                    report.Stages.Add(outcome);
+                }
+                catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                {
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    report.Stages.Add(new StageOutcome(stage.Name, 0, ex.Message));
+                }
+            }
+
+            report.CompletedAt = DateTime.UtcNow;
+            return report;
+        }, new BulkOptions { OperationName = "maintenance" }, ct);
 }

--- a/src/Eidet.Core/Maintenance/IMaintenanceStage.cs
+++ b/src/Eidet.Core/Maintenance/IMaintenanceStage.cs
@@ -18,8 +18,10 @@ public readonly record struct StageOutcome(string Name, int Affected, string? Er
 public sealed class MaintenanceContext
 {
     public required IEidetStore Store { get; init; }
+    public required BulkMutationCtx Write { get; init; }
     public required EnrichmentService Enrichment { get; init; }
     public required ConsolidationEngine Consolidation { get; init; }
+    public required DedupEngine Dedup { get; init; }
 
     public required string RepoId { get; init; }
     public required bool IsRepoActive { get; init; }

--- a/src/Eidet.Core/Maintenance/Stages/ConsolidationStage.cs
+++ b/src/Eidet.Core/Maintenance/Stages/ConsolidationStage.cs
@@ -7,7 +7,7 @@ internal sealed class ConsolidationStage : IMaintenanceStage
 
     public async Task<StageOutcome> ExecuteAsync(MaintenanceContext ctx, CancellationToken ct)
     {
-        var result = await ctx.Consolidation.ConsolidateAsync(ctx.RepoId, dryRun: false, ct);
+        var result = await ctx.Consolidation.ConsolidateAsync(ctx.RepoId, dryRun: false, ct, write: ctx.Write);
         // Count boosted insights too: both creates and boosts mutate recall-scoring fields,
         // and this Affected count is the orchestrator's gate for invalidating the recall cache.
         return new StageOutcome(Name, result.InsightsCreated + result.InsightsBoosted);

--- a/src/Eidet.Core/Maintenance/Stages/DedupSweepStage.cs
+++ b/src/Eidet.Core/Maintenance/Stages/DedupSweepStage.cs
@@ -8,8 +8,7 @@ internal sealed class DedupSweepStage : IMaintenanceStage
 
     public async Task<StageOutcome> ExecuteAsync(MaintenanceContext ctx, CancellationToken ct)
     {
-        var engine = new DedupEngine(ctx.Store, ctx.Enrichment);
-        var result = await engine.DedupAsync(ctx.RepoId, ct: ct);
+        var result = await ctx.Dedup.DedupAsync(ctx.RepoId, new DedupOptions(), dryRun: false, write: ctx.Write, ct: ct);
         return new StageOutcome(Name, result.MergedCount);
     }
 }

--- a/src/Eidet.Core/Maintenance/Stages/EnrichmentCleanupStage.cs
+++ b/src/Eidet.Core/Maintenance/Stages/EnrichmentCleanupStage.cs
@@ -45,7 +45,7 @@ internal sealed class EnrichmentCleanupStage : IMaintenanceStage
 
             if (changed)
             {
-                await ctx.Store.UpdateAsync(entry, ct);
+                await ctx.Write.WriteAsync(entry, ct);
                 cleaned++;
             }
         }

--- a/src/Eidet.Core/Maintenance/Stages/HeuristicEnrichmentBackfillStage.cs
+++ b/src/Eidet.Core/Maintenance/Stages/HeuristicEnrichmentBackfillStage.cs
@@ -31,7 +31,7 @@ internal sealed class HeuristicEnrichmentBackfillStage : IMaintenanceStage
 
             if (changed)
             {
-                await ctx.Store.UpdateAsync(entry, ct);
+                await ctx.Write.WriteAsync(entry, ct);
                 enriched++;
             }
         }

--- a/src/Eidet.Core/Maintenance/Stages/ImportanceDecayStage.cs
+++ b/src/Eidet.Core/Maintenance/Stages/ImportanceDecayStage.cs
@@ -7,7 +7,7 @@ internal sealed class ImportanceDecayStage : IMaintenanceStage
 
     public async Task<StageOutcome> ExecuteAsync(MaintenanceContext ctx, CancellationToken ct)
     {
-        var updated = await ctx.Consolidation.ApplyImportanceDecayAsync(ctx.RepoId, ctx.IsRepoActive, ct);
+        var updated = await ctx.Consolidation.ApplyImportanceDecayAsync(ctx.RepoId, ctx.IsRepoActive, ct, write: ctx.Write);
         return new StageOutcome(Name, updated);
     }
 }

--- a/src/Eidet.Core/Maintenance/Stages/ObservationRetentionStage.cs
+++ b/src/Eidet.Core/Maintenance/Stages/ObservationRetentionStage.cs
@@ -21,7 +21,7 @@ internal sealed class ObservationRetentionStage : IMaintenanceStage
 
             obs.Validity.ValidUntil = ctx.Now;
             obs.ForgetReason = $"Observation retention ({ctx.ObservationRetentionDays}d)";
-            await ctx.Store.UpdateAsync(obs, ct);
+            await ctx.Write.WriteAsync(obs, ct);
             expired++;
         }
 

--- a/src/Eidet.Core/Maintenance/Stages/OllamaEnrichmentStage.cs
+++ b/src/Eidet.Core/Maintenance/Stages/OllamaEnrichmentStage.cs
@@ -20,7 +20,7 @@ internal sealed class OllamaEnrichmentStage : IMaintenanceStage
 
             if (await ctx.Enrichment.EnrichMemoryAsync(entry, ct))
             {
-                await ctx.Store.UpdateAsync(entry, ct);
+                await ctx.Write.WriteAsync(entry, ct);
                 enriched++;
             }
         }

--- a/src/Eidet.Core/Maintenance/Stages/OrphanCleanupStage.cs
+++ b/src/Eidet.Core/Maintenance/Stages/OrphanCleanupStage.cs
@@ -26,7 +26,7 @@ internal sealed class OrphanCleanupStage : IMaintenanceStage
 
             entry.Validity.ValidUntil = ctx.Now;
             entry.ForgetReason = "Orphan cleanup";
-            await ctx.Store.UpdateAsync(entry, ct);
+            await ctx.Write.WriteAsync(entry, ct);
             cleaned++;
         }
 

--- a/src/Eidet.Core/Maintenance/Stages/TtlExpiryStage.cs
+++ b/src/Eidet.Core/Maintenance/Stages/TtlExpiryStage.cs
@@ -16,7 +16,7 @@ internal sealed class TtlExpiryStage : IMaintenanceStage
         {
             entry.Validity.ValidUntil = ctx.Now;
             entry.ForgetReason = "TTL expired";
-            await ctx.Store.UpdateAsync(entry, ct);
+            await ctx.Write.WriteAsync(entry, ct);
             expired++;
         }
 

--- a/src/Eidet.Core/Services/EnrichmentWorker.cs
+++ b/src/Eidet.Core/Services/EnrichmentWorker.cs
@@ -16,13 +16,13 @@ public sealed class EnrichmentWorker : IDisposable
 
     private readonly IDocumentStore _store;
     private readonly EnrichmentService _enrichment;
-    private readonly MemoryService? _memory;
+    private readonly MemoryService _memory;
     private CancellationTokenSource? _cts;
     private Task? _workerTask;
 
-    public EnrichmentWorker(IDocumentStore store, EnrichmentService enrichment, MemoryService? memory = null)
+    public EnrichmentWorker(IDocumentStore subscriptionStore, EnrichmentService enrichment, MemoryService memory)
     {
-        _store = store;
+        _store = subscriptionStore;
         _enrichment = enrichment;
         _memory = memory;
     }
@@ -92,13 +92,9 @@ public sealed class EnrichmentWorker : IDisposable
     {
         if (!await _enrichment.EnrichMemoryAsync(entry, ct)) return;
 
-        using var session = _store.OpenAsyncSession();
-        await session.StoreAsync(entry, entry.Id, ct);
-        await session.SaveChangesAsync(ct);
-
         // Enrichment updates Summary/OneLiner/ForesightHint — all part of SearchText and recall
-        // scoring — so a cached recall for this repo could otherwise serve pre-enrichment results.
-        _memory?.InvalidateRecallCache(entry.RepoId);
+        // scoring — so the write must route through the gate to invalidate this repo's recall cache.
+        await _memory.UpdateManyAsync([entry], ct);
     }
 
     public void Dispose()

--- a/src/Eidet.Core/Services/MemoryService.cs
+++ b/src/Eidet.Core/Services/MemoryService.cs
@@ -580,22 +580,6 @@ public sealed class MemoryService
     public bool IsRepoActive(string repoId, int withinDays = 7) =>
         _activity.IsActive(repoId, withinDays);
 
-    // ─── Bulk-write coherence assist ─────────────────────────────────
-
-    /// <summary>
-    /// Bumps the recall-cache generation for <paramref name="scope"/>. Serves the bulk paths
-    /// that have not yet been migrated onto <see cref="RunBulkAsync"/> — the Enrichment worker,
-    /// the Dedup engine, and the Maintenance stages, which still write through <see cref="IEidetStore"/>
-    /// directly and invalidate by hand.
-    /// </summary>
-    internal void InvalidateRecallCache(string scope) => _cache.Invalidate(scope);
-
-    /// <summary>
-    /// Bumps the recall-cache generation for every scope. Serves the not-yet-migrated bulk
-    /// paths (Enrichment / Dedup / Maintenance stages).
-    /// </summary>
-    internal void InvalidateRecallCache(IEnumerable<string> scopes) => _cache.InvalidateAll(scopes);
-
     // ─── Bulk mutations ──────────────────────────────────────────────
 
     /// <summary>
@@ -652,8 +636,7 @@ public sealed class MemoryService
     /// Escape hatch for mixed-op bulk bodies (store + update + delete). Hands the body a
     /// <see cref="BulkMutationCtx"/> whose write methods each record the touched scope; the
     /// surrounding pipeline invalidates each touched scope exactly once in a <c>finally</c>,
-    /// including when the body throws. This is the structural guarantee callers used to provide
-    /// by hand-calling <c>InvalidateRecallCache</c>.
+    /// including when the body throws — so callers never invalidate the recall cache by hand.
     /// </summary>
     /// <remarks>
     /// The touched-scope set is shared by reference and is not thread-safe; writes within a body

--- a/src/Eidet.Service/Commands/MaintainCommand.cs
+++ b/src/Eidet.Service/Commands/MaintainCommand.cs
@@ -30,7 +30,7 @@ public sealed class MaintainCommand : AsyncCommand<MaintainCommand.Settings>
         var memorySvc = new MemoryService(eidetStore);
         var consolidationEngine = new ConsolidationEngine(eidetStore, enrichment, memorySvc);
         IMaintenanceRunner runner = new MaintenanceRunner(
-            new MaintenanceOrchestrator(eidetStore, enrichment, consolidationEngine, memory: memorySvc));
+            new MaintenanceOrchestrator(eidetStore, memorySvc, enrichment, consolidationEngine));
 
         var repoId = Eidet.Core.Domain.RepoIdNormalizer.Normalize(settings.Repo ?? Directory.GetCurrentDirectory());
 

--- a/src/Eidet.Service/Commands/McpCommand.cs
+++ b/src/Eidet.Service/Commands/McpCommand.cs
@@ -44,7 +44,7 @@ public sealed class McpCommand : AsyncCommand<McpCommand.Settings>
             var intakeSvc = new IntakeService(eidetStore, memorySvc);
             var consolidationEngine = new ConsolidationEngine(eidetStore, enrichment, memorySvc);
             IMaintenanceRunner maintenanceRunner = new MaintenanceRunner(
-                new MaintenanceOrchestrator(eidetStore, enrichment, consolidationEngine, memory: memorySvc));
+                new MaintenanceOrchestrator(eidetStore, memorySvc, enrichment, consolidationEngine));
 
             var exportSvc = new ExportService(eidetStore, memorySvc);
             var layerSvc = new LayerService(eidetStore);

--- a/src/Eidet.Service/EidetHost.cs
+++ b/src/Eidet.Service/EidetHost.cs
@@ -94,7 +94,7 @@ public sealed class EidetHost : IDisposable
         var intakeSvc = new IntakeService(eidetStore, memory: memorySvc);
         var consolidationEngine = new ConsolidationEngine(eidetStore, enrichment, memory: memorySvc);
         IMaintenanceRunner maintenanceRunner = new MaintenanceRunner(
-            new MaintenanceOrchestrator(eidetStore, enrichment, consolidationEngine, memory: memorySvc));
+            new MaintenanceOrchestrator(eidetStore, memorySvc, enrichment, consolidationEngine));
         var exportSvc = new ExportService(eidetStore, memory: memorySvc);
         var qualitySvc = new QualityService(eidetStore);
         var usageTracker = new UsageTracker(store);

--- a/tests/Eidet.Core.Tests/Maintenance/DedupEngineTests.cs
+++ b/tests/Eidet.Core.Tests/Maintenance/DedupEngineTests.cs
@@ -1,5 +1,6 @@
 using Eidet.Core.Domain;
 using Eidet.Core.Maintenance;
+using Eidet.Core.Services;
 using Eidet.Core.Storage;
 using Eidet.Core.Tests.Services;
 
@@ -51,7 +52,7 @@ public class DedupEngineTests
         await store.StoreAsync(high);
         await store.StoreAsync(low);
 
-        var engine = new DedupEngine(store);
+        var engine = new DedupEngine(store, new MemoryService(store));
         var result = await engine.DedupAsync("repo-a");
 
         Assert.Equal(1, result.MergedCount);
@@ -100,7 +101,7 @@ public class DedupEngineTests
         // The vector index "knows" b is a near-dup of a.
         store.SeedNearDuplicate(a.Id, b.Id);
 
-        var engine = new DedupEngine(store);
+        var engine = new DedupEngine(store, new MemoryService(store));
         var result = await engine.DedupAsync("repo-a");
 
         Assert.Equal(1, result.MergedCount);
@@ -136,7 +137,7 @@ public class DedupEngineTests
         // Even if the index were asked, cross-type seeding must not bridge them.
         store.SeedNearDuplicate(observation.Id, insight.Id);
 
-        var engine = new DedupEngine(store);
+        var engine = new DedupEngine(store, new MemoryService(store));
         var result = await engine.DedupAsync("repo-a");
 
         Assert.Equal(0, result.MergedCount);
@@ -161,7 +162,7 @@ public class DedupEngineTests
         await store.StoreAsync(high);
         await store.StoreAsync(low);
 
-        var engine = new DedupEngine(store);
+        var engine = new DedupEngine(store, new MemoryService(store));
         var result = await engine.DedupAsync("repo-a", dryRun: true);
 
         // The would-merge pair is reported.
@@ -185,7 +186,7 @@ public class DedupEngineTests
             "The cache layer evicts least-recently-used entries on memory pressure",
             importance: 0.6f));
 
-        var engine = new DedupEngine(store);
+        var engine = new DedupEngine(store, new MemoryService(store));
         var result = await engine.DedupAsync("repo-a");
 
         Assert.Equal(0, result.MergedCount);
@@ -211,7 +212,7 @@ public class DedupEngineTests
         await store.StoreAsync(e2);
         await store.StoreAsync(e3);
 
-        var engine = new DedupEngine(store);
+        var engine = new DedupEngine(store, new MemoryService(store));
         var result = await engine.DedupAsync("repo-a");
 
         // Two merges fold e2 and e3 away; no entry is both kept and discarded.
@@ -254,7 +255,7 @@ public class DedupEngineTests
         await store.StoreAsync(obsHigh);
         await store.StoreAsync(obsLow);
 
-        var engine = new DedupEngine(store);
+        var engine = new DedupEngine(store, new MemoryService(store));
         var result = await engine.DedupAsync("repo-a",
             new DedupOptions { Types = [MemoryType.Insight] });
 
@@ -289,7 +290,7 @@ public class DedupEngineTests
         store.SeedNearDuplicate(mid.Id, high.Id);
         store.SeedNearDuplicate(mid.Id, low.Id);
 
-        var engine = new DedupEngine(store);
+        var engine = new DedupEngine(store, new MemoryService(store));
         var result = await engine.DedupAsync("repo-a");
 
         // Exactly one merge: mid folds into high; low is untouched.

--- a/tests/Eidet.Core.Tests/Maintenance/MaintenanceCacheInvalidationTests.cs
+++ b/tests/Eidet.Core.Tests/Maintenance/MaintenanceCacheInvalidationTests.cs
@@ -44,7 +44,7 @@ public class MaintenanceCacheInvalidationTests
         Assert.Single(before);
 
         // Run maintenance: TtlExpiry sets ValidUntil on the past-due entry.
-        var orch = new MaintenanceOrchestrator(store, memory: svc);
+        var orch = new MaintenanceOrchestrator(store, svc);
         var report = await orch.RunAsync(new MaintenanceRequest
         {
             RepoId = "repo-a",
@@ -82,7 +82,7 @@ public class MaintenanceCacheInvalidationTests
         var before = await svc.RecallAsync("repo-a", "deployment");
         Assert.Single(before);
 
-        var orch = new MaintenanceOrchestrator(store, memory: svc);
+        var orch = new MaintenanceOrchestrator(store, svc);
         var report = await orch.RunAsync(new MaintenanceRequest
         {
             RepoId = "repo-a",
@@ -96,34 +96,159 @@ public class MaintenanceCacheInvalidationTests
         Assert.Single(after);
     }
 
+    // ─── DedupEngine standalone cache coherence (#17) ────────────────────
+    //
+    // A standalone DedupAsync (no `write:` arg) now opens its own RunBulkAsync scope so its
+    // merge writes invalidate the recall cache. Before #17 the engine wrote through the store
+    // directly and called InvalidateRecallCache by hand; these pin the new own-scope behavior
+    // through the public recall surface.
+
     [Fact]
-    public async Task Maintenance_with_null_memory_completes_and_reports_the_affected_entry()
+    public async Task DedupEngine_standalone_run_invalidates_the_recall_cache()
     {
         var store = new InMemoryEidetStore();
-        var now = DateTime.UtcNow;
+        var svc = new MemoryService(store);
+
+        // Two near-identical entries of the same type — Jaccard well above the 0.85 lexical
+        // threshold, so the in-process lexical pass merges them (InMemoryEidetStore returns []
+        // from FindNearDuplicatesAsync, so the semantic pass never fires here).
+        await store.StoreAsync(new MemoryEntry
+        {
+            Id = "memories/repo-a/insight/dedup-high",
+            RepoId = "repo-a",
+            Type = MemoryType.Insight,
+            Content = "The deployment pipeline runs database migrations before starting the application server",
+            CreatedAt = DateTime.UtcNow,
+            Validity = new Validity { ValidFrom = DateTime.UtcNow },
+            IsLatest = true,
+            Importance = 0.8f,
+        });
+        await store.StoreAsync(new MemoryEntry
+        {
+            Id = "memories/repo-a/insight/dedup-low",
+            RepoId = "repo-a",
+            Type = MemoryType.Insight,
+            Content = "The deployment pipeline runs the database migrations before starting the application server",
+            CreatedAt = DateTime.UtcNow,
+            Validity = new Validity { ValidFrom = DateTime.UtcNow },
+            IsLatest = true,
+            Importance = 0.4f,
+        });
+
+        // Warm the cache: both entries surface for this query, so a stale post-merge hit
+        // would still return two.
+        var before = await svc.RecallAsync("repo-a", "deployment");
+        Assert.Equal(2, before.Count);
+
+        var engine = new DedupEngine(store, svc);
+        var result = await engine.DedupAsync("repo-a");   // no write: arg → own RunBulkAsync scope
+        Assert.Equal(1, result.MergedCount);
+
+        // Load-bearing assertion: WITHOUT the own-scope invalidation this recall would serve
+        // the stale pre-merge cache and still return both entries. The discarded entry now has
+        // ValidUntil set, so a coherent recall returns only the survivor.
+        var after = await svc.RecallAsync("repo-a", "deployment");
+        Assert.Single(after);
+        Assert.Equal("memories/repo-a/insight/dedup-high", after[0].Id);
+    }
+
+    [Fact]
+    public async Task DedupEngine_standalone_dryRun_leaves_a_warmed_recall_unchanged()
+    {
+        var store = new InMemoryEidetStore();
+        var svc = new MemoryService(store);
 
         await store.StoreAsync(new MemoryEntry
         {
-            Id = "memories/repo-a/insight/ttl-deploy-2",
+            Id = "memories/repo-a/insight/dedup-high",
             RepoId = "repo-a",
             Type = MemoryType.Insight,
-            Content = "deployment uses argo cd via gitops",
-            CreatedAt = now,
-            Validity = new Validity { ValidFrom = now },
-            ForgetAfter = now.AddDays(-1),
+            Content = "The deployment pipeline runs database migrations before starting the application server",
+            CreatedAt = DateTime.UtcNow,
+            Validity = new Validity { ValidFrom = DateTime.UtcNow },
             IsLatest = true,
-            Importance = 0.7f,
+            Importance = 0.8f,
+        });
+        await store.StoreAsync(new MemoryEntry
+        {
+            Id = "memories/repo-a/insight/dedup-low",
+            RepoId = "repo-a",
+            Type = MemoryType.Insight,
+            Content = "The deployment pipeline runs the database migrations before starting the application server",
+            CreatedAt = DateTime.UtcNow,
+            Validity = new Validity { ValidFrom = DateTime.UtcNow },
+            IsLatest = true,
+            Importance = 0.4f,
         });
 
-        // No memory passed: invalidation is skipped (null-safe) and the run still completes.
-        var orch = new MaintenanceOrchestrator(store);
+        var before = await svc.RecallAsync("repo-a", "deployment");
+        Assert.Equal(2, before.Count);
+
+        var engine = new DedupEngine(store, svc);
+        var result = await engine.DedupAsync("repo-a", dryRun: true);
+
+        // The would-merge pair is reported, but no write reaches the store.
+        Assert.Equal(1, result.MergedCount);
+
+        // Recall is unchanged — dry run does NOT invalidate, so the warmed result is served
+        // intact. (The engine mutates the in-memory candidate's ValidUntil in place even on a
+        // dry run — a test-double artifact, since no UpdateAsync persists it; the cache-coherence
+        // contract is asserted at the recall boundary, exactly as DedupEngineTests.DryRun_* does.)
+        var after = await svc.RecallAsync("repo-a", "deployment");
+        Assert.Equal(2, after.Count);
+    }
+
+    // ─── Maintenance run through a JOINED engine stage (#17) ─────────────
+    //
+    // ConsolidationStage routes through ConsolidationEngine.ConsolidateAsync(write: ctx.Write),
+    // joining the orchestrator's single RunBulkAsync scope. The new insight it creates must
+    // surface in a recall warmed before the run, proving the joined write invalidated through
+    // that one scope (no per-stage hand invalidation remains).
+
+    [Fact]
+    public async Task Maintenance_consolidation_stage_invalidates_via_the_joined_bulk_scope()
+    {
+        var store = new InMemoryEidetStore();
+        var svc = new MemoryService(store);
+        var now = DateTime.UtcNow;
+
+        // Three tag-overlapping observations (shared "deploy" tag → one TagOverlapGrouper group
+        // of size >= 3). InMemoryEidetStore.FindDuplicateAsync returns null, so consolidation
+        // creates a new insight (never boosts).
+        for (var i = 0; i < 3; i++)
+        {
+            await store.StoreAsync(new MemoryEntry
+            {
+                Id = $"memories/repo-a/observation/consolidate-{i}",
+                RepoId = "repo-a",
+                Type = MemoryType.Observation,
+                Content = $"The release runs database migrations during deployment step {i}",
+                Tags = ["deploy"],
+                CreatedAt = now,
+                Validity = new Validity { ValidFrom = now },
+                IsLatest = true,
+                Importance = 0.6f,
+            });
+        }
+
+        // Warm the cache: only the 3 observations match before the run.
+        var before = await svc.RecallAsync("repo-a", "migrations");
+        Assert.Equal(3, before.Count);
+
+        var orch = new MaintenanceOrchestrator(store, svc);
         var report = await orch.RunAsync(new MaintenanceRequest
         {
             RepoId = "repo-a",
             IsRepoActive = true,
-            OnlyStages = new HashSet<string> { TtlExpiryStage.StageName },
+            OnlyStages = new HashSet<string> { ConsolidationStage.StageName },
         });
+        Assert.Equal(1, report.AffectedBy(ConsolidationStage.StageName));
 
-        Assert.Equal(1, report.AffectedBy(TtlExpiryStage.StageName));
+        // Load-bearing assertion: the consolidation insight (content copied from a representative
+        // observation, so it matches "migrations") now surfaces. Without the joined write
+        // invalidating the orchestrator's single scope, recall would still serve the warmed 3.
+        var after = await svc.RecallAsync("repo-a", "migrations");
+        Assert.Equal(4, after.Count);
+        Assert.Contains(after, r => r.Type == MemoryType.Insight);
     }
 }

--- a/tests/Eidet.Core.Tests/Maintenance/MaintenanceOrchestratorTests.cs
+++ b/tests/Eidet.Core.Tests/Maintenance/MaintenanceOrchestratorTests.cs
@@ -25,7 +25,7 @@ public class MaintenanceOrchestratorTests
     private static MaintenanceOrchestrator WithStages(params IMaintenanceStage[] stages)
     {
         IEidetStore store = null!; // stub stages don't touch the store
-        return new MaintenanceOrchestrator(store, EnrichmentService.CreateNull(),
+        return new MaintenanceOrchestrator(store, new MemoryService(store), EnrichmentService.CreateNull(),
             new ConsolidationEngine(store, enrichment: null, memory: new MemoryService(store)), stages);
     }
 

--- a/tests/Eidet.Core.Tests/Services/EnrichmentWorkerTests.cs
+++ b/tests/Eidet.Core.Tests/Services/EnrichmentWorkerTests.cs
@@ -17,7 +17,7 @@ public class EnrichmentWorkerTests
         // CreateNull() means Ollama is disabled — worker should not start.
         // Passing null! for store proves it's never accessed.
         using var enrichment = EnrichmentService.CreateNull();
-        using var worker = new EnrichmentWorker(null!, enrichment);
+        using var worker = new EnrichmentWorker(null!, enrichment, null!);
         await worker.StartAsync(CancellationToken.None);
     }
 
@@ -25,7 +25,7 @@ public class EnrichmentWorkerTests
     public void Dispose_WithoutStart_DoesNotThrow()
     {
         using var enrichment = EnrichmentService.CreateNull();
-        var worker = new EnrichmentWorker(null!, enrichment);
+        var worker = new EnrichmentWorker(null!, enrichment, null!);
         worker.Dispose();
     }
 
@@ -33,7 +33,7 @@ public class EnrichmentWorkerTests
     public async Task Dispose_AfterNullEnrichmentStart_DoesNotThrow()
     {
         using var enrichment = EnrichmentService.CreateNull();
-        var worker = new EnrichmentWorker(null!, enrichment);
+        var worker = new EnrichmentWorker(null!, enrichment, null!);
         await worker.StartAsync(CancellationToken.None);
         worker.Dispose();
     }

--- a/tests/Eidet.Core.Tests/Services/MemoryServiceBoundaryTests.cs
+++ b/tests/Eidet.Core.Tests/Services/MemoryServiceBoundaryTests.cs
@@ -102,43 +102,6 @@ public class MemoryServiceBoundaryTests
         Assert.Single(afterReject);
     }
 
-    [Fact]
-    public async Task Bulk_invalidate_keeps_recall_coherent_after_direct_store_writes()
-    {
-        var store = new InMemoryEidetStore();
-        var svc = new MemoryService(store);
-
-        // Warm cache.
-        var initial = await svc.RecallAsync("repo-a", "deployment");
-        Assert.Empty(initial);
-
-        // Simulate a bulk-write path (e.g. ExportService.ImportPackAsync) that writes
-        // directly to the store and then explicitly invalidates the recall cache via
-        // the internal helper. This is exactly what the four tactical patches do.
-        var entry = new MemoryEntry
-        {
-            Id = "memories/repo-a/insight/bulk-deploy-1",
-            RepoId = "repo-a",
-            Type = MemoryType.Insight,
-            Content = "deployment uses argo cd via gitops",
-            CreatedAt = DateTime.UtcNow,
-            Validity = new Validity { ValidFrom = DateTime.UtcNow },
-            IsLatest = true,
-            Importance = 0.7f,
-        };
-        await store.StoreAsync(entry);
-
-        // Without invalidation, the next recall would hit the stale empty cache.
-        // The internal helper is what bulk callers use; here we verify it works.
-        typeof(MemoryService)
-            .GetMethod("InvalidateRecallCache", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance,
-                types: [typeof(string)])!
-            .Invoke(svc, ["repo-a"]);
-
-        var after = await svc.RecallAsync("repo-a", "deployment");
-        Assert.Contains(after, r => r.Id == entry.Id);
-    }
-
     // ─── Bulk-write gate (#10) ──────────────────────────────────────
 
     private static MemoryEntry MakeEntry(string repoId, string id, string content) => new()

--- a/tests/Eidet.Integration.Tests/Fixtures/EidetApiFixture.cs
+++ b/tests/Eidet.Integration.Tests/Fixtures/EidetApiFixture.cs
@@ -42,7 +42,7 @@ public class EidetApiFixture : IAsyncLifetime
             var intakeSvc = new IntakeService(eidetStore, memory: memorySvc);
             var consolidationEngine = new ConsolidationEngine(eidetStore, enrichment: null, memory: memorySvc);
             IMaintenanceRunner maintenanceRunner = new MaintenanceRunner(
-                new MaintenanceOrchestrator(eidetStore, consolidation: consolidationEngine));
+                new MaintenanceOrchestrator(eidetStore, memorySvc, consolidation: consolidationEngine));
             var exportSvc = new ExportService(eidetStore, memory: memorySvc);
             var qualitySvc = new QualityService(eidetStore);
 


### PR DESCRIPTION
Closes #17. Phase 3 of the `MemoryService` cache-gate line of work (#9 → #10/#16 → this).

## What & why
Three write paths still called `MemoryService.InvalidateRecallCache(...)` by hand after writing directly to storage, which forced the helper to stay non-private. This migrates all three onto the existing bulk gate (`RunBulkAsync` / `BulkMutationCtx`), so recall-cache invalidation becomes a **structural consequence of writing** — then deletes the helper.

## Design
Hardened via `/design-interface` (4-way parallel exploration; chosen design + rejected alternatives are recorded on the issue). The unifying mechanism: a maintenance run opens **exactly one** `RunBulkAsync`; every write — the direct-writing stages *and* both dual-use engines — flows into that single `BulkMutationCtx`. Standalone API/MCP callers pass nothing and the engine opens its own scope.

- **Maintenance** — `MaintenanceContext` exposes `BulkMutationCtx Write` (writes) alongside `IEidetStore Store` (reads); the 6 direct-writing stages switch `ctx.Store.UpdateAsync` → `ctx.Write.WriteAsync`; `DedupSweep`/`Consolidation`/`ImportanceDecay` join the run's scope via `write: ctx.Write`. The orchestrator's post-loop manual invalidate and `Sum(Affected) > 0` gate are gone.
- **Dual-use engines** — `DedupEngine` / `ConsolidationEngine` take an optional trailing `BulkMutationCtx? write`: non-null **joins** the caller's scope (no nested `finally`), null **opens its own** via `RunBulkAsync`.
- **EnrichmentWorker** — reroutes its enriched-entry write-back through `MemoryService.UpdateManyAsync([entry])`. Behavior-preserving: `RavenEidetStore.UpdateAsync` is literally `session.StoreAsync(entry, entry.Id) + SaveChanges` — identical to the prior raw-session write. `IDocumentStore` is kept for the subscription transport only.
- **Fixture gap closed structurally** — `MemoryService` is now a required ctor dependency on `MaintenanceOrchestrator`, `DedupEngine`, and `EnrichmentWorker`. The `EidetApiFixture`'s old no-`memory:` wiring (which silently disabled stage invalidation) would no longer compile.
- **Final step** — both `InvalidateRecallCache` overloads **deleted** (zero remaining callers; `RunMutationAsync`/`RunBulkAsync` touch `_cache` directly).

## Tests
- Removed the reflection-based `Bulk_invalidate_keeps_recall_coherent_after_direct_store_writes` and the now-uncompilable `Maintenance_with_null_memory_completes_*`.
- Added 3 recall-coherence tests: DedupEngine standalone invalidation, dryRun no-op, and a joined consolidation-stage invalidation through the orchestrator's single scope.
- **Core suite: 397 pass / 0 fail / 0 skip.** Full solution rebuilds clean (0 warnings).

## Quality gates (`/implement-issue` pipeline)
| Gate | Result |
|---|---|
| Implement | Build green, all projects |
| Test | 397 pass / 0 fail / 0 skip |
| Review | No blocking, no should-fix (one nit fixed: context hoisted out of the stage loop to keep `Now`/`Items` run-consistent) |
| Verify | Conforms — 12/12 acceptance criteria, none of the rejected patterns present |

## Out of scope (unchanged from the issue)
- Per-stage scope granularity (single-repo per run).
- Cross-pipeline transactionality.
- A general `IBulkScope` mutation-sink port (rejected as speculative).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
