### PR TITLE
feat(enrichment): support OpenAI-compatible backends (LM Studio, llama.cpp, vLLM)

### DIFF
--- a/src/Eidet.Core/Configuration/ConfigManager.cs
+++ b/src/Eidet.Core/Configuration/ConfigManager.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 
 namespace Eidet.Core.Configuration;
@@ -34,12 +35,41 @@ public static class ConfigManager
         else
         {
             var json = File.ReadAllText(path);
+            json = MigrateLegacyEnrichmentKeys(json);
             config = JsonSerializer.Deserialize<EidetConfig>(json, JsonOptions) ?? new EidetConfig();
         }
 
         // Environment variable overrides
         ApplyEnvironmentOverrides(config);
         return config;
+    }
+
+    // Pre-v0.2 configs stored enrichment under ollamaEnabled/ollamaUrl/ollamaModel.
+    // Map those onto the new enabled/url/model keys when the new keys are absent,
+    // so existing config.json files keep working without manual edits.
+    private static string MigrateLegacyEnrichmentKeys(string json)
+    {
+        JsonNode? root;
+        try { root = JsonNode.Parse(json); }
+        catch { return json; }
+
+        if (root?["enrichment"] is not JsonObject enrichment) return json;
+
+        var migrated = false;
+        migrated |= RenameKey(enrichment, "ollamaEnabled", "enabled");
+        migrated |= RenameKey(enrichment, "ollamaUrl", "url");
+        migrated |= RenameKey(enrichment, "ollamaModel", "model");
+
+        return migrated ? root!.ToJsonString() : json;
+    }
+
+    private static bool RenameKey(JsonObject obj, string legacy, string current)
+    {
+        if (obj.ContainsKey(current) || !obj.ContainsKey(legacy)) return false;
+        var node = obj[legacy];
+        obj.Remove(legacy);
+        obj[current] = node;
+        return true;
     }
 
     private static void ApplyEnvironmentOverrides(EidetConfig config)
@@ -57,15 +87,17 @@ public static class ConfigManager
         if (!string.IsNullOrEmpty(ravenUrl))
             config.Storage.RavenUrl = ravenUrl;
 
-        // EIDET_OLLAMA_URL — override Ollama connection
-        var ollamaUrl = Environment.GetEnvironmentVariable("EIDET_OLLAMA_URL");
-        if (!string.IsNullOrEmpty(ollamaUrl))
-            config.Enrichment.OllamaUrl = ollamaUrl;
+        // EIDET_ENRICHMENT_URL (EIDET_OLLAMA_URL = legacy alias) — override enrichment endpoint
+        var enrichUrl = Environment.GetEnvironmentVariable("EIDET_ENRICHMENT_URL")
+            ?? Environment.GetEnvironmentVariable("EIDET_OLLAMA_URL");
+        if (!string.IsNullOrEmpty(enrichUrl))
+            config.Enrichment.Url = enrichUrl;
 
-        // EIDET_OLLAMA_MODEL — override Ollama model
-        var ollamaModel = Environment.GetEnvironmentVariable("EIDET_OLLAMA_MODEL");
-        if (!string.IsNullOrEmpty(ollamaModel))
-            config.Enrichment.OllamaModel = ollamaModel;
+        // EIDET_ENRICHMENT_MODEL (EIDET_OLLAMA_MODEL = legacy alias) — override enrichment model
+        var enrichModel = Environment.GetEnvironmentVariable("EIDET_ENRICHMENT_MODEL")
+            ?? Environment.GetEnvironmentVariable("EIDET_OLLAMA_MODEL");
+        if (!string.IsNullOrEmpty(enrichModel))
+            config.Enrichment.Model = enrichModel;
 
         // EIDET_STORAGE_MODE — override storage mode (embedded/external)
         var storageMode = Environment.GetEnvironmentVariable("EIDET_STORAGE_MODE");

--- a/src/Eidet.Core/Configuration/ConfigManager.cs
+++ b/src/Eidet.Core/Configuration/ConfigManager.cs
@@ -53,14 +53,14 @@ public static class ConfigManager
         try { root = JsonNode.Parse(json); }
         catch { return json; }
 
-        if (root?["enrichment"] is not JsonObject enrichment) return json;
+        if (root is not JsonObject rootObj || rootObj["enrichment"] is not JsonObject enrichment) return json;
 
         var migrated = false;
         migrated |= RenameKey(enrichment, "ollamaEnabled", "enabled");
         migrated |= RenameKey(enrichment, "ollamaUrl", "url");
         migrated |= RenameKey(enrichment, "ollamaModel", "model");
 
-        return migrated ? root!.ToJsonString() : json;
+        return migrated ? rootObj.ToJsonString() : json;
     }
 
     private static bool RenameKey(JsonObject obj, string legacy, string current)

--- a/src/Eidet.Core/Configuration/EidetConfig.cs
+++ b/src/Eidet.Core/Configuration/EidetConfig.cs
@@ -5,6 +5,9 @@ namespace Eidet.Core.Configuration;
 [JsonConverter(typeof(JsonStringEnumConverter<StorageMode>))]
 public enum StorageMode { External, Embedded }
 
+[JsonConverter(typeof(JsonStringEnumConverter<EnrichmentProvider>))]
+public enum EnrichmentProvider { Ollama, OpenAiCompatible }
+
 public class EidetConfig
 {
     public ServiceConfig Service { get; set; } = new();
@@ -52,9 +55,10 @@ public class MaintenanceConfig
 
 public class EnrichmentConfig
 {
-    public bool OllamaEnabled { get; set; }
-    public string OllamaUrl { get; set; } = "http://localhost:11434";
-    public string OllamaModel { get; set; } = "gemma4";
+    public bool Enabled { get; set; }
+    public EnrichmentProvider Provider { get; set; } = EnrichmentProvider.Ollama;
+    public string Url { get; set; } = "http://localhost:11434";
+    public string Model { get; set; } = "gemma4";
     public bool AutoOneLiner { get; set; } = true;
     public bool AutoForesight { get; set; } = true;
     public bool AutoConsolidation { get; set; } = true;

--- a/src/Eidet.Core/Enrichment/EnrichmentHealthCache.cs
+++ b/src/Eidet.Core/Enrichment/EnrichmentHealthCache.cs
@@ -15,8 +15,12 @@ internal sealed class EnrichmentHealthCache
 
     public EnrichmentHealthCache(HttpClient http) => _http = http;
 
+    // Optimistic once the cache goes stale, regardless of the last result: a stale
+    // unhealthy verdict must not pin enrichment off forever — letting IsAvailable return
+    // true after CacheDuration lets the next call re-probe and recover when the backend
+    // comes back (the actual probe still happens in CheckAsync).
     public bool IsAvailable => _lastHealthy == true ||
-        (_lastHealthy == null && DateTime.UtcNow - _lastCheck > CacheDuration);
+        DateTime.UtcNow - _lastCheck > CacheDuration;
 
     public async Task<bool> CheckAsync(string probePath, CancellationToken ct)
     {

--- a/src/Eidet.Core/Enrichment/EnrichmentHealthCache.cs
+++ b/src/Eidet.Core/Enrichment/EnrichmentHealthCache.cs
@@ -1,0 +1,39 @@
+namespace Eidet.Core.Enrichment;
+
+/// <summary>
+/// Caches the result of a backend health probe for 5 minutes so enrichment doesn't
+/// hammer the server on every memory. Shared by the Ollama-native and OpenAI-compatible
+/// adapters, which differ only in the probe endpoint they pass to <see cref="CheckAsync"/>.
+/// </summary>
+internal sealed class EnrichmentHealthCache
+{
+    private static readonly TimeSpan CacheDuration = TimeSpan.FromMinutes(5);
+
+    private readonly HttpClient _http;
+    private bool? _lastHealthy;
+    private DateTime _lastCheck = DateTime.MinValue;
+
+    public EnrichmentHealthCache(HttpClient http) => _http = http;
+
+    public bool IsAvailable => _lastHealthy == true ||
+        (_lastHealthy == null && DateTime.UtcNow - _lastCheck > CacheDuration);
+
+    public async Task<bool> CheckAsync(string probePath, CancellationToken ct)
+    {
+        if (DateTime.UtcNow - _lastCheck < CacheDuration && _lastHealthy.HasValue)
+            return _lastHealthy.Value;
+
+        try
+        {
+            var response = await _http.GetAsync(probePath, ct);
+            _lastHealthy = response.IsSuccessStatusCode;
+        }
+        catch
+        {
+            _lastHealthy = false;
+        }
+
+        _lastCheck = DateTime.UtcNow;
+        return _lastHealthy.Value;
+    }
+}

--- a/src/Eidet.Core/Enrichment/EnrichmentPrompts.cs
+++ b/src/Eidet.Core/Enrichment/EnrichmentPrompts.cs
@@ -1,0 +1,58 @@
+namespace Eidet.Core.Enrichment;
+
+/// <summary>
+/// Prompt wording shared by every enrichment backend. Kept in one place so the
+/// Ollama-native and OpenAI-compatible adapters never diverge on prompt text.
+/// </summary>
+internal static class EnrichmentPrompts
+{
+    public static string Build(EnrichmentRequest request) => request.Kind switch
+    {
+        EnrichmentPrompt.OneLiner => $"""
+            Generate an ultra-compact one-liner summary (~10 words max) of this memory.
+            Return ONLY the one-liner, nothing else.
+
+            Memory: {request.Primary}
+            """,
+
+        EnrichmentPrompt.Summary => $"""
+            Summarize this memory in 1-2 concise sentences for a software developer.
+            Return ONLY the summary, nothing else.
+
+            Memory: {request.Primary}
+            """,
+
+        EnrichmentPrompt.ForesightHint => $"""
+            Given this developer memory, predict WHEN and HOW it will be most useful in the future.
+            Write a brief foresight hint (1 sentence) that helps an AI agent know when to surface this memory.
+            Return ONLY the hint, nothing else.
+
+            Memory: {request.Primary}
+            """,
+
+        EnrichmentPrompt.Entities => $"""
+            Extract named entities from this developer memory: project names, package names,
+            file paths, class names, function names, API endpoints, configuration keys, error codes.
+            Return one entity per line, nothing else. If none found, return empty.
+
+            Text: {request.Primary}
+            """,
+
+        EnrichmentPrompt.MergeObservations => BuildMergePrompt(request.Aux ?? []),
+
+        _ => request.Primary,
+    };
+
+    private static string BuildMergePrompt(IReadOnlyList<string> observations)
+    {
+        var numbered = string.Join("\n", observations.Select((o, i) => $"{i + 1}. {o}"));
+        return $"""
+            These related developer observations should be merged into a single coherent insight.
+            Write a concise insight (2-3 sentences) that captures the essential knowledge.
+            Return ONLY the merged insight, nothing else.
+
+            Observations:
+            {numbered}
+            """;
+    }
+}

--- a/src/Eidet.Core/Enrichment/EnrichmentService.cs
+++ b/src/Eidet.Core/Enrichment/EnrichmentService.cs
@@ -1,3 +1,4 @@
+using Eidet.Core.Configuration;
 using Eidet.Core.Domain;
 using Eidet.Core.Services;
 
@@ -24,6 +25,18 @@ public sealed class EnrichmentService : IDisposable
 
     public static EnrichmentService CreateNull()
         => new(new NullEnrichmentAdapter());
+
+    /// <summary>
+    /// Builds the enrichment service the config asks for: disabled → null adapter,
+    /// OpenAI-compatible provider → <see cref="OpenAiEnrichmentAdapter"/>, otherwise Ollama.
+    /// </summary>
+    public static EnrichmentService CreateFromConfig(EnrichmentConfig cfg)
+    {
+        if (!cfg.Enabled) return CreateNull();
+        return cfg.Provider == EnrichmentProvider.OpenAiCompatible
+            ? new EnrichmentService(new OpenAiEnrichmentAdapter(cfg.Url, cfg.Model))
+            : CreateOllama(cfg.Url, cfg.Model);
+    }
 
     public bool IsAvailable => _port.IsAvailable;
 

--- a/src/Eidet.Core/Enrichment/OllamaEnrichmentAdapter.cs
+++ b/src/Eidet.Core/Enrichment/OllamaEnrichmentAdapter.cs
@@ -50,7 +50,7 @@ internal sealed class OllamaEnrichmentAdapter : IEnrichmentPort, IDisposable
 
             var json = JsonSerializer.Serialize(payload, JsonOpts);
             var httpContent = new StringContent(json, Encoding.UTF8, "application/json");
-            var response = await _http.PostAsync("/api/chat", httpContent, ct);
+            using var response = await _http.PostAsync("/api/chat", httpContent, ct);
 
             if (!response.IsSuccessStatusCode)
                 return null;

--- a/src/Eidet.Core/Enrichment/OpenAiEnrichmentAdapter.cs
+++ b/src/Eidet.Core/Enrichment/OpenAiEnrichmentAdapter.cs
@@ -3,7 +3,12 @@ using System.Text.Json;
 
 namespace Eidet.Core.Enrichment;
 
-internal sealed class OllamaEnrichmentAdapter : IEnrichmentPort, IDisposable
+/// <summary>
+/// Enrichment over any OpenAI-compatible local server (LM Studio, llama.cpp server, vLLM):
+/// <c>GET /v1/models</c> for health, <c>POST /v1/chat/completions</c> for chat. No Ollama-only
+/// <c>think</c> field; response is read from <c>choices[0].message.content</c>.
+/// </summary>
+internal sealed class OpenAiEnrichmentAdapter : IEnrichmentPort, IDisposable
 {
     private static readonly JsonSerializerOptions JsonOpts = new()
     {
@@ -14,12 +19,12 @@ internal sealed class OllamaEnrichmentAdapter : IEnrichmentPort, IDisposable
     private readonly EnrichmentHealthCache _health;
     private readonly string _model;
 
-    public OllamaEnrichmentAdapter(string ollamaUrl, string model)
+    public OpenAiEnrichmentAdapter(string baseUrl, string model)
     {
         _model = model;
         _http = new HttpClient
         {
-            BaseAddress = new Uri(ollamaUrl.TrimEnd('/')),
+            BaseAddress = new Uri(baseUrl.TrimEnd('/')),
             Timeout = TimeSpan.FromSeconds(120),
         };
         _health = new EnrichmentHealthCache(_http);
@@ -28,7 +33,7 @@ internal sealed class OllamaEnrichmentAdapter : IEnrichmentPort, IDisposable
     public bool IsAvailable => _health.IsAvailable;
 
     public Task<bool> CheckHealthAsync(CancellationToken ct = default)
-        => _health.CheckAsync("/api/tags", ct);
+        => _health.CheckAsync("/v1/models", ct);
 
     public async Task<string?> CompleteAsync(EnrichmentRequest request, CancellationToken ct = default)
     {
@@ -45,12 +50,11 @@ internal sealed class OllamaEnrichmentAdapter : IEnrichmentPort, IDisposable
                 model = _model,
                 messages = new[] { new { role = "user", content = prompt } },
                 stream = false,
-                think = false,
             };
 
             var json = JsonSerializer.Serialize(payload, JsonOpts);
             var httpContent = new StringContent(json, Encoding.UTF8, "application/json");
-            var response = await _http.PostAsync("/api/chat", httpContent, ct);
+            var response = await _http.PostAsync("/v1/chat/completions", httpContent, ct);
 
             if (!response.IsSuccessStatusCode)
                 return null;
@@ -58,7 +62,9 @@ internal sealed class OllamaEnrichmentAdapter : IEnrichmentPort, IDisposable
             var responseJson = await response.Content.ReadAsStringAsync(ct);
             using var doc = JsonDocument.Parse(responseJson);
 
-            if (doc.RootElement.TryGetProperty("message", out var msg) &&
+            if (doc.RootElement.TryGetProperty("choices", out var choices) &&
+                choices.ValueKind == JsonValueKind.Array && choices.GetArrayLength() > 0 &&
+                choices[0].TryGetProperty("message", out var msg) &&
                 msg.TryGetProperty("content", out var content))
             {
                 var text = OllamaTextSanitizer.Clean(content.GetString()?.Trim());

--- a/src/Eidet.Core/Enrichment/OpenAiEnrichmentAdapter.cs
+++ b/src/Eidet.Core/Enrichment/OpenAiEnrichmentAdapter.cs
@@ -54,7 +54,7 @@ internal sealed class OpenAiEnrichmentAdapter : IEnrichmentPort, IDisposable
 
             var json = JsonSerializer.Serialize(payload, JsonOpts);
             var httpContent = new StringContent(json, Encoding.UTF8, "application/json");
-            var response = await _http.PostAsync("/v1/chat/completions", httpContent, ct);
+            using var response = await _http.PostAsync("/v1/chat/completions", httpContent, ct);
 
             if (!response.IsSuccessStatusCode)
                 return null;

--- a/src/Eidet.Service/Api/Endpoints/MetaEndpoints.cs
+++ b/src/Eidet.Service/Api/Endpoints/MetaEndpoints.cs
@@ -36,17 +36,18 @@ internal sealed class MetaEndpoints
     {
         var info = await _svc.GetStoreInfoAsync(ct);
 
-        // Check Ollama health if enrichment is configured
+        // Check enrichment backend health if configured
         object? ollamaStatus = null;
-        if (_config?.Enrichment.OllamaEnabled == true && _enrichment is not null)
+        if (_config?.Enrichment.Enabled == true && _enrichment is not null)
         {
             var healthy = await _enrichment.CheckHealthAsync(ct);
             ollamaStatus = new
             {
                 enabled = true,
                 healthy,
-                model = _config.Enrichment.OllamaModel,
-                url = _config.Enrichment.OllamaUrl,
+                provider = _config.Enrichment.Provider.ToString(),
+                model = _config.Enrichment.Model,
+                url = _config.Enrichment.Url,
             };
         }
         else if (_config is not null)

--- a/src/Eidet.Service/Commands/ConfigCommand.cs
+++ b/src/Eidet.Service/Commands/ConfigCommand.cs
@@ -127,9 +127,14 @@ internal static class ConfigHelper
         ["maintenance.consolidationIntervalHours"] = (c => c.Maintenance.ConsolidationIntervalHours.ToString(), (c, v) => c.Maintenance.ConsolidationIntervalHours = int.Parse(v)),
 
         // Enrichment
-        ["enrichment.ollamaEnabled"] = (c => c.Enrichment.OllamaEnabled.ToString(), (c, v) => c.Enrichment.OllamaEnabled = bool.Parse(v)),
-        ["enrichment.ollamaUrl"] = (c => c.Enrichment.OllamaUrl, (c, v) => c.Enrichment.OllamaUrl = v),
-        ["enrichment.ollamaModel"] = (c => c.Enrichment.OllamaModel, (c, v) => c.Enrichment.OllamaModel = v),
+        ["enrichment.enabled"] = (c => c.Enrichment.Enabled.ToString(), (c, v) => c.Enrichment.Enabled = bool.Parse(v)),
+        ["enrichment.provider"] = (c => c.Enrichment.Provider.ToString(), (c, v) => c.Enrichment.Provider = Enum.Parse<EnrichmentProvider>(v, true)),
+        ["enrichment.url"] = (c => c.Enrichment.Url, (c, v) => c.Enrichment.Url = v),
+        ["enrichment.model"] = (c => c.Enrichment.Model, (c, v) => c.Enrichment.Model = v),
+        // Legacy aliases (pre-v0.2) — same getters/setters so existing scripts keep working.
+        ["enrichment.ollamaEnabled"] = (c => c.Enrichment.Enabled.ToString(), (c, v) => c.Enrichment.Enabled = bool.Parse(v)),
+        ["enrichment.ollamaUrl"] = (c => c.Enrichment.Url, (c, v) => c.Enrichment.Url = v),
+        ["enrichment.ollamaModel"] = (c => c.Enrichment.Model, (c, v) => c.Enrichment.Model = v),
         ["enrichment.autoOneLiner"] = (c => c.Enrichment.AutoOneLiner.ToString(), (c, v) => c.Enrichment.AutoOneLiner = bool.Parse(v)),
         ["enrichment.autoForesight"] = (c => c.Enrichment.AutoForesight.ToString(), (c, v) => c.Enrichment.AutoForesight = bool.Parse(v)),
         ["enrichment.autoConsolidation"] = (c => c.Enrichment.AutoConsolidation.ToString(), (c, v) => c.Enrichment.AutoConsolidation = bool.Parse(v)),

--- a/src/Eidet.Service/Commands/DoctorCommand.cs
+++ b/src/Eidet.Service/Commands/DoctorCommand.cs
@@ -131,7 +131,7 @@ public sealed class DoctorCommand : AsyncCommand<DoctorCommand.Settings>
         try
         {
             using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(5) };
-            var response = await http.GetAsync($"{config.Enrichment.Url}{probePath}");
+            var response = await http.GetAsync($"{config.Enrichment.Url.TrimEnd('/')}{probePath}");
             if (response.IsSuccessStatusCode)
             {
                 var body = await response.Content.ReadAsStringAsync();

--- a/src/Eidet.Service/Commands/DoctorCommand.cs
+++ b/src/Eidet.Service/Commands/DoctorCommand.cs
@@ -83,7 +83,7 @@ public sealed class DoctorCommand : AsyncCommand<DoctorCommand.Settings>
         checks.Add(await CheckServiceAsync());
 
         // Ollama check (optional)
-        checks.Add(await CheckOllamaAsync(config));
+        checks.Add(await CheckEnrichmentAsync(config));
 
         // Config file check
         checks.Add(CheckConfigFile());
@@ -117,37 +117,45 @@ public sealed class DoctorCommand : AsyncCommand<DoctorCommand.Settings>
             $"Healthy (PID {info.Pid}, port {info.Port}, up {uptime.TotalHours:F0}h {uptime.Minutes}m)");
     }
 
-    private static async Task<CheckResult> CheckOllamaAsync(EidetConfig config)
+    private static async Task<CheckResult> CheckEnrichmentAsync(EidetConfig config)
     {
-        if (!config.Enrichment.OllamaEnabled)
-            return new CheckResult("Ollama", true, "Disabled (optional)", Optional: true);
+        var label = config.Enrichment.Provider == EnrichmentProvider.OpenAiCompatible
+            ? "Enrichment (OpenAI)" : "Enrichment (Ollama)";
+
+        if (!config.Enrichment.Enabled)
+            return new CheckResult(label, true, "Disabled (optional)", Optional: true);
+
+        var openAi = config.Enrichment.Provider == EnrichmentProvider.OpenAiCompatible;
+        var probePath = openAi ? "/v1/models" : "/api/tags";
 
         try
         {
             using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(5) };
-            var response = await http.GetAsync($"{config.Enrichment.OllamaUrl}/api/tags");
+            var response = await http.GetAsync($"{config.Enrichment.Url}{probePath}");
             if (response.IsSuccessStatusCode)
             {
                 var body = await response.Content.ReadAsStringAsync();
-                var hasModel = body.Contains(config.Enrichment.OllamaModel, StringComparison.OrdinalIgnoreCase);
+                var hasModel = body.Contains(config.Enrichment.Model, StringComparison.OrdinalIgnoreCase);
                 return hasModel
-                    ? new CheckResult("Ollama", true, $"Connected ({config.Enrichment.OllamaModel})")
-                    : new CheckResult("Ollama", false,
-                        $"Connected but model \"{config.Enrichment.OllamaModel}\" not found",
+                    ? new CheckResult(label, true, $"Connected ({config.Enrichment.Model})")
+                    : new CheckResult(label, false,
+                        $"Connected but model \"{config.Enrichment.Model}\" not found",
                         Optional: true,
-                        Fix: $"Pull the model: ollama pull {config.Enrichment.OllamaModel}");
+                        Fix: openAi
+                            ? $"Load \"{config.Enrichment.Model}\" in your server, or: eidet config set enrichment.model <name>"
+                            : $"Pull the model: ollama pull {config.Enrichment.Model}");
             }
 
-            return new CheckResult("Ollama", false,
-                $"HTTP {(int)response.StatusCode} from {config.Enrichment.OllamaUrl}",
+            return new CheckResult(label, false,
+                $"HTTP {(int)response.StatusCode} from {config.Enrichment.Url}",
                 Optional: true);
         }
         catch (Exception ex)
         {
-            return new CheckResult("Ollama", false,
+            return new CheckResult(label, false,
                 $"Connection failed: {ex.Message}",
                 Optional: true,
-                Fix: "Install Ollama from https://ollama.ai or disable:\n  eidet config set enrichment.ollamaEnabled false");
+                Fix: "Start the enrichment backend or disable:\n  eidet config set enrichment.enabled false");
         }
     }
 

--- a/src/Eidet.Service/Commands/MaintainCommand.cs
+++ b/src/Eidet.Service/Commands/MaintainCommand.cs
@@ -24,9 +24,7 @@ public sealed class MaintainCommand : AsyncCommand<MaintainCommand.Settings>
         var config = ConfigManager.Load();
         var store = DocumentStoreFactory.CreateFromConfig(config);
         var eidetStore = new RavenEidetStore(store);
-        using var enrichment = config.Enrichment.OllamaEnabled
-            ? EnrichmentService.CreateOllama(config.Enrichment.OllamaUrl, config.Enrichment.OllamaModel)
-            : EnrichmentService.CreateNull();
+        using var enrichment = EnrichmentService.CreateFromConfig(config.Enrichment);
         var memorySvc = new MemoryService(eidetStore);
         var consolidationEngine = new ConsolidationEngine(eidetStore, enrichment, memorySvc);
         IMaintenanceRunner runner = new MaintenanceRunner(

--- a/src/Eidet.Service/Commands/McpCommand.cs
+++ b/src/Eidet.Service/Commands/McpCommand.cs
@@ -32,9 +32,7 @@ public sealed class McpCommand : AsyncCommand<McpCommand.Settings>
             var store = DocumentStoreFactory.CreateFromConfig(config);
             DatabaseProvisioner.DeployIndexes(store);
             var eidetStore = new RavenEidetStore(store);
-            using var enrichment = config.Enrichment.OllamaEnabled
-                ? EnrichmentService.CreateOllama(config.Enrichment.OllamaUrl, config.Enrichment.OllamaModel)
-                : EnrichmentService.CreateNull();
+            using var enrichment = EnrichmentService.CreateFromConfig(config.Enrichment);
             IHookRunner hookRunner = config.Hooks.PreStore.Count > 0 || config.Hooks.PostStore.Count > 0
                 || config.Hooks.PreRecall.Count > 0 || config.Hooks.PostRecall.Count > 0
                 || config.Hooks.PreForget.Count > 0 || config.Hooks.PostForget.Count > 0

--- a/src/Eidet.Service/Commands/OllamaCommand.cs
+++ b/src/Eidet.Service/Commands/OllamaCommand.cs
@@ -17,11 +17,11 @@ public sealed class OllamaStatusCommand : AsyncCommand<OllamaStatusCommand.Setti
     protected override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellation)
     {
         var config = ConfigManager.Load();
-        using var svc = new OllamaService(config.Enrichment.OllamaUrl);
+        using var svc = new OllamaService(config.Enrichment.Url);
 
         var version = await svc.GetVersionAsync(cancellation);
         var models = await svc.ListModelsAsync(cancellation);
-        var configuredModel = config.Enrichment.OllamaModel;
+        var configuredModel = config.Enrichment.Model;
         var hasConfigured = models.Any(m =>
             m.Name.Equals(configuredModel, StringComparison.OrdinalIgnoreCase) ||
             m.Name.StartsWith(configuredModel + ":", StringComparison.OrdinalIgnoreCase));
@@ -32,8 +32,8 @@ public sealed class OllamaStatusCommand : AsyncCommand<OllamaStatusCommand.Setti
             {
                 available = version != null,
                 version,
-                url = config.Enrichment.OllamaUrl,
-                enrichmentEnabled = config.Enrichment.OllamaEnabled,
+                url = config.Enrichment.Url,
+                enrichmentEnabled = config.Enrichment.Enabled,
                 configuredModel,
                 modelInstalled = hasConfigured,
                 models = models.Select(m => new { m.Name, size = OllamaService.FormatSize(m.Size) }),
@@ -45,8 +45,8 @@ public sealed class OllamaStatusCommand : AsyncCommand<OllamaStatusCommand.Setti
         AnsiConsole.WriteLine();
         if (version != null)
         {
-            AnsiConsole.MarkupLine($"[green]Ollama[/] v{version} at {config.Enrichment.OllamaUrl}");
-            AnsiConsole.MarkupLine($"  Enrichment:  {(config.Enrichment.OllamaEnabled ? "[green]Enabled[/]" : "[dim]Disabled[/]")}");
+            AnsiConsole.MarkupLine($"[green]Ollama[/] v{version} at {config.Enrichment.Url}");
+            AnsiConsole.MarkupLine($"  Enrichment:  {(config.Enrichment.Enabled ? "[green]Enabled[/]" : "[dim]Disabled[/]")}");
             AnsiConsole.MarkupLine($"  Model:       {configuredModel} {(hasConfigured ? "[green](installed)[/]" : "[red](not installed)[/]")}");
 
             if (models.Count > 0)
@@ -65,12 +65,12 @@ public sealed class OllamaStatusCommand : AsyncCommand<OllamaStatusCommand.Setti
 
                 var (suggested, isInstalled) = await svc.SuggestModelAsync(cancellation);
                 if (isInstalled && suggested != configuredModel)
-                    AnsiConsole.MarkupLine($"  Or use:   [dim]eidet config set enrichment.ollamaModel {suggested}[/]");
+                    AnsiConsole.MarkupLine($"  Or use:   [dim]eidet config set enrichment.model {suggested}[/]");
             }
         }
         else
         {
-            AnsiConsole.MarkupLine($"[red]Ollama not available[/] at {config.Enrichment.OllamaUrl}");
+            AnsiConsole.MarkupLine($"[red]Ollama not available[/] at {config.Enrichment.Url}");
             AnsiConsole.MarkupLine("[dim]Install Ollama from https://ollama.ai[/]");
         }
 
@@ -90,7 +90,7 @@ public sealed class OllamaPullCommand : AsyncCommand<OllamaPullCommand.Settings>
     protected override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellation)
     {
         var config = ConfigManager.Load();
-        using var svc = new OllamaService(config.Enrichment.OllamaUrl);
+        using var svc = new OllamaService(config.Enrichment.Url);
 
         if (!await svc.IsAvailableAsync(cancellation))
         {
@@ -98,7 +98,7 @@ public sealed class OllamaPullCommand : AsyncCommand<OllamaPullCommand.Settings>
             return 1;
         }
 
-        var modelName = settings.Model ?? config.Enrichment.OllamaModel;
+        var modelName = settings.Model ?? config.Enrichment.Model;
 
         // Check if already installed
         if (await svc.HasModelAsync(modelName, cancellation))
@@ -144,16 +144,16 @@ public sealed class OllamaPullCommand : AsyncCommand<OllamaPullCommand.Settings>
         AnsiConsole.MarkupLine($"[green]Model \"{modelName}\" pulled successfully.[/]");
 
         // Auto-configure if this is the first model
-        if (!config.Enrichment.OllamaEnabled)
+        if (!config.Enrichment.Enabled)
         {
-            config.Enrichment.OllamaEnabled = true;
-            config.Enrichment.OllamaModel = modelName;
+            config.Enrichment.Enabled = true;
+            config.Enrichment.Model = modelName;
             ConfigManager.Save(config);
             AnsiConsole.MarkupLine("[green]Ollama enrichment enabled automatically.[/]");
         }
-        else if (config.Enrichment.OllamaModel != modelName)
+        else if (config.Enrichment.Model != modelName)
         {
-            AnsiConsole.MarkupLine($"[dim]To use this model: eidet config set enrichment.ollamaModel {modelName}[/]");
+            AnsiConsole.MarkupLine($"[dim]To use this model: eidet config set enrichment.model {modelName}[/]");
         }
 
         return 0;
@@ -167,7 +167,7 @@ public sealed class OllamaListCommand : AsyncCommand<OllamaListCommand.Settings>
     protected override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellation)
     {
         var config = ConfigManager.Load();
-        using var svc = new OllamaService(config.Enrichment.OllamaUrl);
+        using var svc = new OllamaService(config.Enrichment.Url);
 
         var models = await svc.ListModelsAsync(cancellation);
 
@@ -189,7 +189,7 @@ public sealed class OllamaListCommand : AsyncCommand<OllamaListCommand.Settings>
         foreach (var m in models)
         {
             var baseName = m.Name.Split(':')[0];
-            var isCurrent = baseName.Equals(config.Enrichment.OllamaModel, StringComparison.OrdinalIgnoreCase);
+            var isCurrent = baseName.Equals(config.Enrichment.Model, StringComparison.OrdinalIgnoreCase);
             var status = isCurrent ? "[green]active[/]" : "";
             table.AddRow(m.Name, OllamaService.FormatSize(m.Size), status);
         }

--- a/src/Eidet.Service/Commands/ServeCommand.cs
+++ b/src/Eidet.Service/Commands/ServeCommand.cs
@@ -115,10 +115,10 @@ public sealed class ServeCommand : AsyncCommand<ServeCommand.Settings>
         else
             AnsiConsole.MarkupLine($"  RavenDB: [green]Connected[/] ({Markup.Escape(host.RavenUrl)})");
 
-        if (host.OllamaEnabled)
+        if (host.EnrichmentEnabled)
         {
-            var healthy = await host.CheckOllamaAsync(cancellation);
-            AnsiConsole.MarkupLine($"  Ollama:  {(healthy ? "[green]Connected[/]" : "[yellow]Unavailable[/]")} ({host.OllamaModel} @ {Markup.Escape(host.OllamaUrl)})");
+            var healthy = await host.CheckEnrichmentAsync(cancellation);
+            AnsiConsole.MarkupLine($"  Enrichment: {(healthy ? "[green]Connected[/]" : "[yellow]Unavailable[/]")} ({host.EnrichmentModel} @ {Markup.Escape(host.EnrichmentUrl)})");
         }
 
         if (host.AuthEnabled)
@@ -145,7 +145,7 @@ public sealed class ServeCommand : AsyncCommand<ServeCommand.Settings>
         await host.StartSchedulerAsync(cancellation);
         AnsiConsole.MarkupLine($"  Scheduler: [green]Active[/] (persisted — maintenance every {host.MaintenanceIntervalHours}h, consolidation every {host.ConsolidationIntervalHours}h)");
 
-        if (host.OllamaEnabled)
+        if (host.EnrichmentEnabled)
         {
             await host.StartEnrichmentWorkerAsync(cancellation);
             AnsiConsole.MarkupLine("  Enrichment: [green]Active[/] (RavenDB subscription — enriches on store)");

--- a/src/Eidet.Service/Commands/SetupCommand.cs
+++ b/src/Eidet.Service/Commands/SetupCommand.cs
@@ -157,7 +157,7 @@ public sealed class SetupCommand : AsyncCommand<SetupCommand.Settings>
         try
         {
             using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(3) };
-            var resp = await http.GetAsync($"{config.Enrichment.Url}/api/version", cancellation);
+            var resp = await http.GetAsync($"{config.Enrichment.Url.TrimEnd('/')}/api/version", cancellation);
             ollamaConnected = resp.IsSuccessStatusCode;
         }
         catch { }

--- a/src/Eidet.Service/Commands/SetupCommand.cs
+++ b/src/Eidet.Service/Commands/SetupCommand.cs
@@ -157,21 +157,21 @@ public sealed class SetupCommand : AsyncCommand<SetupCommand.Settings>
         try
         {
             using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(3) };
-            var resp = await http.GetAsync($"{config.Enrichment.OllamaUrl}/api/version", cancellation);
+            var resp = await http.GetAsync($"{config.Enrichment.Url}/api/version", cancellation);
             ollamaConnected = resp.IsSuccessStatusCode;
         }
         catch { }
 
         if (ollamaConnected)
         {
-            AnsiConsole.MarkupLine($"  [green]✓[/] Ollama detected at {config.Enrichment.OllamaUrl}");
+            AnsiConsole.MarkupLine($"  [green]✓[/] Ollama detected at {config.Enrichment.Url}");
             if (!settings.NonInteractive)
             {
-                config.Enrichment.OllamaEnabled = AnsiConsole.Confirm("  Enable Ollama enrichment?", defaultValue: true);
+                config.Enrichment.Enabled = AnsiConsole.Confirm("  Enable Ollama enrichment?", defaultValue: true);
             }
             else
             {
-                config.Enrichment.OllamaEnabled = true;
+                config.Enrichment.Enabled = true;
             }
             changed = true;
         }

--- a/src/Eidet.Service/Commands/StatusCommand.cs
+++ b/src/Eidet.Service/Commands/StatusCommand.cs
@@ -90,8 +90,9 @@ public sealed class StatusCommand : AsyncCommand<StatusCommand.Settings>
                 },
                 enrichment = new
                 {
-                    ollamaEnabled = config.Enrichment.OllamaEnabled,
-                    ollamaUrl = config.Enrichment.OllamaUrl,
+                    enabled = config.Enrichment.Enabled,
+                    provider = config.Enrichment.Provider.ToString(),
+                    url = config.Enrichment.Url,
                 },
                 versionHistory = versionHistory.TakeLast(5).Select(e => new
                 {
@@ -140,7 +141,7 @@ public sealed class StatusCommand : AsyncCommand<StatusCommand.Settings>
             if (ravenVersion != null)
                 AnsiConsole.MarkupLine($"  RavenDB:    v{ravenVersion}");
 
-            AnsiConsole.MarkupLine($"  Ollama:     {(config.Enrichment.OllamaEnabled ? config.Enrichment.OllamaUrl : "[dim]Disabled[/]")}");
+            AnsiConsole.MarkupLine($"  Enrichment: {(config.Enrichment.Enabled ? $"{config.Enrichment.Provider} @ {config.Enrichment.Url}" : "[dim]Disabled[/]")}");
             AnsiConsole.MarkupLine($"  Config:     {ConfigManager.GetConfigPath()}");
             AnsiConsole.MarkupLine($"  Logs:       {Path.Combine(ConfigManager.GetConfigDir(), "logs", "eidet.log")}");
             AnsiConsole.MarkupLine($"  MCP:        {FormatMcpClients(mcpClients)}");

--- a/src/Eidet.Service/EidetHost.cs
+++ b/src/Eidet.Service/EidetHost.cs
@@ -26,15 +26,16 @@ public sealed class EidetHost : IDisposable
     public string BindAddress { get; }
     public int Port { get; }
     public StorageMode StorageMode { get; }
-    public bool OllamaEnabled { get; }
-    public bool OllamaHealthy { get; private set; }
-    public string OllamaModel { get; }
+    public bool EnrichmentEnabled { get; }
+    public EnrichmentProvider EnrichmentProvider { get; }
+    public bool EnrichmentHealthy { get; private set; }
+    public string EnrichmentModel { get; }
     public bool AuthEnabled { get; }
     public int ApiKeyCount { get; }
     public int MaintenanceIntervalHours { get; }
     public int ConsolidationIntervalHours { get; }
     public string RavenUrl { get; }
-    public string OllamaUrl { get; }
+    public string EnrichmentUrl { get; }
     public int HookCount { get; }
 
     private EidetHost(IDocumentStore store, IEidetStore eidetStore, EnrichmentService enrichment,
@@ -51,8 +52,9 @@ public sealed class EidetHost : IDisposable
         BindAddress = bind;
         Port = port;
         StorageMode = config.Storage.Mode;
-        OllamaEnabled = config.Enrichment.OllamaEnabled;
-        OllamaModel = config.Enrichment.OllamaModel;
+        EnrichmentEnabled = config.Enrichment.Enabled;
+        EnrichmentProvider = config.Enrichment.Provider;
+        EnrichmentModel = config.Enrichment.Model;
         AuthEnabled = config.Auth.Enabled;
         ApiKeyCount = config.Auth.ApiKeys.Count;
         MaintenanceIntervalHours = config.Maintenance.IntervalHours;
@@ -60,7 +62,7 @@ public sealed class EidetHost : IDisposable
         RavenUrl = config.Storage.Mode == StorageMode.Embedded
             ? $"Embedded ({config.Storage.DataDir ?? "default"})"
             : config.Storage.RavenUrl;
-        OllamaUrl = config.Enrichment.OllamaUrl;
+        EnrichmentUrl = config.Enrichment.Url;
         HookCount = config.Hooks.PreStore.Count + config.Hooks.PostStore.Count
             + config.Hooks.PreRecall.Count + config.Hooks.PostRecall.Count
             + config.Hooks.PreForget.Count + config.Hooks.PostForget.Count;
@@ -80,9 +82,7 @@ public sealed class EidetHost : IDisposable
 
         var eidetStore = new RavenEidetStore(store);
 
-        var enrichment = config.Enrichment.OllamaEnabled
-            ? EnrichmentService.CreateOllama(config.Enrichment.OllamaUrl, config.Enrichment.OllamaModel)
-            : EnrichmentService.CreateNull();
+        var enrichment = EnrichmentService.CreateFromConfig(config.Enrichment);
 
         var layerSvc = new LayerService(eidetStore);
         IHookRunner hookRunner = config.Hooks.PreStore.Count > 0 || config.Hooks.PostStore.Count > 0
@@ -127,11 +127,11 @@ public sealed class EidetHost : IDisposable
         return new EidetHost(store, eidetStore, enrichment, scheduler, enrichmentWorker, apiServer, config, actualBind, actualPort);
     }
 
-    public async Task<bool> CheckOllamaAsync(CancellationToken ct = default)
+    public async Task<bool> CheckEnrichmentAsync(CancellationToken ct = default)
     {
-        if (!OllamaEnabled) return false;
-        OllamaHealthy = await _enrichment.CheckHealthAsync(ct);
-        return OllamaHealthy;
+        if (!EnrichmentEnabled) return false;
+        EnrichmentHealthy = await _enrichment.CheckHealthAsync(ct);
+        return EnrichmentHealthy;
     }
 
     public bool CheckAuthGuard()
@@ -149,18 +149,19 @@ public sealed class EidetHost : IDisposable
     public Task StartEnrichmentWorkerAsync(CancellationToken ct) => _enrichmentWorker.StartAsync(ct);
 
     /// <summary>
-    /// Starts a background health monitor that checks RavenDB and Ollama every 30 seconds
-    /// and fires OnStatusChanged when a dependency's health state changes.
+    /// Starts a background health monitor that checks RavenDB and the enrichment backend every
+    /// 30 seconds and fires OnStatusChanged when a dependency's health state changes.
     /// </summary>
     public HealthMonitor StartHealthMonitor(CancellationToken ct)
     {
         _healthMonitor = new HealthMonitor(
             _eidetStore,
-            OllamaEnabled,
-            OllamaModel,
-            OllamaUrl,
+            EnrichmentEnabled,
+            EnrichmentProvider,
+            EnrichmentModel,
+            EnrichmentUrl,
             RavenUrl,
-            OllamaHealthy,
+            EnrichmentHealthy,
             ct);
         _healthMonitor.Start();
         return _healthMonitor;

--- a/src/Eidet.Service/EidetWindowsService.cs
+++ b/src/Eidet.Service/EidetWindowsService.cs
@@ -25,11 +25,11 @@ public sealed class EidetWindowsService : BackgroundService
             _logger.LogInformation("Eidet v{Version} starting on http://{Bind}:{Port}",
                 Eidet.Core.EidetVersion.Current, _host.BindAddress, _host.Port);
 
-            if (_host.OllamaEnabled)
+            if (_host.EnrichmentEnabled)
             {
-                var healthy = await _host.CheckOllamaAsync(stoppingToken);
-                _logger.LogInformation("Ollama: {Status} ({Model})",
-                    healthy ? "Connected" : "Unavailable", _host.OllamaModel);
+                var healthy = await _host.CheckEnrichmentAsync(stoppingToken);
+                _logger.LogInformation("Enrichment: {Status} ({Model})",
+                    healthy ? "Connected" : "Unavailable", _host.EnrichmentModel);
             }
 
             if (!_host.CheckAuthGuard())
@@ -42,7 +42,7 @@ public sealed class EidetWindowsService : BackgroundService
             _logger.LogInformation("Scheduler active (persisted — maintenance every {M}h, consolidation every {C}h)",
                 _host.MaintenanceIntervalHours, _host.ConsolidationIntervalHours);
 
-            if (_host.OllamaEnabled)
+            if (_host.EnrichmentEnabled)
             {
                 await _host.StartEnrichmentWorkerAsync(stoppingToken);
                 _logger.LogInformation("Enrichment worker active (RavenDB subscription)");

--- a/src/Eidet.Service/HealthMonitor.cs
+++ b/src/Eidet.Service/HealthMonitor.cs
@@ -1,14 +1,21 @@
+using Eidet.Core.Configuration;
 using Eidet.Core.Storage;
 
 namespace Eidet.Service;
 
 /// <summary>
-/// Background health monitor that periodically checks dependency health (RavenDB, Ollama)
-/// and raises events when status changes. Used by ServeCommand to print live status updates.
+/// Background health monitor that periodically checks dependency health (RavenDB and the
+/// enrichment backend) and raises events when status changes. Used by ServeCommand to print
+/// live status updates. The enrichment probe path is provider-aware so it works against both
+/// Ollama-native and OpenAI-compatible servers.
 /// </summary>
 public sealed class HealthMonitor : IDisposable
 {
-    public record HealthState(bool RavenDbHealthy, bool OllamaHealthy);
+    public record HealthState(bool RavenDbHealthy, bool EnrichmentHealthy);
+
+    /// <summary>The lightweight liveness endpoint to probe for a given enrichment provider.</summary>
+    internal static string ProbePathFor(EnrichmentProvider provider) =>
+        provider == EnrichmentProvider.OpenAiCompatible ? "/v1/models" : "/api/tags";
 
     /// <summary>
     /// Fired when a dependency's health status changes.
@@ -17,16 +24,17 @@ public sealed class HealthMonitor : IDisposable
     public event Action<string, bool, string>? OnStatusChanged;
 
     private readonly IEidetStore _store;
-    private readonly HttpClient? _ollamaHttp;
-    private readonly bool _ollamaEnabled;
-    private readonly string _ollamaModel;
-    private readonly string _ollamaUrl;
+    private readonly HttpClient? _enrichmentHttp;
+    private readonly bool _enrichmentEnabled;
+    private readonly string _enrichmentModel;
+    private readonly string _enrichmentUrl;
+    private readonly string _probePath;
     private readonly string _ravenUrl;
     private readonly Timer _timer;
     private readonly CancellationToken _ct;
 
     private bool _ravenHealthy = true; // assume healthy at start (we just connected)
-    private bool _ollamaHealthy;
+    private bool _enrichmentHealthy;
     private bool _disposed;
 
     private static readonly TimeSpan CheckInterval = TimeSpan.FromSeconds(30);
@@ -34,33 +42,35 @@ public sealed class HealthMonitor : IDisposable
 
     public HealthMonitor(
         IEidetStore store,
-        bool ollamaEnabled,
-        string ollamaModel,
-        string ollamaUrl,
+        bool enrichmentEnabled,
+        EnrichmentProvider provider,
+        string enrichmentModel,
+        string enrichmentUrl,
         string ravenUrl,
-        bool initialOllamaHealthy,
+        bool initialEnrichmentHealthy,
         CancellationToken ct)
     {
         _store = store;
-        _ollamaEnabled = ollamaEnabled;
-        _ollamaModel = ollamaModel;
-        _ollamaUrl = ollamaUrl;
+        _enrichmentEnabled = enrichmentEnabled;
+        _enrichmentModel = enrichmentModel;
+        _enrichmentUrl = enrichmentUrl;
+        _probePath = ProbePathFor(provider);
         _ravenUrl = ravenUrl;
-        _ollamaHealthy = initialOllamaHealthy;
+        _enrichmentHealthy = initialEnrichmentHealthy;
         _ct = ct;
         _timer = new Timer(OnTick, null, Timeout.Infinite, Timeout.Infinite);
 
-        if (ollamaEnabled)
+        if (enrichmentEnabled)
         {
-            _ollamaHttp = new HttpClient
+            _enrichmentHttp = new HttpClient
             {
-                BaseAddress = new Uri(ollamaUrl.TrimEnd('/')),
+                BaseAddress = new Uri(enrichmentUrl.TrimEnd('/')),
                 Timeout = TimeSpan.FromSeconds(5),
             };
         }
     }
 
-    public HealthState CurrentState => new(_ravenHealthy, _ollamaHealthy);
+    public HealthState CurrentState => new(_ravenHealthy, _enrichmentHealthy);
 
     public void Start()
     {
@@ -75,8 +85,8 @@ public sealed class HealthMonitor : IDisposable
         {
             await CheckRavenDbAsync();
 
-            if (_ollamaEnabled)
-                await CheckOllamaAsync();
+            if (_enrichmentEnabled)
+                await CheckEnrichmentAsync();
         }
         catch
         {
@@ -96,14 +106,14 @@ public sealed class HealthMonitor : IDisposable
         }
     }
 
-    private async Task CheckOllamaAsync()
+    private async Task CheckEnrichmentAsync()
     {
-        // Direct lightweight check — bypasses the Ollama adapter's 5-minute health cache
+        // Direct lightweight check — bypasses the adapter's 5-minute health cache
         // so we can detect status changes within 30 seconds.
         bool healthy;
         try
         {
-            var response = await _ollamaHttp!.GetAsync("/api/tags", _ct);
+            var response = await _enrichmentHttp!.GetAsync(_probePath, _ct);
             healthy = response.IsSuccessStatusCode;
         }
         catch
@@ -111,13 +121,13 @@ public sealed class HealthMonitor : IDisposable
             healthy = false;
         }
 
-        if (healthy != _ollamaHealthy)
+        if (healthy != _enrichmentHealthy)
         {
-            _ollamaHealthy = healthy;
+            _enrichmentHealthy = healthy;
             var detail = healthy
-                ? $"Connected ({_ollamaModel} @ {_ollamaUrl})"
-                : $"Unavailable ({_ollamaModel} @ {_ollamaUrl})";
-            OnStatusChanged?.Invoke("Ollama", healthy, detail);
+                ? $"Connected ({_enrichmentModel} @ {_enrichmentUrl})"
+                : $"Unavailable ({_enrichmentModel} @ {_enrichmentUrl})";
+            OnStatusChanged?.Invoke("Enrichment", healthy, detail);
         }
     }
 
@@ -126,6 +136,6 @@ public sealed class HealthMonitor : IDisposable
         if (_disposed) return;
         _disposed = true;
         _timer.Dispose();
-        _ollamaHttp?.Dispose();
+        _enrichmentHttp?.Dispose();
     }
 }

--- a/src/Eidet.Service/HealthMonitor.cs
+++ b/src/Eidet.Service/HealthMonitor.cs
@@ -113,7 +113,7 @@ public sealed class HealthMonitor : IDisposable
         bool healthy;
         try
         {
-            var response = await _enrichmentHttp!.GetAsync(_probePath, _ct);
+            using var response = await _enrichmentHttp!.GetAsync(_probePath, _ct);
             healthy = response.IsSuccessStatusCode;
         }
         catch

--- a/tests/Eidet.Core.Tests/Configuration/ConfigManagerTests.cs
+++ b/tests/Eidet.Core.Tests/Configuration/ConfigManagerTests.cs
@@ -1,9 +1,39 @@
+using System.Reflection;
+using System.Text.Json;
 using Eidet.Core.Configuration;
 
 namespace Eidet.Core.Tests.Configuration;
 
 public class ConfigManagerTests
 {
+    // ConfigManager.Load() is anchored at the real user-profile config path with no
+    // injectable seam, so the migration/env-override logic is exercised directly via the
+    // private static methods rather than touching the filesystem (which would clobber the
+    // developer's real config.json).
+
+    private static string MigrateLegacyEnrichmentKeys(string json)
+    {
+        var m = typeof(ConfigManager).GetMethod("MigrateLegacyEnrichmentKeys",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+        return (string)m.Invoke(null, [json])!;
+    }
+
+    private static void ApplyEnvironmentOverrides(EidetConfig config)
+    {
+        var m = typeof(ConfigManager).GetMethod("ApplyEnvironmentOverrides",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+        m.Invoke(null, [config]);
+    }
+
+    private static EnrichmentConfig DeserializeEnrichment(string json)
+    {
+        var options = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        };
+        return JsonSerializer.Deserialize<EidetConfig>(json, options)!.Enrichment;
+    }
+
     [Fact]
     public void Load_NoFile_ReturnsDefaults()
     {
@@ -33,9 +63,10 @@ public class ConfigManagerTests
     public void EnrichmentConfig_Defaults()
     {
         var enrichment = new EnrichmentConfig();
-        Assert.False(enrichment.OllamaEnabled);
-        Assert.Equal("http://localhost:11434", enrichment.OllamaUrl);
-        Assert.Equal("gemma4", enrichment.OllamaModel);
+        Assert.False(enrichment.Enabled);
+        Assert.Equal(EnrichmentProvider.Ollama, enrichment.Provider);
+        Assert.Equal("http://localhost:11434", enrichment.Url);
+        Assert.Equal("gemma4", enrichment.Model);
         Assert.True(enrichment.AutoOneLiner);
         Assert.True(enrichment.AutoForesight);
         Assert.True(enrichment.AutoConsolidation);
@@ -59,5 +90,118 @@ public class ConfigManagerTests
         var maintenance = new MaintenanceConfig();
         Assert.Equal(24, maintenance.IntervalHours);
         Assert.Equal(6, maintenance.ConsolidationIntervalHours);
+    }
+
+    // ─── Legacy enrichment-key migration ─────────────────────────────────
+
+    [Fact]
+    public void Migrate_LegacyKeysOnly_MapToNewKeys()
+    {
+        var json = """
+            { "enrichment": { "ollamaEnabled": true, "ollamaUrl": "http://legacy:11434", "ollamaModel": "llama3" } }
+            """;
+        var enrichment = DeserializeEnrichment(MigrateLegacyEnrichmentKeys(json));
+        Assert.True(enrichment.Enabled);
+        Assert.Equal("http://legacy:11434", enrichment.Url);
+        Assert.Equal("llama3", enrichment.Model);
+    }
+
+    [Fact]
+    public void Migrate_BothLegacyAndNewKeys_NewWins_LegacyIgnored()
+    {
+        var json = """
+            {
+              "enrichment": {
+                "ollamaEnabled": false, "ollamaUrl": "http://legacy:11434", "ollamaModel": "llama3",
+                "enabled": true, "url": "http://new:1234", "model": "qwen"
+              }
+            }
+            """;
+        var enrichment = DeserializeEnrichment(MigrateLegacyEnrichmentKeys(json));
+        Assert.True(enrichment.Enabled);
+        Assert.Equal("http://new:1234", enrichment.Url);
+        Assert.Equal("qwen", enrichment.Model);
+    }
+
+    [Fact]
+    public void Migrate_NewKeysOnly_Unchanged()
+    {
+        var json = """
+            { "enrichment": { "enabled": true, "provider": "OpenAiCompatible", "url": "http://new:1234", "model": "qwen" } }
+            """;
+        var enrichment = DeserializeEnrichment(MigrateLegacyEnrichmentKeys(json));
+        Assert.True(enrichment.Enabled);
+        Assert.Equal(EnrichmentProvider.OpenAiCompatible, enrichment.Provider);
+        Assert.Equal("http://new:1234", enrichment.Url);
+        Assert.Equal("qwen", enrichment.Model);
+    }
+
+    [Fact]
+    public void Migrate_MalformedJson_ReturnedUntouched()
+    {
+        var json = "{ not valid json";
+        Assert.Equal(json, MigrateLegacyEnrichmentKeys(json));
+    }
+
+    // ─── Environment-variable overrides (new wins over legacy alias) ─────
+
+    [Fact]
+    public void EnvOverride_NewVars_WinOverLegacyAliases()
+    {
+        var prev = (
+            Environment.GetEnvironmentVariable("EIDET_ENRICHMENT_URL"),
+            Environment.GetEnvironmentVariable("EIDET_OLLAMA_URL"),
+            Environment.GetEnvironmentVariable("EIDET_ENRICHMENT_MODEL"),
+            Environment.GetEnvironmentVariable("EIDET_OLLAMA_MODEL"));
+        try
+        {
+            Environment.SetEnvironmentVariable("EIDET_ENRICHMENT_URL", "http://new:1234");
+            Environment.SetEnvironmentVariable("EIDET_OLLAMA_URL", "http://legacy:11434");
+            Environment.SetEnvironmentVariable("EIDET_ENRICHMENT_MODEL", "qwen");
+            Environment.SetEnvironmentVariable("EIDET_OLLAMA_MODEL", "llama3");
+
+            var config = new EidetConfig();
+            ApplyEnvironmentOverrides(config);
+
+            Assert.Equal("http://new:1234", config.Enrichment.Url);
+            Assert.Equal("qwen", config.Enrichment.Model);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("EIDET_ENRICHMENT_URL", prev.Item1);
+            Environment.SetEnvironmentVariable("EIDET_OLLAMA_URL", prev.Item2);
+            Environment.SetEnvironmentVariable("EIDET_ENRICHMENT_MODEL", prev.Item3);
+            Environment.SetEnvironmentVariable("EIDET_OLLAMA_MODEL", prev.Item4);
+        }
+    }
+
+    [Fact]
+    public void EnvOverride_LegacyVarsOnly_StillApply()
+    {
+        var prev = (
+            Environment.GetEnvironmentVariable("EIDET_ENRICHMENT_URL"),
+            Environment.GetEnvironmentVariable("EIDET_OLLAMA_URL"),
+            Environment.GetEnvironmentVariable("EIDET_ENRICHMENT_MODEL"),
+            Environment.GetEnvironmentVariable("EIDET_OLLAMA_MODEL"));
+        try
+        {
+            Environment.SetEnvironmentVariable("EIDET_ENRICHMENT_URL", null);
+            Environment.SetEnvironmentVariable("EIDET_ENRICHMENT_MODEL", null);
+            Environment.SetEnvironmentVariable("EIDET_OLLAMA_URL", "http://legacy:11434");
+            Environment.SetEnvironmentVariable("EIDET_OLLAMA_MODEL", "llama3");
+
+            var config = new EidetConfig();
+            ApplyEnvironmentOverrides(config);
+
+            Assert.Equal("http://legacy:11434", config.Enrichment.Url);
+            Assert.Equal("llama3", config.Enrichment.Model);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("EIDET_ENRICHMENT_URL", prev.Item1);
+            Environment.SetEnvironmentVariable("EIDET_OLLAMA_URL", prev.Item2);
+            Environment.SetEnvironmentVariable("EIDET_ENRICHMENT_MODEL", prev.Item3);
+            Environment.SetEnvironmentVariable("EIDET_OLLAMA_MODEL", prev.Item4);
+        }
     }
 }

--- a/tests/Eidet.Core.Tests/Services/EnrichmentHealthCacheTests.cs
+++ b/tests/Eidet.Core.Tests/Services/EnrichmentHealthCacheTests.cs
@@ -1,0 +1,53 @@
+using System.Reflection;
+using Eidet.Core.Enrichment;
+
+namespace Eidet.Core.Tests.Services;
+
+/// <summary>
+/// Guards the recoverability contract of <c>EnrichmentHealthCache.IsAvailable</c>: a stale
+/// unhealthy verdict must not pin enrichment off forever, or a transient backend restart
+/// would permanently disable enrichment for the process lifetime.
+/// </summary>
+public class EnrichmentHealthCacheTests
+{
+    private static EnrichmentHealthCache NewCache() =>
+        (EnrichmentHealthCache)Activator.CreateInstance(
+            typeof(EnrichmentHealthCache), new HttpClient())!;
+
+    private static void SetState(EnrichmentHealthCache cache, bool? lastHealthy, DateTime lastCheck)
+    {
+        var t = typeof(EnrichmentHealthCache);
+        t.GetField("_lastHealthy", BindingFlags.NonPublic | BindingFlags.Instance)!.SetValue(cache, lastHealthy);
+        t.GetField("_lastCheck", BindingFlags.NonPublic | BindingFlags.Instance)!.SetValue(cache, lastCheck);
+    }
+
+    [Fact]
+    public void IsAvailable_StaleUnhealthy_BecomesAvailableForRetry()
+    {
+        var cache = NewCache();
+        SetState(cache, lastHealthy: false, lastCheck: DateTime.UtcNow.AddMinutes(-6));
+
+        // After the cache goes stale, IsAvailable must flip back to true so the next
+        // call re-probes and the backend can recover.
+        Assert.True(cache.IsAvailable);
+    }
+
+    [Fact]
+    public void IsAvailable_RecentUnhealthy_StaysUnavailable()
+    {
+        var cache = NewCache();
+        SetState(cache, lastHealthy: false, lastCheck: DateTime.UtcNow);
+
+        // Within the cache window an unhealthy verdict still suppresses calls.
+        Assert.False(cache.IsAvailable);
+    }
+
+    [Fact]
+    public void IsAvailable_Healthy_IsAvailable()
+    {
+        var cache = NewCache();
+        SetState(cache, lastHealthy: true, lastCheck: DateTime.UtcNow);
+
+        Assert.True(cache.IsAvailable);
+    }
+}

--- a/tests/Eidet.Core.Tests/Services/EnrichmentServiceTests.cs
+++ b/tests/Eidet.Core.Tests/Services/EnrichmentServiceTests.cs
@@ -1,3 +1,5 @@
+using System.Reflection;
+using Eidet.Core.Configuration;
 using Eidet.Core.Domain;
 using Eidet.Core.Enrichment;
 using Eidet.Core.Services;
@@ -6,6 +8,13 @@ namespace Eidet.Core.Tests.Services;
 
 public class EnrichmentServiceTests
 {
+    private static IEnrichmentPort GetPort(EnrichmentService svc)
+    {
+        var field = typeof(EnrichmentService).GetField("_port",
+            BindingFlags.NonPublic | BindingFlags.Instance)!;
+        return (IEnrichmentPort)field.GetValue(svc)!;
+    }
+
     // ─── Null / unavailable ──────────────────────────────────────────────
 
     [Fact]
@@ -330,5 +339,113 @@ public class EnrichmentServiceTests
         var input = "The user wants an ultra-compact, 10-word maximum summary.\nDraft 1: option A\nDraft 2: option B\n<channel|>Use AndAlso() in RavenDB queries to enforce AND logic over OR.";
         Assert.Equal("Use AndAlso() in RavenDB queries to enforce AND logic over OR.",
             OllamaTextSanitizer.Clean(input));
+    }
+
+    // ─── CreateFromConfig dispatch ────────────────────────────────────────
+
+    [Fact]
+    public void CreateFromConfig_Disabled_UsesNullAdapter_NotAvailable()
+    {
+        var cfg = new EnrichmentConfig { Enabled = false, Provider = EnrichmentProvider.OpenAiCompatible };
+        using var svc = EnrichmentService.CreateFromConfig(cfg);
+        Assert.False(svc.IsAvailable);
+        Assert.IsType<NullEnrichmentAdapter>(GetPort(svc));
+    }
+
+    [Fact]
+    public void CreateFromConfig_OpenAiCompatible_UsesOpenAiAdapter()
+    {
+        var cfg = new EnrichmentConfig { Enabled = true, Provider = EnrichmentProvider.OpenAiCompatible, Url = "http://localhost:1234", Model = "qwen" };
+        using var svc = EnrichmentService.CreateFromConfig(cfg);
+        Assert.IsType<OpenAiEnrichmentAdapter>(GetPort(svc));
+    }
+
+    [Fact]
+    public void CreateFromConfig_Ollama_UsesOllamaAdapter()
+    {
+        var cfg = new EnrichmentConfig { Enabled = true, Provider = EnrichmentProvider.Ollama, Url = "http://localhost:11434", Model = "gemma4" };
+        using var svc = EnrichmentService.CreateFromConfig(cfg);
+        Assert.IsType<OllamaEnrichmentAdapter>(GetPort(svc));
+    }
+
+    // ─── EnrichmentPrompts.Build parity ───────────────────────────────────
+    // Guards against the two adapters diverging: the shared builder must produce
+    // exactly the prompt text the original per-adapter logic produced.
+
+    [Fact]
+    public void Prompts_OneLiner_EmbedsContent_AndConstraint()
+    {
+        var prompt = EnrichmentPrompts.Build(new EnrichmentRequest(EnrichmentPrompt.OneLiner, "My memory body"));
+        Assert.Contains("ultra-compact one-liner", prompt);
+        Assert.Contains("Memory: My memory body", prompt);
+    }
+
+    [Fact]
+    public void Prompts_Summary_EmbedsContent()
+    {
+        var prompt = EnrichmentPrompts.Build(new EnrichmentRequest(EnrichmentPrompt.Summary, "Body text"));
+        Assert.Contains("Summarize this memory", prompt);
+        Assert.Contains("Memory: Body text", prompt);
+    }
+
+    [Fact]
+    public void Prompts_ForesightHint_EmbedsContent()
+    {
+        var prompt = EnrichmentPrompts.Build(new EnrichmentRequest(EnrichmentPrompt.ForesightHint, "Body text"));
+        Assert.Contains("foresight hint", prompt);
+        Assert.Contains("Memory: Body text", prompt);
+    }
+
+    [Fact]
+    public void Prompts_Entities_UsesTextLabel()
+    {
+        var prompt = EnrichmentPrompts.Build(new EnrichmentRequest(EnrichmentPrompt.Entities, "Body text"));
+        Assert.Contains("Extract named entities", prompt);
+        Assert.Contains("Text: Body text", prompt);
+    }
+
+    [Fact]
+    public void Prompts_MergeObservations_NumbersTheAuxList()
+    {
+        var prompt = EnrichmentPrompts.Build(
+            new EnrichmentRequest(EnrichmentPrompt.MergeObservations, string.Empty, ["first obs", "second obs"]));
+        Assert.Contains("merged into a single coherent insight", prompt);
+        Assert.Contains("1. first obs", prompt);
+        Assert.Contains("2. second obs", prompt);
+    }
+
+    [Fact]
+    public void Prompts_SameRequest_IsDeterministic()
+    {
+        var a = EnrichmentPrompts.Build(new EnrichmentRequest(EnrichmentPrompt.Summary, "same content"));
+        var b = EnrichmentPrompts.Build(new EnrichmentRequest(EnrichmentPrompt.Summary, "same content"));
+        Assert.Equal(a, b);
+    }
+
+    // ─── OpenAiEnrichmentAdapter (no server running) ──────────────────────
+    // The adapter constructs its own HttpClient with no injection seam, so the HTTP
+    // request shape (/v1/chat/completions, choices[0].message.content parsing, sanitizer
+    // pass) cannot be asserted without modifying production code. What IS cleanly
+    // testable is the health-gated short-circuit against an unreachable endpoint.
+
+    [Fact]
+    public void OpenAi_BeforeHealthCheck_IsAvailable()
+    {
+        using var adapter = new OpenAiEnrichmentAdapter("http://localhost:1234", "qwen");
+        Assert.True(adapter.IsAvailable);
+    }
+
+    [Fact]
+    public async Task OpenAi_CheckHealth_Unreachable_ReturnsFalse()
+    {
+        using var adapter = new OpenAiEnrichmentAdapter("http://localhost:19999", "qwen");
+        Assert.False(await adapter.CheckHealthAsync());
+    }
+
+    [Fact]
+    public async Task OpenAi_Complete_WhenUnhealthy_ReturnsNull()
+    {
+        using var adapter = new OpenAiEnrichmentAdapter("http://localhost:19999", "qwen");
+        Assert.Null(await adapter.CompleteAsync(new EnrichmentRequest(EnrichmentPrompt.OneLiner, "content")));
     }
 }

--- a/tests/Eidet.Service.Tests/Commands/ConfigCommandTests.cs
+++ b/tests/Eidet.Service.Tests/Commands/ConfigCommandTests.cs
@@ -41,7 +41,7 @@ public class ConfigCommandTests
     {
         var config = new EidetConfig();
         ConfigHelper.SetValue(config, "enrichment.ollamaEnabled", "True");
-        Assert.True(config.Enrichment.OllamaEnabled);
+        Assert.True(config.Enrichment.Enabled);
     }
 
     [Fact]
@@ -85,7 +85,42 @@ public class ConfigCommandTests
     {
         var config = new EidetConfig();
         ConfigHelper.SetValue(config, "enrichment.ollamaUrl", "http://custom:11434");
-        Assert.Equal("http://custom:11434", config.Enrichment.OllamaUrl);
+        Assert.Equal("http://custom:11434", config.Enrichment.Url);
+    }
+
+    [Fact]
+    public void SetValue_LegacyOllamaUrlAlias_MapsToSameValueAsNewKey()
+    {
+        var config = new EidetConfig();
+        ConfigHelper.SetValue(config, "enrichment.ollamaUrl", "http://aliased:9999");
+        Assert.Equal("http://aliased:9999", ConfigHelper.GetValue(config, "enrichment.url"));
+        Assert.Equal("http://aliased:9999", ConfigHelper.GetValue(config, "enrichment.ollamaUrl"));
+    }
+
+    [Fact]
+    public void SetValue_NewUrlKey_ReadableViaLegacyAlias()
+    {
+        var config = new EidetConfig();
+        ConfigHelper.SetValue(config, "enrichment.url", "http://viaNew:7777");
+        Assert.Equal("http://viaNew:7777", ConfigHelper.GetValue(config, "enrichment.ollamaUrl"));
+    }
+
+    [Fact]
+    public void SetValue_LegacyEnabledAndModelAliases_MapToNewKeys()
+    {
+        var config = new EidetConfig();
+        ConfigHelper.SetValue(config, "enrichment.ollamaEnabled", "True");
+        ConfigHelper.SetValue(config, "enrichment.ollamaModel", "qwen");
+        Assert.Equal("True", ConfigHelper.GetValue(config, "enrichment.enabled"));
+        Assert.Equal("qwen", ConfigHelper.GetValue(config, "enrichment.model"));
+    }
+
+    [Fact]
+    public void SetValue_ProviderKey_ParsesEnum()
+    {
+        var config = new EidetConfig();
+        Assert.True(ConfigHelper.SetValue(config, "enrichment.provider", "OpenAiCompatible"));
+        Assert.Equal(EnrichmentProvider.OpenAiCompatible, config.Enrichment.Provider);
     }
 
     [Fact]

--- a/tests/Eidet.Service.Tests/HealthMonitorTests.cs
+++ b/tests/Eidet.Service.Tests/HealthMonitorTests.cs
@@ -1,3 +1,4 @@
+using Eidet.Core.Configuration;
 using Eidet.Core.Domain;
 using Eidet.Core.Storage;
 
@@ -5,32 +6,40 @@ namespace Eidet.Service.Tests;
 
 public class HealthMonitorTests
 {
+    [Theory]
+    [InlineData(EnrichmentProvider.Ollama, "/api/tags")]
+    [InlineData(EnrichmentProvider.OpenAiCompatible, "/v1/models")]
+    public void ProbePathFor_IsProviderSpecific(EnrichmentProvider provider, string expected)
+    {
+        Assert.Equal(expected, HealthMonitor.ProbePathFor(provider));
+    }
+
     [Fact]
     public void CurrentState_ReflectsInitialState()
     {
         using var cts = new CancellationTokenSource();
         using var monitor = new HealthMonitor(
-            new StubStore(healthy: true), ollamaEnabled: false,
-            "gemma4", "http://localhost:11434", "http://localhost:8080",
-            initialOllamaHealthy: false, cts.Token);
+            new StubStore(healthy: true), enrichmentEnabled: false,
+            EnrichmentProvider.Ollama, "gemma4", "http://localhost:11434", "http://localhost:8080",
+            initialEnrichmentHealthy: false, cts.Token);
 
         var state = monitor.CurrentState;
         Assert.True(state.RavenDbHealthy);
-        Assert.False(state.OllamaHealthy);
+        Assert.False(state.EnrichmentHealthy);
     }
 
     [Fact]
-    public void CurrentState_OllamaEnabled_ReflectsInitialHealth()
+    public void CurrentState_EnrichmentEnabled_ReflectsInitialHealth()
     {
         using var cts = new CancellationTokenSource();
         using var monitor = new HealthMonitor(
-            new StubStore(healthy: true), ollamaEnabled: true,
-            "gemma4", "http://localhost:11434", "http://localhost:8080",
-            initialOllamaHealthy: true, cts.Token);
+            new StubStore(healthy: true), enrichmentEnabled: true,
+            EnrichmentProvider.OpenAiCompatible, "gemma4", "http://localhost:1234", "http://localhost:8080",
+            initialEnrichmentHealthy: true, cts.Token);
 
         var state = monitor.CurrentState;
         Assert.True(state.RavenDbHealthy);
-        Assert.True(state.OllamaHealthy);
+        Assert.True(state.EnrichmentHealthy);
     }
 
     [Fact]
@@ -38,9 +47,9 @@ public class HealthMonitorTests
     {
         using var cts = new CancellationTokenSource();
         var monitor = new HealthMonitor(
-            new StubStore(healthy: true), ollamaEnabled: true,
-            "gemma4", "http://localhost:11434", "http://localhost:8080",
-            initialOllamaHealthy: false, cts.Token);
+            new StubStore(healthy: true), enrichmentEnabled: true,
+            EnrichmentProvider.Ollama, "gemma4", "http://localhost:11434", "http://localhost:8080",
+            initialEnrichmentHealthy: false, cts.Token);
 
         monitor.Dispose();
         // Should not throw on double dispose
@@ -53,6 +62,7 @@ public class HealthMonitorTests
         var a = new HealthMonitor.HealthState(true, false);
         var b = new HealthMonitor.HealthState(true, false);
         var c = new HealthMonitor.HealthState(false, false);
+        // record field rename guard: second positional is EnrichmentHealthy
 
         Assert.Equal(a, b);
         Assert.NotEqual(a, c);
@@ -64,9 +74,9 @@ public class HealthMonitorTests
         using var cts = new CancellationTokenSource();
         var store = new StubStore(healthy: true);
         using var monitor = new HealthMonitor(
-            store, ollamaEnabled: false,
-            "gemma4", "http://localhost:11434", "http://localhost:8080",
-            initialOllamaHealthy: false, cts.Token);
+            store, enrichmentEnabled: false,
+            EnrichmentProvider.Ollama, "gemma4", "http://localhost:11434", "http://localhost:8080",
+            initialEnrichmentHealthy: false, cts.Token);
 
         var events = new List<(string Component, bool Healthy, string Detail)>();
         monitor.OnStatusChanged += (c, h, d) => events.Add((c, h, d));
@@ -99,9 +109,9 @@ public class HealthMonitorTests
         // The monitor assumes RavenDB is healthy at start, so a false store will trigger "down" first,
         // then we flip to healthy to trigger "recovered"
         using var monitor = new HealthMonitor(
-            store, ollamaEnabled: false,
-            "gemma4", "http://localhost:11434", "http://localhost:8080",
-            initialOllamaHealthy: false, cts.Token);
+            store, enrichmentEnabled: false,
+            EnrichmentProvider.Ollama, "gemma4", "http://localhost:11434", "http://localhost:8080",
+            initialEnrichmentHealthy: false, cts.Token);
 
         var events = new List<(string Component, bool Healthy, string Detail)>();
         monitor.OnStatusChanged += (c, h, d) => events.Add((c, h, d));
@@ -134,9 +144,9 @@ public class HealthMonitorTests
         using var cts = new CancellationTokenSource();
         var store = new StubStore(healthy: true);
         using var monitor = new HealthMonitor(
-            store, ollamaEnabled: false,
-            "gemma4", "http://localhost:11434", "http://localhost:8080",
-            initialOllamaHealthy: false, cts.Token);
+            store, enrichmentEnabled: false,
+            EnrichmentProvider.Ollama, "gemma4", "http://localhost:11434", "http://localhost:8080",
+            initialEnrichmentHealthy: false, cts.Token);
 
         var events = new List<(string Component, bool Healthy, string Detail)>();
         monitor.OnStatusChanged += (c, h, d) => events.Add((c, h, d));


### PR DESCRIPTION
Closes #20. Design hardened via `/design-interface` (issue #20), built via `/implement-issue`.

## What & why

Enrichment was coupled to **Ollama's native API** — not the string `"ollama"`, but the wire protocol (`/api/chat`, the `think` field, `message.content`). Pointing the URL at LM Studio / llama.cpp / vLLM didn't work because those speak the **OpenAI-compatible** dialect (`/v1/chat/completions`, `/v1/models`, `choices[0].message.content`). This adds a second adapter and a provider switch so any OpenAI-compatible local server works, without breaking the existing Ollama path.

## Changes

- **`OpenAiEnrichmentAdapter`** — `/v1/chat/completions` (no `think`), `/v1/models` health, parses `choices[0].message.content`, reuses `OllamaTextSanitizer` (reasoning models still emit `<think>`).
- **Shared internals** — `EnrichmentPrompts.Build` + `EnrichmentHealthCache` lifted out so the two adapters can't diverge on prompt text or cache semantics (5-min TTL preserved byte-for-byte).
- **`EnrichmentService.CreateFromConfig`** — dispatches on a new `EnrichmentProvider` enum (`Ollama` | `OpenAiCompatible`); the 3 construction sites collapse to one call.
- **Config rename + back-compat** — `EnrichmentConfig` `OllamaEnabled/Url/Model` → `Enabled/Url/Model` + `Provider`. Legacy configs migrate in `ConfigManager.Load()` (JsonNode), CLI keeps `enrichment.ollama*` aliases, `EIDET_OLLAMA_*` env vars still work (new name wins).
- **`HealthMonitor` made provider-aware** — probes `/v1/models` vs `/api/tags` so `serve` no longer reports an OpenAI-compatible backend as perpetually Unavailable. *(This was the one blocking gap caught in review — the adapter and `doctor` were correct, but the 30s live monitor still hardcoded Ollama's endpoint.)*

## Out of scope (deliberate)

- Ollama model management (`eidet ollama pull`) stays Ollama-specific — package management, orthogonal to enrichment transport.
- No `ApiKey` field and no runtime autodetection — deferred (see issue #20's trap analysis; the flat shape bets on "local server, no auth").

## Testing

- New: config-migration (legacy-only / both / new-only / malformed), env-var precedence, `CreateFromConfig` dispatch, `EnrichmentPrompts.Build` parity, OpenAI adapter health-gating, CLI alias mapping, and a provider→probe-path regression guard for the HealthMonitor fix.
- **585 tests pass** (Core 415, Service 170). Build clean, 0 warnings.

### Known limitation
The exact OpenAI HTTP request/response shape isn't asserted — both `OpenAiEnrichmentAdapter` and `HealthMonitor` construct their own `HttpClient` with no handler-injection seam, and the suite has no `HttpMessageHandler` stub pattern. Tests cover the cleanly-assertable behavior (prompt parity, health-gating, provider→path mapping) instead of inventing mock infrastructure. Worth a follow-up if we want full wire-level coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
