### PR TITLE
refactor(maintenance): collapse facade, derive IsRepoActive, unit-testable stages (#22)

### DIFF
--- a/architecture-friction.md
+++ b/architecture-friction.md
@@ -96,7 +96,14 @@ The handler split is intentional (sharing between MCP and REST). Question is whe
 
 ---
 
-## 4. Maintenance stages + orchestrator
+## 4. Maintenance stages + orchestrator — ✅ DESIGNED
+
+> Design hardened 2026-06-11 via `/design-interface` → RFC [#22](https://github.com/stevehansen/eidet/issues/22).
+> Verdict: **stage count is not the problem.** Chosen hybrid — collapse the redundant `IMaintenanceRunner`/`IMaintenanceOrchestrator`
+> double-facade, add a `RunAsync(string repo)` happy-path overload that derives `IsRepoActive` (fixes a CLI footgun),
+> add a `MaintenanceContext.ForTest` seam so the 10 stages become unit-testable, and type `OnlyStages`/`SkipStages`
+> as a `MaintenanceStep` enum. Rejected: folding stages into private methods (kills testability — the scope invariant
+> is already structurally sealed), `RunsAfter` topo-sort (speculative), engine ports (shallow pass-throughs).
 
 **Files**
 - `src/Eidet.Core/Maintenance/MaintenanceOrchestrator.cs`

--- a/src/Eidet.Core/Maintenance/IMaintenanceRunner.cs
+++ b/src/Eidet.Core/Maintenance/IMaintenanceRunner.cs
@@ -1,24 +1,16 @@
 namespace Eidet.Core.Maintenance;
 
 /// <summary>
-/// Thin default-path facade used by scheduler / REST / MCP. Keeps those callers
-/// immune to stage additions: adding a new stage in the pipeline doesn't change
-/// this signature.
+/// Sole entry point for the maintenance pipeline (scheduler / REST / MCP / CLI). Keeps callers
+/// immune to stage additions: adding a stage doesn't change these signatures.
 /// </summary>
 public interface IMaintenanceRunner
 {
+    /// <summary>
+    /// Happy path: normalize the repo path and derive <c>IsRepoActive</c> internally, run all stages.
+    /// </summary>
+    Task<MaintenanceReport> RunAsync(string repoPathOrId, CancellationToken ct = default);
+
+    /// <summary>Power path: subset/skip/retention overrides and an explicit <c>IsRepoActive</c>.</summary>
     Task<MaintenanceReport> RunAsync(MaintenanceRequest request, CancellationToken ct = default);
-}
-
-public sealed class MaintenanceRunner : IMaintenanceRunner
-{
-    private readonly IMaintenanceOrchestrator _orchestrator;
-
-    public MaintenanceRunner(IMaintenanceOrchestrator orchestrator)
-    {
-        _orchestrator = orchestrator;
-    }
-
-    public Task<MaintenanceReport> RunAsync(MaintenanceRequest request, CancellationToken ct = default)
-        => _orchestrator.RunAsync(request, ct);
 }

--- a/src/Eidet.Core/Maintenance/IMaintenanceStage.cs
+++ b/src/Eidet.Core/Maintenance/IMaintenanceStage.cs
@@ -32,4 +32,30 @@ public sealed class MaintenanceContext
 
     /// <summary>Stage-to-stage scratch area — avoid unless truly needed.</summary>
     public IDictionary<string, object> Items { get; } = new Dictionary<string, object>();
+
+    /// <summary>
+    /// Drives a single stage without the orchestrator. Builds the dual-use engines internally so
+    /// tests pass only the store + bulk write scope; run-constants default to an active test repo.
+    /// The engines run on a throwaway <see cref="MemoryService"/> distinct from the one that opened
+    /// <paramref name="write"/>; that is coherent only because delegator stages and the engines write
+    /// through the supplied <paramref name="write"/> scope — if an engine ever fell back to its own
+    /// (<c>write == null</c>) scope, a ForTest run would invalidate the wrong cache.
+    /// </summary>
+    public static MaintenanceContext ForTest(
+        IEidetStore store, BulkMutationCtx write,
+        EnrichmentService? enrichment = null, string repoId = "test-repo")
+    {
+        var memory = new MemoryService(store);
+        var enrich = enrichment ?? EnrichmentService.CreateNull();
+        return new MaintenanceContext
+        {
+            Store = store,
+            Write = write,
+            Enrichment = enrich,
+            Consolidation = new ConsolidationEngine(store, enrich, memory),
+            Dedup = new DedupEngine(store, memory, enrich),
+            RepoId = repoId,
+            IsRepoActive = true,
+        };
+    }
 }

--- a/src/Eidet.Core/Maintenance/MaintenanceOrchestrator.cs
+++ b/src/Eidet.Core/Maintenance/MaintenanceOrchestrator.cs
@@ -56,8 +56,11 @@ public sealed class MaintenanceOrchestrator : IMaintenanceRunner
         // through `write`, so the touched scopes are invalidated exactly once in the finally.
         _memory.RunBulkAsync(async write =>
         {
+            // Normalize here too (idempotent): the string overload already does, but a direct
+            // MaintenanceRequest caller might pass a raw path — un-normalized it misses the corpus.
+            var repoId = RepoIdNormalizer.Normalize(request.RepoId);
             var dedup = new DedupEngine(_store, _memory, _enrichment);
-            var report = new MaintenanceReport { RepoId = request.RepoId };
+            var report = new MaintenanceReport { RepoId = repoId };
 
             // Built once per run: every field is run-constant, and stages share one Now and one
             // Items scratch dictionary (the documented stage-to-stage contract).
@@ -68,9 +71,9 @@ public sealed class MaintenanceOrchestrator : IMaintenanceRunner
                 Enrichment = _enrichment,
                 Consolidation = _consolidation,
                 Dedup = dedup,
-                RepoId = request.RepoId,
+                RepoId = repoId,
                 // Single derivation site: null ⇒ derive so the CLI path can't decay an inactive repo.
-                IsRepoActive = request.IsRepoActive ?? _memory.IsRepoActive(request.RepoId),
+                IsRepoActive = request.IsRepoActive ?? _memory.IsRepoActive(repoId),
                 ObservationRetentionDays = request.ObservationRetentionDays,
                 Drift = _drift,
             };

--- a/src/Eidet.Core/Maintenance/MaintenanceOrchestrator.cs
+++ b/src/Eidet.Core/Maintenance/MaintenanceOrchestrator.cs
@@ -1,4 +1,5 @@
 using Eidet.Core.Configuration;
+using Eidet.Core.Domain;
 using Eidet.Core.Enrichment;
 using Eidet.Core.Maintenance.Stages;
 using Eidet.Core.Services;
@@ -6,12 +7,7 @@ using Eidet.Core.Storage;
 
 namespace Eidet.Core.Maintenance;
 
-public interface IMaintenanceOrchestrator
-{
-    Task<MaintenanceReport> RunAsync(MaintenanceRequest request, CancellationToken ct = default);
-}
-
-public sealed class MaintenanceOrchestrator : IMaintenanceOrchestrator
+public sealed class MaintenanceOrchestrator : IMaintenanceRunner
 {
     private readonly IEidetStore _store;
     private readonly MemoryService _memory;
@@ -52,6 +48,9 @@ public sealed class MaintenanceOrchestrator : IMaintenanceOrchestrator
         new ConsolidationStage(),
     ];
 
+    public Task<MaintenanceReport> RunAsync(string repoPathOrId, CancellationToken ct = default) =>
+        RunAsync(new MaintenanceRequest { RepoId = RepoIdNormalizer.Normalize(repoPathOrId) }, ct);
+
     public Task<MaintenanceReport> RunAsync(MaintenanceRequest request, CancellationToken ct = default) =>
         // One bulk scope per run: every direct-writing stage and both dual-use engines write
         // through `write`, so the touched scopes are invalidated exactly once in the finally.
@@ -70,17 +69,26 @@ public sealed class MaintenanceOrchestrator : IMaintenanceOrchestrator
                 Consolidation = _consolidation,
                 Dedup = dedup,
                 RepoId = request.RepoId,
-                IsRepoActive = request.IsRepoActive,
+                // Single derivation site: null ⇒ derive so the CLI path can't decay an inactive repo.
+                IsRepoActive = request.IsRepoActive ?? _memory.IsRepoActive(request.RepoId),
                 ObservationRetentionDays = request.ObservationRetentionDays,
                 Drift = _drift,
             };
+
+            // Map the requested enum sets to stage names once. Comparing by name (never parsing
+            // stage.Name) keeps selection total: a stage whose name has no MaintenanceStep member
+            // simply never matches an Only filter, rather than throwing and aborting the run.
+            var onlyNames = request.OnlyStages is { Count: > 0 } only
+                ? only.Select(s => s.ToString()).ToHashSet(StringComparer.Ordinal) : null;
+            var skipNames = request.SkipStages is { Count: > 0 } skip
+                ? skip.Select(s => s.ToString()).ToHashSet(StringComparer.Ordinal) : null;
 
             foreach (var stage in _stages)
             {
                 if (ct.IsCancellationRequested) break;
 
-                if (request.OnlyStages is { Count: > 0 } only && !only.Contains(stage.Name)) continue;
-                if (request.SkipStages is { Count: > 0 } skip && skip.Contains(stage.Name)) continue;
+                if (onlyNames is not null && !onlyNames.Contains(stage.Name)) continue;
+                if (skipNames is not null && skipNames.Contains(stage.Name)) continue;
 
                 try
                 {

--- a/src/Eidet.Core/Maintenance/MaintenanceReport.cs
+++ b/src/Eidet.Core/Maintenance/MaintenanceReport.cs
@@ -1,12 +1,30 @@
 namespace Eidet.Core.Maintenance;
 
+/// <summary>
+/// The 10 maintenance stages, in pipeline order. Each value's name equals the matching
+/// stage's <c>StageName</c> const; the orchestrator maps enum ⇄ name at the selection boundary.
+/// </summary>
+public enum MaintenanceStep
+{
+    TtlExpiry,
+    ObservationRetention,
+    DedupSweep,
+    ImportanceDecay,
+    OrphanCleanup,
+    EnrichmentCleanup,
+    HeuristicEnrichmentBackfill,
+    OllamaEnrichment,
+    DriftReview,
+    Consolidation,
+}
+
 public sealed class MaintenanceRequest
 {
     public required string RepoId { get; init; }
-    public bool IsRepoActive { get; init; } = true;
+    public bool? IsRepoActive { get; init; }
     public int ObservationRetentionDays { get; init; } = 90;
-    public ISet<string>? OnlyStages { get; init; }
-    public ISet<string>? SkipStages { get; init; }
+    public ISet<MaintenanceStep>? OnlyStages { get; init; }
+    public ISet<MaintenanceStep>? SkipStages { get; init; }
 }
 
 public sealed class MaintenanceReport
@@ -17,6 +35,8 @@ public sealed class MaintenanceReport
 
     public int AffectedBy(string stageName) =>
         Stages.FirstOrDefault(s => s.Name == stageName).Affected;
+
+    public int AffectedBy(MaintenanceStep step) => AffectedBy(step.ToString());
 
     public IEnumerable<StageOutcome> Failures => Stages.Where(s => !s.Succeeded);
 

--- a/src/Eidet.Core/Services/ScheduledTaskService.cs
+++ b/src/Eidet.Core/Services/ScheduledTaskService.cs
@@ -26,7 +26,6 @@ public sealed class ScheduledTaskService : IDisposable
 {
     private readonly IDocumentStore _documentStore;
     private readonly IEidetStore _eidetStore;
-    private readonly MemoryService _memorySvc;
     private readonly IMaintenanceRunner _maintenance;
     private readonly ConsolidationEngine _consolidation;
     private readonly MaintenanceConfig _config;
@@ -42,14 +41,12 @@ public sealed class ScheduledTaskService : IDisposable
     public ScheduledTaskService(
         IDocumentStore documentStore,
         IEidetStore eidetStore,
-        MemoryService memorySvc,
         IMaintenanceRunner maintenance,
         ConsolidationEngine consolidation,
         MaintenanceConfig config)
     {
         _documentStore = documentStore;
         _eidetStore = eidetStore;
-        _memorySvc = memorySvc;
         _maintenance = maintenance;
         _consolidation = consolidation;
         _config = config;
@@ -212,8 +209,7 @@ public sealed class ScheduledTaskService : IDisposable
                 switch (task.TaskType)
                 {
                     case ScheduledTaskType.Maintenance:
-                        var isActive = _memorySvc.IsRepoActive(repoId);
-                        await _maintenance.RunAsync(new MaintenanceRequest { RepoId = repoId, IsRepoActive = isActive });
+                        await _maintenance.RunAsync(repoId);
                         break;
 
                     case ScheduledTaskType.Consolidation:

--- a/src/Eidet.Service/Commands/MaintainCommand.cs
+++ b/src/Eidet.Service/Commands/MaintainCommand.cs
@@ -27,15 +27,15 @@ public sealed class MaintainCommand : AsyncCommand<MaintainCommand.Settings>
         using var enrichment = EnrichmentService.CreateFromConfig(config.Enrichment);
         var memorySvc = new MemoryService(eidetStore);
         var consolidationEngine = new ConsolidationEngine(eidetStore, enrichment, memorySvc);
-        IMaintenanceRunner runner = new MaintenanceRunner(
-            new MaintenanceOrchestrator(eidetStore, memorySvc, enrichment, consolidationEngine,
-                drift: config.Enrichment.DriftReview));
+        IMaintenanceRunner runner = new MaintenanceOrchestrator(
+            eidetStore, memorySvc, enrichment, consolidationEngine,
+            drift: config.Enrichment.DriftReview);
 
         var repoId = Eidet.Core.Domain.RepoIdNormalizer.Normalize(settings.Repo ?? Directory.GetCurrentDirectory());
 
         try
         {
-            var report = await runner.RunAsync(new MaintenanceRequest { RepoId = repoId }, cancellation);
+            var report = await runner.RunAsync(repoId, cancellation);
 
             if (settings.Json)
             {

--- a/src/Eidet.Service/Commands/McpCommand.cs
+++ b/src/Eidet.Service/Commands/McpCommand.cs
@@ -41,9 +41,9 @@ public sealed class McpCommand : AsyncCommand<McpCommand.Settings>
             var memorySvc = new MemoryService(eidetStore, hooks: hookRunner);
             var intakeSvc = new IntakeService(eidetStore, memorySvc);
             var consolidationEngine = new ConsolidationEngine(eidetStore, enrichment, memorySvc);
-            IMaintenanceRunner maintenanceRunner = new MaintenanceRunner(
-                new MaintenanceOrchestrator(eidetStore, memorySvc, enrichment, consolidationEngine,
-                    drift: config.Enrichment.DriftReview));
+            IMaintenanceRunner maintenanceRunner = new MaintenanceOrchestrator(
+                eidetStore, memorySvc, enrichment, consolidationEngine,
+                drift: config.Enrichment.DriftReview);
 
             var exportSvc = new ExportService(eidetStore, memorySvc);
             var layerSvc = new LayerService(eidetStore);

--- a/src/Eidet.Service/EidetHost.cs
+++ b/src/Eidet.Service/EidetHost.cs
@@ -93,9 +93,9 @@ public sealed class EidetHost : IDisposable
         var memorySvc = new MemoryService(eidetStore, layerSvc, hookRunner);
         var intakeSvc = new IntakeService(eidetStore, memory: memorySvc);
         var consolidationEngine = new ConsolidationEngine(eidetStore, enrichment, memory: memorySvc);
-        IMaintenanceRunner maintenanceRunner = new MaintenanceRunner(
-            new MaintenanceOrchestrator(eidetStore, memorySvc, enrichment, consolidationEngine,
-                drift: config.Enrichment.DriftReview));
+        IMaintenanceRunner maintenanceRunner = new MaintenanceOrchestrator(
+            eidetStore, memorySvc, enrichment, consolidationEngine,
+            drift: config.Enrichment.DriftReview);
         var exportSvc = new ExportService(eidetStore, memory: memorySvc);
         var qualitySvc = new QualityService(eidetStore);
         var usageTracker = new UsageTracker(store);
@@ -103,7 +103,7 @@ public sealed class EidetHost : IDisposable
         var mcpServer = new McpServer(memorySvc, intakeSvc, consolidationEngine, maintenanceRunner,
             Directory.GetCurrentDirectory(), autoIntake: config.Memory.AutoIntakeOnFirstSession, usage: usageTracker,
             export: exportSvc, layers: layerSvc);
-        var scheduler = new ScheduledTaskService(store, eidetStore, memorySvc, maintenanceRunner, consolidationEngine, config.Maintenance);
+        var scheduler = new ScheduledTaskService(store, eidetStore, maintenanceRunner, consolidationEngine, config.Maintenance);
         var apiServer = new EidetApiServer(new EidetApiServerOptions
         {
             Memory = memorySvc,

--- a/src/Eidet.Service/Tools/Handlers/MaintenanceToolHandler.cs
+++ b/src/Eidet.Service/Tools/Handlers/MaintenanceToolHandler.cs
@@ -1,7 +1,5 @@
 using System.Text.Json.Nodes;
-using Eidet.Core.Domain;
 using Eidet.Core.Maintenance;
-using Eidet.Core.Services;
 using Eidet.Service.Mcp;
 
 namespace Eidet.Service.Tools.Handlers;
@@ -13,12 +11,10 @@ namespace Eidet.Service.Tools.Handlers;
 public sealed class MaintenanceToolHandler : IToolHandler
 {
     private readonly IMaintenanceRunner _maintenance;
-    private readonly MemoryService _svc;
 
-    public MaintenanceToolHandler(IMaintenanceRunner maintenance, MemoryService svc)
+    public MaintenanceToolHandler(IMaintenanceRunner maintenance)
     {
         _maintenance = maintenance;
-        _svc = svc;
     }
 
     public string Name => "eidet_maintenance";
@@ -33,10 +29,7 @@ public sealed class MaintenanceToolHandler : IToolHandler
 
     public async Task<ToolResult> ExecuteAsync(ToolRequest request)
     {
-        var normalizedRepoId = RepoIdNormalizer.Normalize(request.RepoId);
-        var isActive = _svc.IsRepoActive(normalizedRepoId);
-        var report = await _maintenance.RunAsync(
-            new MaintenanceRequest { RepoId = normalizedRepoId, IsRepoActive = isActive }, request.Ct);
+        var report = await _maintenance.RunAsync(request.RepoId, request.Ct);
 
         return ToolResult.Ok(
             payload: report,

--- a/src/Eidet.Service/Tools/ToolDispatcherFactory.cs
+++ b/src/Eidet.Service/Tools/ToolDispatcherFactory.cs
@@ -29,7 +29,7 @@ internal static class ToolDispatcherFactory
             new ContextToolHandler(svc),
             new LinkToolHandler(svc),
             new ConsolidateToolHandler(consolidation),
-            new MaintenanceToolHandler(maintenance, svc),
+            new MaintenanceToolHandler(maintenance),
             new EditToolHandler(svc),
             new IntakeToolHandler(intake),
             new PackExportToolHandler(export),

--- a/tests/Eidet.Core.Tests/Maintenance/DriftReviewStageTests.cs
+++ b/tests/Eidet.Core.Tests/Maintenance/DriftReviewStageTests.cs
@@ -53,7 +53,7 @@ public class DriftReviewStageTests
         {
             RepoId = "repo-a",
             IsRepoActive = true,
-            OnlyStages = new HashSet<string> { DriftReviewStage.StageName },
+            OnlyStages = new HashSet<MaintenanceStep> { MaintenanceStep.DriftReview },
         });
     }
 

--- a/tests/Eidet.Core.Tests/Maintenance/MaintenanceCacheInvalidationTests.cs
+++ b/tests/Eidet.Core.Tests/Maintenance/MaintenanceCacheInvalidationTests.cs
@@ -49,7 +49,7 @@ public class MaintenanceCacheInvalidationTests
         {
             RepoId = "repo-a",
             IsRepoActive = true,
-            OnlyStages = new HashSet<string> { TtlExpiryStage.StageName },
+            OnlyStages = new HashSet<MaintenanceStep> { MaintenanceStep.TtlExpiry },
         });
         Assert.Equal(1, report.AffectedBy(TtlExpiryStage.StageName));
 
@@ -87,7 +87,7 @@ public class MaintenanceCacheInvalidationTests
         {
             RepoId = "repo-a",
             IsRepoActive = true,
-            OnlyStages = new HashSet<string> { TtlExpiryStage.StageName },
+            OnlyStages = new HashSet<MaintenanceStep> { MaintenanceStep.TtlExpiry },
         });
         Assert.Equal(0, report.AffectedBy(TtlExpiryStage.StageName));
 
@@ -240,7 +240,7 @@ public class MaintenanceCacheInvalidationTests
         {
             RepoId = "repo-a",
             IsRepoActive = true,
-            OnlyStages = new HashSet<string> { ConsolidationStage.StageName },
+            OnlyStages = new HashSet<MaintenanceStep> { MaintenanceStep.Consolidation },
         });
         Assert.Equal(1, report.AffectedBy(ConsolidationStage.StageName));
 

--- a/tests/Eidet.Core.Tests/Maintenance/MaintenanceOrchestratorTests.cs
+++ b/tests/Eidet.Core.Tests/Maintenance/MaintenanceOrchestratorTests.cs
@@ -48,43 +48,43 @@ public class MaintenanceOrchestratorTests
     [Fact]
     public async Task SkipStages_SkipsNamedStage()
     {
-        var a = new StubStage("A");
-        var b = new StubStage("B");
-        var c = new StubStage("C");
+        var a = new StubStage(nameof(MaintenanceStep.TtlExpiry));
+        var b = new StubStage(nameof(MaintenanceStep.DedupSweep));
+        var c = new StubStage(nameof(MaintenanceStep.OrphanCleanup));
 
         var orchestrator = WithStages(a, b, c);
         var report = await orchestrator.RunAsync(new MaintenanceRequest
         {
             RepoId = "r",
-            SkipStages = new HashSet<string> { "B" },
+            SkipStages = new HashSet<MaintenanceStep> { MaintenanceStep.DedupSweep },
         });
 
         Assert.Equal(1, a.InvocationCount);
         Assert.Equal(0, b.InvocationCount);
         Assert.Equal(1, c.InvocationCount);
         Assert.Equal(2, report.Stages.Count);
-        Assert.DoesNotContain(report.Stages, s => s.Name == "B");
+        Assert.DoesNotContain(report.Stages, s => s.Name == nameof(MaintenanceStep.DedupSweep));
     }
 
     [Fact]
     public async Task OnlyStages_RunsOnlyNamedStages()
     {
-        var a = new StubStage("A");
-        var b = new StubStage("B");
-        var c = new StubStage("C");
+        var a = new StubStage(nameof(MaintenanceStep.TtlExpiry));
+        var b = new StubStage(nameof(MaintenanceStep.DedupSweep));
+        var c = new StubStage(nameof(MaintenanceStep.OrphanCleanup));
 
         var orchestrator = WithStages(a, b, c);
         var report = await orchestrator.RunAsync(new MaintenanceRequest
         {
             RepoId = "r",
-            OnlyStages = new HashSet<string> { "B" },
+            OnlyStages = new HashSet<MaintenanceStep> { MaintenanceStep.DedupSweep },
         });
 
         Assert.Equal(0, a.InvocationCount);
         Assert.Equal(1, b.InvocationCount);
         Assert.Equal(0, c.InvocationCount);
         Assert.Single(report.Stages);
-        Assert.Equal("B", report.Stages[0].Name);
+        Assert.Equal(nameof(MaintenanceStep.DedupSweep), report.Stages[0].Name);
     }
 
     [Fact]
@@ -135,20 +135,13 @@ public class MaintenanceOrchestratorTests
     }
 
     [Fact]
-    public void DefaultStages_IncludesAllTenStages()
+    public void DefaultStages_NamesMatchMaintenanceStepEnumExactly()
     {
-        var names = MaintenanceOrchestrator.DefaultStages().Select(s => s.Name).ToList();
-        Assert.Equal(10, names.Count);
-        Assert.Contains("TtlExpiry", names);
-        Assert.Contains("ObservationRetention", names);
-        Assert.Contains("DedupSweep", names);
-        Assert.Contains("ImportanceDecay", names);
-        Assert.Contains("OrphanCleanup", names);
-        Assert.Contains("EnrichmentCleanup", names);
-        Assert.Contains("HeuristicEnrichmentBackfill", names);
-        Assert.Contains("OllamaEnrichment", names);
-        Assert.Contains("DriftReview", names);
-        Assert.Contains("Consolidation", names);
+        var stageNames = MaintenanceOrchestrator.DefaultStages().Select(s => s.Name).ToHashSet();
+        var enumNames = Enum.GetNames<MaintenanceStep>().ToHashSet();
+
+        Assert.Equal(10, stageNames.Count);
+        Assert.Equal(enumNames, stageNames);
     }
 
     [Fact]

--- a/tests/Eidet.Core.Tests/Maintenance/MaintenanceRepoActiveDerivationTests.cs
+++ b/tests/Eidet.Core.Tests/Maintenance/MaintenanceRepoActiveDerivationTests.cs
@@ -1,0 +1,164 @@
+using Eidet.Core.Domain;
+using Eidet.Core.Enrichment;
+using Eidet.Core.Maintenance;
+using Eidet.Core.Services;
+using Eidet.Core.Storage;
+using Eidet.Core.Tests.Services;
+
+namespace Eidet.Core.Tests.Maintenance;
+
+/// <summary>
+/// Issue #22's footgun fix: the orchestrator is the single derivation site for IsRepoActive.
+/// A null request value is derived from MemoryService.IsRepoActive; an explicit value overrides
+/// the derivation. The string RunAsync overload normalizes the repo path and still derives.
+///
+/// Activity is tracked in-process by MemoryService (RepoActivityTracker), populated only when a
+/// repo is touched THROUGH that same service instance — so "active" fixtures call svc.StoreAsync
+/// (which Tracks the normalized id), and "inactive" repos are simply never touched through svc.
+/// </summary>
+public class MaintenanceRepoActiveDerivationTests
+{
+    /// <summary>Captures the IsRepoActive the orchestrator built into the per-run context.</summary>
+    private sealed class CaptureStage : IMaintenanceStage
+    {
+        public string Name => "Capture";
+        public bool? Captured { get; private set; }
+
+        public Task<StageOutcome> ExecuteAsync(MaintenanceContext ctx, CancellationToken ct)
+        {
+            Captured = ctx.IsRepoActive;
+            return Task.FromResult(new StageOutcome(Name, 0));
+        }
+    }
+
+    private static MaintenanceOrchestrator OrchestratorWith(
+        IEidetStore store, MemoryService svc, params IMaintenanceStage[] stages) =>
+        new(store, svc, EnrichmentService.CreateNull(),
+            new ConsolidationEngine(store, enrichment: null, memory: svc), stages);
+
+    // ─── Derivation from MemoryService activity (request value null) ─────────
+
+    [Fact]
+    public async Task NullIsRepoActive_ActiveRepo_DerivesTrue()
+    {
+        var store = new InMemoryEidetStore();
+        var svc = new MemoryService(store);
+        // Touch the repo through svc → RepoActivityTracker records it as active.
+        await svc.StoreAsync("repo-a", "deployment uses argo cd via gitops", MemoryType.Insight);
+
+        var capture = new CaptureStage();
+        var orch = OrchestratorWith(store, svc, capture);
+        await orch.RunAsync(new MaintenanceRequest { RepoId = "repo-a", IsRepoActive = null });
+
+        Assert.True(capture.Captured);
+    }
+
+    [Fact]
+    public async Task NullIsRepoActive_InactiveRepo_DerivesFalse()
+    {
+        var store = new InMemoryEidetStore();
+        var svc = new MemoryService(store);
+        // Entry exists in the store but was inserted directly — svc never Tracked this repo.
+        await store.StoreAsync(new MemoryEntry
+        {
+            Id = "memories/repo-cold/insight/x",
+            RepoId = "repo-cold",
+            Type = MemoryType.Insight,
+            Content = "deployment uses argo cd via gitops",
+            CreatedAt = DateTime.UtcNow,
+            Validity = new Validity { ValidFrom = DateTime.UtcNow },
+            IsLatest = true,
+        });
+
+        var capture = new CaptureStage();
+        var orch = OrchestratorWith(store, svc, capture);
+        await orch.RunAsync(new MaintenanceRequest { RepoId = "repo-cold", IsRepoActive = null });
+
+        Assert.False(capture.Captured);
+    }
+
+    // ─── Explicit override honored (no derivation) ───────────────────────────
+
+    [Fact]
+    public async Task ExplicitTrue_InactiveRepo_OverridesDerivation()
+    {
+        var store = new InMemoryEidetStore();
+        var svc = new MemoryService(store); // repo never touched → would derive false
+        var capture = new CaptureStage();
+        var orch = OrchestratorWith(store, svc, capture);
+
+        await orch.RunAsync(new MaintenanceRequest { RepoId = "repo-cold", IsRepoActive = true });
+
+        Assert.True(capture.Captured);
+    }
+
+    // ─── String overload: normalizes path AND derives (not left default) ─────
+
+    [Fact]
+    public async Task RunAsyncStringOverload_NormalizesRepoIdAndDerivesActive()
+    {
+        const string path = @"C:\Projects\My_Repo\";
+        var normalized = RepoIdNormalizer.Normalize(path);
+
+        var store = new InMemoryEidetStore();
+        var svc = new MemoryService(store);
+        // Make the NORMALIZED repo active by storing through svc with the same path.
+        await svc.StoreAsync(path, "deployment uses argo cd via gitops", MemoryType.Insight);
+
+        var capture = new CaptureStage();
+        var orch = OrchestratorWith(store, svc, capture);
+        var report = await orch.RunAsync(path);
+
+        Assert.Equal(normalized, report.RepoId);
+        // Derived (not left null/default): an active repo yields true via the string path too.
+        Assert.True(capture.Captured);
+    }
+
+    [Fact]
+    public async Task RunAsyncStringOverload_InactiveRepo_DerivesFalse()
+    {
+        const string path = @"C:\Projects\Cold_Repo\";
+        var store = new InMemoryEidetStore();
+        var svc = new MemoryService(store); // never touched through svc
+        var capture = new CaptureStage();
+        var orch = OrchestratorWith(store, svc, capture);
+
+        var report = await orch.RunAsync(path);
+
+        Assert.Equal(RepoIdNormalizer.Normalize(path), report.RepoId);
+        Assert.False(capture.Captured); // derived, not a stray true
+    }
+
+    // ─── AffectedBy(MaintenanceStep) delegates to AffectedBy(string) ─────────
+
+    [Fact]
+    public async Task AffectedBy_EnumOverload_MatchesStringOverload()
+    {
+        var store = new InMemoryEidetStore();
+        var svc = new MemoryService(store);
+        // Past-due TTL entry so the real TtlExpiry stage reports a non-zero, comparable count.
+        var now = DateTime.UtcNow;
+        await store.StoreAsync(new MemoryEntry
+        {
+            Id = "memories/repo-a/insight/ttl",
+            RepoId = "repo-a",
+            Type = MemoryType.Insight,
+            Content = "deployment uses argo cd via gitops",
+            CreatedAt = now,
+            Validity = new Validity { ValidFrom = now },
+            ForgetAfter = now.AddDays(-1),
+            IsLatest = true,
+        });
+
+        var orch = new MaintenanceOrchestrator(store, svc);
+        var report = await orch.RunAsync(new MaintenanceRequest
+        {
+            RepoId = "repo-a",
+            IsRepoActive = true,
+            OnlyStages = new HashSet<MaintenanceStep> { MaintenanceStep.TtlExpiry },
+        });
+
+        Assert.Equal(1, report.AffectedBy(MaintenanceStep.TtlExpiry));
+        Assert.Equal(report.AffectedBy("TtlExpiry"), report.AffectedBy(MaintenanceStep.TtlExpiry));
+    }
+}

--- a/tests/Eidet.Core.Tests/Maintenance/MaintenanceStageIsolationTests.cs
+++ b/tests/Eidet.Core.Tests/Maintenance/MaintenanceStageIsolationTests.cs
@@ -1,0 +1,198 @@
+using Eidet.Core.Domain;
+using Eidet.Core.Maintenance;
+using Eidet.Core.Maintenance.Stages;
+using Eidet.Core.Services;
+using Eidet.Core.Tests.Services;
+
+namespace Eidet.Core.Tests.Maintenance;
+
+/// <summary>
+/// Per-stage isolation tests for issue #22's new seam: a single stage is driven directly via
+/// <see cref="MaintenanceContext.ForTest"/>, WITHOUT the orchestrator. These exercise the branch
+/// logic inside each stage that was previously only reachable end-to-end.
+///
+/// Fixtures are stored directly through <see cref="InMemoryEidetStore"/> (not svc.StoreAsync) so
+/// tests can set ForgetAfter / LastAccessedAt / Source, which the validated store path won't allow.
+/// All fixtures use RepoId "test-repo" (ForTest's default) and IsLatest+null ValidUntil so the
+/// stages' GetTopScoredAsync sweep picks them up.
+/// </summary>
+public class MaintenanceStageIsolationTests
+{
+    private const string Repo = "test-repo";
+
+    private static MemoryEntry Entry(string id, MemoryType type, DateTime createdAt) => new()
+    {
+        Id = $"memories/{Repo}/{type.ToString().ToLowerInvariant()}/{id}",
+        RepoId = Repo,
+        Type = type,
+        Content = $"content for {id}",
+        CreatedAt = createdAt,
+        Validity = new Validity { ValidFrom = createdAt },
+        IsLatest = true,
+        Importance = 0.6f,
+    };
+
+    /// <summary>Runs one stage inside a real bulk-write scope and returns its outcome.</summary>
+    private static async Task<StageOutcome> RunStageAsync(InMemoryEidetStore store, IMaintenanceStage stage)
+    {
+        var svc = new MemoryService(store);
+        return await svc.RunBulkAsync(async write =>
+        {
+            var ctx = MaintenanceContext.ForTest(store, write);
+            return await stage.ExecuteAsync(ctx, default);
+        });
+    }
+
+    // ─── ObservationRetentionStage: the grace-window branch ──────────────────
+    //
+    // An observation past the retention cutoff is only expired if its last touch is ALSO past the
+    // grace window (ObservationRetentionDays / 2). A recently-touched old observation is spared.
+
+    [Fact]
+    public async Task ObservationRetention_OldButTouchedWithinGraceWindow_NotExpired()
+    {
+        var now = DateTime.UtcNow;
+        var store = new InMemoryEidetStore();
+        // Created 200d ago (> 90d cutoff) but accessed 10d ago (< 45d grace window) → spared.
+        var obs = Entry("recently-touched", MemoryType.Observation, now.AddDays(-200));
+        obs.LastAccessedAt = now.AddDays(-10);
+        await store.StoreAsync(obs);
+
+        var outcome = await RunStageAsync(store, new ObservationRetentionStage());
+
+        Assert.Equal(0, outcome.Affected);
+        Assert.Null(obs.Validity.ValidUntil);
+        Assert.Null(obs.ForgetReason);
+    }
+
+    [Fact]
+    public async Task ObservationRetention_OldAndUntouchedPastGraceWindow_Expired()
+    {
+        var now = DateTime.UtcNow;
+        var store = new InMemoryEidetStore();
+        // Created 200d ago and last accessed 100d ago (> 45d grace window) → expired.
+        var obs = Entry("stale", MemoryType.Observation, now.AddDays(-200));
+        obs.LastAccessedAt = now.AddDays(-100);
+        await store.StoreAsync(obs);
+
+        var outcome = await RunStageAsync(store, new ObservationRetentionStage());
+
+        Assert.Equal(1, outcome.Affected);
+        Assert.NotNull(obs.Validity.ValidUntil);
+        Assert.Contains("Observation retention", obs.ForgetReason);
+    }
+
+    [Fact]
+    public async Task ObservationRetention_NullLastAccessed_FallsBackToCreatedAt_Expired()
+    {
+        var now = DateTime.UtcNow;
+        var store = new InMemoryEidetStore();
+        // Never accessed → grace window measured from CreatedAt (200d ago) → past it → expired.
+        var obs = Entry("never-touched", MemoryType.Observation, now.AddDays(-200));
+        await store.StoreAsync(obs);
+
+        var outcome = await RunStageAsync(store, new ObservationRetentionStage());
+
+        Assert.Equal(1, outcome.Affected);
+        Assert.NotNull(obs.Validity.ValidUntil);
+    }
+
+    // ─── OrphanCleanupStage: the two orphan predicates ───────────────────────
+
+    [Fact]
+    public async Task OrphanCleanup_EmptyContent_IsCleaned()
+    {
+        var store = new InMemoryEidetStore();
+        var empty = Entry("blank", MemoryType.Insight, DateTime.UtcNow);
+        empty.Content = "   "; // whitespace-only → IsNullOrWhiteSpace
+        await store.StoreAsync(empty);
+
+        var outcome = await RunStageAsync(store, new OrphanCleanupStage());
+
+        Assert.Equal(1, outcome.Affected);
+        Assert.NotNull(empty.Validity.ValidUntil);
+        Assert.Equal("Orphan cleanup", empty.ForgetReason);
+    }
+
+    [Fact]
+    public async Task OrphanCleanup_SystemLowImportanceAged_IsCleaned()
+    {
+        var now = DateTime.UtcNow;
+        var store = new InMemoryEidetStore();
+        // Source=="system" AND Importance<=0.1 AND age>30d → orphan.
+        var sys = Entry("sys", MemoryType.Insight, now.AddDays(-40));
+        sys.Source = "system";
+        sys.Importance = 0.05f;
+        await store.StoreAsync(sys);
+
+        var outcome = await RunStageAsync(store, new OrphanCleanupStage());
+
+        Assert.Equal(1, outcome.Affected);
+        Assert.NotNull(sys.Validity.ValidUntil);
+        Assert.Equal("Orphan cleanup", sys.ForgetReason);
+    }
+
+    [Fact]
+    public async Task OrphanCleanup_NormalEntry_IsUntouched()
+    {
+        var now = DateTime.UtcNow;
+        var store = new InMemoryEidetStore();
+        // Non-empty content; even though aged + low importance, Source is not "system".
+        var normal = Entry("keep", MemoryType.Insight, now.AddDays(-40));
+        normal.Importance = 0.05f;
+        await store.StoreAsync(normal);
+
+        var outcome = await RunStageAsync(store, new OrphanCleanupStage());
+
+        Assert.Equal(0, outcome.Affected);
+        Assert.Null(normal.Validity.ValidUntil);
+        Assert.Null(normal.ForgetReason);
+    }
+
+    // ─── TtlExpiryStage: ForgetAfter relative to Now ─────────────────────────
+
+    [Fact]
+    public async Task TtlExpiry_PastDueForgetAfter_Expired()
+    {
+        var now = DateTime.UtcNow;
+        var store = new InMemoryEidetStore();
+        var entry = Entry("expired", MemoryType.Insight, now.AddDays(-5));
+        entry.ForgetAfter = now.AddDays(-1); // <= Now
+        await store.StoreAsync(entry);
+
+        var outcome = await RunStageAsync(store, new TtlExpiryStage());
+
+        Assert.Equal(1, outcome.Affected);
+        Assert.NotNull(entry.Validity.ValidUntil);
+        Assert.Equal("TTL expired", entry.ForgetReason);
+    }
+
+    [Fact]
+    public async Task TtlExpiry_FutureForgetAfter_Untouched()
+    {
+        var now = DateTime.UtcNow;
+        var store = new InMemoryEidetStore();
+        var entry = Entry("keep", MemoryType.Insight, now.AddDays(-5));
+        entry.ForgetAfter = now.AddDays(30); // in the future
+        await store.StoreAsync(entry);
+
+        var outcome = await RunStageAsync(store, new TtlExpiryStage());
+
+        Assert.Equal(0, outcome.Affected);
+        Assert.Null(entry.Validity.ValidUntil);
+        Assert.Null(entry.ForgetReason);
+    }
+
+    [Fact]
+    public async Task TtlExpiry_NoForgetAfter_Untouched()
+    {
+        var store = new InMemoryEidetStore();
+        var entry = Entry("no-ttl", MemoryType.Insight, DateTime.UtcNow.AddDays(-5));
+        await store.StoreAsync(entry); // ForgetAfter stays null
+
+        var outcome = await RunStageAsync(store, new TtlExpiryStage());
+
+        Assert.Equal(0, outcome.Affected);
+        Assert.Null(entry.Validity.ValidUntil);
+    }
+}

--- a/tests/Eidet.Integration.Tests/Fixtures/EidetApiFixture.cs
+++ b/tests/Eidet.Integration.Tests/Fixtures/EidetApiFixture.cs
@@ -41,8 +41,8 @@ public class EidetApiFixture : IAsyncLifetime
             var memorySvc = new MemoryService(eidetStore, layerSvc);
             var intakeSvc = new IntakeService(eidetStore, memory: memorySvc);
             var consolidationEngine = new ConsolidationEngine(eidetStore, enrichment: null, memory: memorySvc);
-            IMaintenanceRunner maintenanceRunner = new MaintenanceRunner(
-                new MaintenanceOrchestrator(eidetStore, memorySvc, consolidation: consolidationEngine));
+            IMaintenanceRunner maintenanceRunner = new MaintenanceOrchestrator(
+                eidetStore, memorySvc, consolidation: consolidationEngine);
             var exportSvc = new ExportService(eidetStore, memory: memorySvc);
             var qualitySvc = new QualityService(eidetStore);
 

--- a/tests/Eidet.Service.Tests/Mcp/McpToolDefinitionsTests.cs
+++ b/tests/Eidet.Service.Tests/Mcp/McpToolDefinitionsTests.cs
@@ -126,7 +126,7 @@ public class McpToolDefinitionsTests
             new ContextToolHandler(svc),
             new LinkToolHandler(svc),
             new ConsolidateToolHandler(consolidation),
-            new MaintenanceToolHandler(maintenance, svc),
+            new MaintenanceToolHandler(maintenance),
             new EditToolHandler(svc),
             new IntakeToolHandler(intake),
             new PackExportToolHandler(null),
@@ -136,6 +136,9 @@ public class McpToolDefinitionsTests
 
     private sealed class StubMaintenanceRunner : IMaintenanceRunner
     {
+        public Task<MaintenanceReport> RunAsync(string repoPathOrId, CancellationToken ct = default) =>
+            Task.FromResult(new MaintenanceReport { RepoId = repoPathOrId });
+
         public Task<MaintenanceReport> RunAsync(MaintenanceRequest request, CancellationToken ct = default) =>
             Task.FromResult(new MaintenanceReport { RepoId = request.RepoId });
     }

--- a/tests/Eidet.Service.Tests/Tools/MaintenanceToolHandlerTests.cs
+++ b/tests/Eidet.Service.Tests/Tools/MaintenanceToolHandlerTests.cs
@@ -1,8 +1,5 @@
 using System.Text.Json;
-using Eidet.Core.Domain;
 using Eidet.Core.Maintenance;
-using Eidet.Core.Services;
-using Eidet.Core.Storage;
 using Eidet.Service.Tools;
 using Eidet.Service.Tools.Handlers;
 
@@ -14,8 +11,7 @@ public class MaintenanceToolHandlerTests
     public async Task Maintenance_RunsAndReturnsReport()
     {
         var runner = new RecordingRunner();
-        var svc = new MemoryService(new EmptyStore());
-        var handler = new MaintenanceToolHandler(runner, svc);
+        var handler = new MaintenanceToolHandler(runner);
 
         var result = await Invoke(handler, new { });
 
@@ -35,43 +31,17 @@ public class MaintenanceToolHandlerTests
     private sealed class RecordingRunner : IMaintenanceRunner
     {
         public int Calls;
+
+        public Task<MaintenanceReport> RunAsync(string repoPathOrId, CancellationToken ct = default)
+        {
+            Calls++;
+            return Task.FromResult(new MaintenanceReport { RepoId = repoPathOrId });
+        }
+
         public Task<MaintenanceReport> RunAsync(MaintenanceRequest request, CancellationToken ct = default)
         {
             Calls++;
             return Task.FromResult(new MaintenanceReport { RepoId = request.RepoId });
         }
-    }
-
-    private sealed class EmptyStore : IEidetStore
-    {
-        public Task<bool> TestConnectionAsync(CancellationToken ct = default) => Task.FromResult(true);
-        public Task<MemoryEntry?> GetAsync(string id, CancellationToken ct = default) => Task.FromResult<MemoryEntry?>(null);
-        public Task<string> StoreAsync(MemoryEntry entry, CancellationToken ct = default) => Task.FromResult(entry.Id);
-        public Task UpdateAsync(MemoryEntry entry, CancellationToken ct = default) => Task.CompletedTask;
-        public Task<bool> ForgetAsync(string id, CancellationToken ct = default) => Task.FromResult(false);
-        public Task<List<MemoryEntry>> FullTextSearchAsync(IReadOnlyList<string> repoIds, MemoryQuery query, CancellationToken ct = default) =>
-            Task.FromResult(new List<MemoryEntry>());
-        public Task<List<MemoryEntry>> VectorSearchAsync(IReadOnlyList<string> repoIds, MemoryQuery query, CancellationToken ct = default) =>
-            Task.FromResult(new List<MemoryEntry>());
-        public Task<MemoryEntry?> FindDuplicateAsync(string repoId, string content, float threshold, CancellationToken ct = default) =>
-            Task.FromResult<MemoryEntry?>(null);
-        public Task<Dictionary<MemoryType, int>> GetCountsByTypeAsync(string repoId, CancellationToken ct = default) =>
-            Task.FromResult(new Dictionary<MemoryType, int>());
-        public Task<List<MemoryEntry>> GetTopScoredAsync(string repoId, MemoryType[] types, int limit, CancellationToken ct = default) =>
-            Task.FromResult(new List<MemoryEntry>());
-        public Task<DatabaseInfo?> GetDatabaseInfoAsync(CancellationToken ct = default) => Task.FromResult<DatabaseInfo?>(null);
-        public Task EnsureIndexesAsync(CancellationToken ct = default) => Task.CompletedTask;
-        public Task<List<string>> GetDistinctRepoIdsAsync(CancellationToken ct = default) => Task.FromResult(new List<string>());
-        public Task<List<MemoryEntry>> BrowseAsync(string repoId, int skip, int take, MemoryType? type = null, CancellationToken ct = default) =>
-            Task.FromResult(new List<MemoryEntry>());
-        public Task<string> StoreMountedLayerAsync(MemoryLayer layer, CancellationToken ct = default) => Task.FromResult("");
-        public Task<bool> UnmountLayerAsync(string layerId, CancellationToken ct = default) => Task.FromResult(false);
-        public Task<List<MemoryLayer>> GetMountedLayersAsync(string repoId, CancellationToken ct = default) =>
-            Task.FromResult(new List<MemoryLayer>());
-        public Task<MemoryLayer?> GetLayerAsync(string layerId, CancellationToken ct = default) =>
-            Task.FromResult<MemoryLayer?>(null);
-        public Task<List<MemoryEntry>> GetByLayerIdAsync(string layerId, CancellationToken ct = default) =>
-            Task.FromResult(new List<MemoryEntry>());
-        public Task<bool> HardDeleteAsync(string id, CancellationToken ct = default) => Task.FromResult(false);
     }
 }


### PR DESCRIPTION
Implements RFC #22 — deepens the maintenance pipeline. Design hardened via `/design-interface`; shipped through the implement → test → review → verify pipeline.

## What changed

- **Collapse the double-facade.** Delete `IMaintenanceOrchestrator` (interface) and the byte-identical `MaintenanceRunner` pass-through; `MaintenanceOrchestrator` now implements `IMaintenanceRunner` directly. One entry interface.
- **Happy-path overload + footgun fix.** Add `RunAsync(string repoPathOrId)` that normalizes the repo and derives `IsRepoActive`. `MaintenanceRequest.IsRepoActive` becomes `bool?` (null ⇒ derive) with a **single** derivation site — fixes the latent CLI bug where inactive repos got active-repo importance decay.
- **Typed step selection.** `OnlyStages`/`SkipStages` are now `ISet<MaintenanceStep>?` (10 values ≡ the `StageName` consts). Selection compares by name so an unknown stage name can never throw mid-run. Adds `MaintenanceReport.AffectedBy(MaintenanceStep)` alongside the retained string overload.
- **Per-stage test seam.** `MaintenanceContext.ForTest(...)` lets a single stage be unit-tested without the orchestrator — the net-new value the refactor unlocks.

The 10 stages stay as separate `IMaintenanceStage` classes (the stage count was never the problem). The single-bulk-scope cache-coherence invariant is preserved unchanged.

## Tests

- `MaintenanceStageIsolationTests` — per-stage isolation via `ForTest` (ObservationRetention grace-window, OrphanCleanup rules, TtlExpiry).
- `MaintenanceRepoActiveDerivationTests` — null⇒derive (active/inactive), explicit override honored, `RunAsync(string)` normalize+derive, `AffectedBy(MaintenanceStep)` parity.
- `DefaultStages_NamesMatchMaintenanceStepEnumExactly` — enum ↔ stage-name sync, both directions.
- Existing tests migrated from `HashSet<string>` to `HashSet<MaintenanceStep>`.

Build clean (`dotnet build Eidet.slnx`, 0 warnings); Core suite **480/480**.

## Quality gates

- **Spec conformance:** 21/21 OK (independent verifier).
- **Code review:** 0 blocking. The two should-fix items raised were applied in this branch — hardened the selection filter (no `Enum.Parse` on stage names → total, can't throw mid-run) and documented the `ForTest` engine-scope caveat.

Closes #22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
