### PR TITLE
docs: sync friction/spec status with reality

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ Design decisions live in `docs/specs/`:
 | [ServiceSpec.md](docs/specs/ServiceSpec.md) | Daemon, MCP server, REST API, RavenDB (embedded/external), TUI, Docker, installation, CLI |
 | [SyncSpec.md](docs/specs/SyncSpec.md) | *(Future)* Remote sync, E2E encryption, team sharing |
 | [IntegrationSpec.md](docs/specs/IntegrationSpec.md) | Claude Code, Claude Desktop, Cursor, TerminalHost, Docker, CI/CD, client SDKs |
+| [PortalSpec.md](docs/specs/PortalSpec.md) | Per-repo Portal — generated, audited Web UI state view (`/api/eidet/portal`); live render, source-traceable claims |
 
 - Architecture deep dive: [docs/deep-dive.md](docs/deep-dive.md)
 - Phase-by-phase implementation history: [docs/phases.md](docs/phases.md)
@@ -107,6 +108,7 @@ Base: `http://localhost:19380`
 | GET  | `/api/eidet/search?repo=...&q=...` | Hybrid search (single-repo by default) |
 | GET  | `/api/eidet/browse?repo=...&type=...` | Paginated browse |
 | GET  | `/api/eidet/graph?repo=...` | Graph data (nodes + edges) |
+| GET  | `/api/eidet/portal?repo=...` | Per-repo Portal view (`augment=off` in v1) |
 | GET  | `/api/eidet/repos` | List repos (with original paths) |
 | GET  | `/api/eidet/usage?repo=...&days=30` | Usage stats |
 | GET  | `/api/eidet/usage/hourly?repo=...` | Hourly bucket counts |

--- a/architecture-friction.md
+++ b/architecture-friction.md
@@ -6,7 +6,7 @@
 
 ## TL;DR
 
-Strongest candidates: **#1 (Memory pipeline)** and **#3 (Hook plumbing)**.
+Strongest candidates: **#1 (Memory pipeline)** ✅ done (RFC #9) and **#3 (Hook plumbing)** → RFC [#19](https://github.com/stevehansen/eidet/issues/19) (open).
 Skip: **#6 (Intake)** — just refactored. **#7 (Enrichment)** — already correct ports & adapters shape.
 
 ---
@@ -73,7 +73,10 @@ The handler split is intentional (sharing between MCP and REST). Question is whe
 
 ---
 
-## 3. Hook event plumbing
+## 3. Hook event plumbing — 🔬 RFC FILED
+
+> Promoted to RFC [#19](https://github.com/stevehansen/eidet/issues/19) on 2026-06-01 (open):
+> collapse firing onto `MutationKind`, kill the duplicated runner predicate.
 
 **Files**
 - `src/Eidet.Core/Services/HookRunner.cs` (defines `HookEvent` enum + `IHookRunner` + `NullHookRunner` + `HookRunner`)
@@ -96,9 +99,10 @@ The handler split is intentional (sharing between MCP and REST). Question is whe
 
 ---
 
-## 4. Maintenance stages + orchestrator — ✅ DESIGNED
+## 4. Maintenance stages + orchestrator — ✅ DONE
 
-> Design hardened 2026-06-11 via `/design-interface` → RFC [#22](https://github.com/stevehansen/eidet/issues/22).
+> Shipped 2026-06-12 via RFC [#22](https://github.com/stevehansen/eidet/issues/22) → PR [#23](https://github.com/stevehansen/eidet/pull/23).
+> Design hardened 2026-06-11 via `/design-interface`.
 > Verdict: **stage count is not the problem.** Chosen hybrid — collapse the redundant `IMaintenanceRunner`/`IMaintenanceOrchestrator`
 > double-facade, add a `RunAsync(string repo)` happy-path overload that derives `IsRepoActive` (fixes a CLI footgun),
 > add a `MaintenanceContext.ForTest` seam so the 10 stages become unit-testable, and type `OnlyStages`/`SkipStages`
@@ -190,8 +194,8 @@ Minor possible nit: `OllamaTextSanitizer` is shared between `OllamaEnrichmentAda
 |---|---------|--------|------|---------------------|
 | 1 | Memory pipeline | High | Medium (touches hot read/write path) | ✅ DONE — RFC #9 / `25abde0` |
 | 2 | API/Tools three-tier | Medium-High | High (cross-cutting MCP+REST) | Yes (intentional split) |
-| 3 | Hook event plumbing | Medium | Low | No |
-| 4 | Maintenance stages | Medium | Low | Yes (composability tradeoff) |
+| 3 | Hook event plumbing | Medium | Low | 🔬 RFC #19 (open) |
+| 4 | Maintenance stages | Medium | Low | ✅ DONE — RFC #22 / PR #23 |
 | 5 | Gates | Low | Very low | No |
 | 6 | Intake | — | — | Just refactored, skip |
 | 7 | Enrichment | — | — | Already correct shape, skip |

--- a/docs/specs/IntegrationSpec.md
+++ b/docs/specs/IntegrationSpec.md
@@ -441,7 +441,9 @@ Keys stored in config as SHA256 hashes. Creating the first key auto-enables auth
 
 ---
 
-## Client SDK (Future)
+## Client SDK ✅ Shipped
+
+Implemented in `sdk/{typescript,python,dotnet}` and published to npm (`@eidet/sdk`), PyPI (`eidet-sdk`), and NuGet (`Eidet.Sdk`).
 
 For easier programmatic integration:
 

--- a/docs/specs/PortalSpec.md
+++ b/docs/specs/PortalSpec.md
@@ -2,7 +2,7 @@
 
 > **Scope**: This spec defines a generated, audited per-repo *state view* rendered in the Eidet Web UI — a single front door that describes a repo as its memories see it, with every claim traceable back to its source memory. It is a live view served by the existing service; it is **not** a file on disk.
 >
-> *Status: ✅ implemented — `Eidet.Core/Portal/*` (renderer + sections) + `Api/Endpoints/PortalEndpoint.cs` + Web UI hash route. No `eidet_portal` MCP tool (deferred by design, see below).*
+> *Status: ✅ implemented — `src/Eidet.Core/Portal/*` (renderer + sections) + `src/Eidet.Service/Api/Endpoints/PortalEndpoint.cs` + Web UI hash route. No `eidet_portal` MCP tool (deferred by design, see below).*
 
 ---
 

--- a/docs/specs/PortalSpec.md
+++ b/docs/specs/PortalSpec.md
@@ -2,7 +2,7 @@
 
 > **Scope**: This spec defines a generated, audited per-repo *state view* rendered in the Eidet Web UI — a single front door that describes a repo as its memories see it, with every claim traceable back to its source memory. It is a live view served by the existing service; it is **not** a file on disk.
 >
-> *Status: design decisions resolved; ready for implementation planning.*
+> *Status: ✅ implemented — `Eidet.Core/Portal/*` (renderer + sections) + `Api/Endpoints/PortalEndpoint.cs` + Web UI hash route. No `eidet_portal` MCP tool (deferred by design, see below).*
 
 ---
 


### PR DESCRIPTION
Sync stale status markers in design docs with reality (audit cross-referenced against GitHub issues + actual code).

## architecture-friction.md
- **#4 Maintenance stages**: `DESIGNED` -> `DONE` — RFC #22 shipped via PR #23 (merged).
- **#3 Hook plumbing**: was listed as an unconsidered top candidate; now tracked as RFC #19 (open). Updated TL;DR + summary table.

## docs/specs/
- **IntegrationSpec.md**: "Client SDK (Future)" -> shipped — sdk/typescript, sdk/python, sdk/dotnet, published to npm/PyPI/NuGet.
- **PortalSpec.md**: status "ready for implementation planning" -> implemented (Core/Portal renderer + sections, PortalEndpoint, Web UI route).

## CLAUDE.md
- The Portal feature was shipped but absent from the docs: added the PortalSpec.md row to the Specs table and GET /api/eidet/portal to the API reference.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
