### PR TITLE
refactor(mcp): slim agent-facing tool surface to 6 core tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ Design decisions live in `docs/specs/`:
 
 ## Current Capabilities
 
-- **16 MCP tools**: store, recall, context, forget, feedback, history, intake, link, consolidate, maintenance, export, pack_export, pack_import, edit (+ layer mgmt)
+- **6 MCP tools** (core session flow): context, recall, store, feedback, forget, link. Advanced operations (history, intake, consolidate, maintenance, edit, pack_export, pack_import) stay off the MCP surface — they run via the scheduler/maintenance pipeline and are reachable through the REST API, CLI, and Web UI. 13 tool handlers total, shared by REST + MCP via `ToolDispatcher`; MCP exposure is gated by `IToolHandler.McpExposed`.
 - **4 memory types**: Observation, Insight, Procedure, Heuristic — each with per-type retrieval budgets
 - **Storage**: RavenDB (embedded or external) with vector + full-text hybrid search on composite `SearchText` field
 - **Write gates**: `WriteValidator` chains rules (13 secret patterns + signal/low-signal + self-talk) — deterministic, local, always-on; single entry point from `MemoryService.StoreAsync` and `UpdateMemoryAsync`
@@ -30,7 +30,7 @@ Design decisions live in `docs/specs/`:
 - **Layers**: Local (rw) + Shared/Base (ro); auto-mount on pack import
 - **Interfaces**: MCP stdio, MCP HTTP, REST API, CLI, Web UI (`/ui`), SDKs (TS/Python/C#)
 - **Operations**: API key auth (4 scopes), hooks (6 lifecycle events), persistent scheduler (RavenDB Refresh), quality dashboard, backup/restore, usage analytics
-- **Curation**: Versioned `PUT` edits / MCP `eidet_edit`, AI-assisted enrichment via `/api/eidet/enrich`, Web UI inline editing
+- **Curation**: Versioned `PUT` / REST edits (handler available off-MCP), AI-assisted enrichment via `/api/eidet/enrich`, Web UI inline editing
 - **Pack format**: Human-readable markdown with YAML frontmatter — ScribeGate compatible
 - **Test coverage**: 646 tests (Core + Service + Integration)
 

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -5,7 +5,7 @@ nav_order: 5
 
 # MCP Tools Reference
 
-Eidet exposes 13 tools via the [Model Context Protocol](https://modelcontextprotocol.io/). These are the tools AI agents call directly.
+Eidet exposes 6 tools via the [Model Context Protocol](https://modelcontextprotocol.io/) — the core session-flow tools AI agents call directly. Advanced operations (intake, consolidation, maintenance, version history, curation, pack import/export) run server-side and are reached via the [REST API](#server-side-operations) and CLI, keeping the agent-facing surface small.
 
 ## Transports
 
@@ -91,26 +91,6 @@ Report whether a recalled memory was useful.
 - `was_used: true` — **Echo**: boosts importance and confidence
 - `was_used: false` — **Fizzle**: reduces importance and confidence
 
-### eidet_history
-
-View the version chain for a memory (current + all ancestors via supersession).
-
-```json
-{
-  "id": "memories/P--MyProject/insight/abc123"
-}
-```
-
-### eidet_intake
-
-Ingest project files (CLAUDE.md, README.md, .editorconfig, package config) as seed memories. Splits by headings, deduplicates by content hash, extracts entities.
-
-```json
-{
-  "repo": "P:\\MyProject"
-}
-```
-
 ### eidet_link
 
 Create a cross-repo link between two memories.
@@ -123,65 +103,19 @@ Create a cross-repo link between two memories.
 }
 ```
 
-### eidet_consolidate
+## Server-side operations
 
-Group related observations and create insights. Runs FadeMem decay on all memories.
+These are deliberately **not** on the MCP surface — agents rarely need them inline, and keeping them off the tool list reduces session overhead. They run automatically (scheduler/maintenance pipeline) or are invoked by an operator via the REST API, CLI, or Web UI:
 
-```json
-{
-  "repo": "P:\\MyProject"
-}
-```
-
-### eidet_maintenance
-
-Run the full 7-stage maintenance pipeline:
-
-1. TTL expiry
-2. Observation retention (default 90 days)
-3. Deduplication sweep (Jaccard similarity 0.85)
-4. Importance decay
-5. Orphan cleanup
-6. Backfill enrichment (entities + one-liners)
-7. Auto-consolidation
-
-```json
-{
-  "repo": "P:\\MyProject"
-}
-```
-
-### eidet_export
-
-Export all memories as formatted markdown.
-
-```json
-{
-  "repo": "P:\\MyProject"
-}
-```
-
-### eidet_pack_export
-
-Export memories as a portable `.eidet` pack file for sharing.
-
-```json
-{
-  "repo": "P:\\MyProject"
-}
-```
-
-### eidet_pack_import
-
-Import a `.eidet` pack and optionally mount it as a layer.
-
-```json
-{
-  "repo": "P:\\MyProject",
-  "data": "...",
-  "mount_as_layer": true
-}
-```
+| Operation | REST endpoint | Notes |
+|-----------|---------------|-------|
+| Intake | `POST /api/eidet/intake` | Also fires automatically on first `eidet_context` for a new repo |
+| Consolidate | `POST /api/eidet/consolidate` | Also runs as a maintenance stage |
+| Maintenance | `POST /api/maintenance` | TTL expiry, dedup, decay, enrichment, auto-consolidation |
+| Version history | `GET /api/eidet/{id}` (version chain) | Supersession ancestry |
+| Curation / edit | `PUT /api/eidet/{id}` | Versioned on content change |
+| Pack export | `POST` export endpoints | Portable `.eidet` pack |
+| Pack import | mount-as-layer endpoints | Import + mount a pack |
 
 ## Agent Integration Pattern
 

--- a/src/Eidet.Service/Commands/InstructionsCommand.cs
+++ b/src/Eidet.Service/Commands/InstructionsCommand.cs
@@ -127,26 +127,18 @@ public sealed class InstructionsCommand : AsyncCommand<InstructionsCommand.Setti
             - Call `eidet_feedback` with `used: false` (fizzle) when a recalled memory was irrelevant
             - This feedback tunes future recall scoring
 
-            ### Maintenance
-            - Call `eidet_consolidate` after storing several observations — it merges related ones into insights
+            ### Forgetting
             - Call `eidet_forget` to invalidate memories that are no longer true (with a reason)
 
             ### Available Tools
             | Tool | Purpose |
             |------|---------|
-            | `eidet_store` | Store a memory (observation/insight/procedure/heuristic) |
-            | `eidet_recall` | Search memories (hybrid vector + full-text) |
             | `eidet_context` | Get compact project context (~600 tokens) |
-            | `eidet_forget` | Soft-delete a memory with audit trail |
+            | `eidet_recall` | Search memories (hybrid vector + full-text) |
+            | `eidet_store` | Store a memory (observation/insight/procedure/heuristic) |
             | `eidet_feedback` | Echo (useful) or fizzle (irrelevant) a memory |
-            | `eidet_history` | View version chain for a memory |
-            | `eidet_intake` | Ingest project files as seed memories |
+            | `eidet_forget` | Soft-delete a memory with audit trail |
             | `eidet_link` | Create cross-repo or memory-to-memory links |
-            | `eidet_consolidate` | Merge observations into insights |
-            | `eidet_maintenance` | Run TTL expiry, dedup, decay, enrichment |
-            | `eidet_export` | Export memories as markdown |
-            | `eidet_pack_export` | Export shareable memory bundle |
-            | `eidet_pack_import` | Import memory bundle |
             """;
     }
 }

--- a/src/Eidet.Service/Mcp/McpServer.cs
+++ b/src/Eidet.Service/Mcp/McpServer.cs
@@ -11,6 +11,7 @@ public class McpServer
 {
     private readonly string _repoId;
     private readonly ToolDispatcher _dispatcher;
+    private readonly HashSet<string> _exposedTools;
     private readonly JsonRpcDispatcher _rpc;
     private readonly AutoIntakeOnContext? _autoIntake;
 
@@ -20,6 +21,7 @@ public class McpServer
     {
         _repoId = repoId;
         _dispatcher = ToolDispatcherFactory.Create(svc, intake, consolidation, maintenance, export, layers, usage);
+        _exposedTools = _dispatcher.Handlers.Where(h => h.McpExposed).Select(h => h.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
         _autoIntake = autoIntake ? new AutoIntakeOnContext(svc, intake, repoId) : null;
 
         _rpc = new JsonRpcDispatcher(new Dictionary<string, JsonRpcDispatcher.Handler>
@@ -106,7 +108,7 @@ public class McpServer
     {
         return JsonRpcResponse.Success(request.Id, new McpToolsListResult
         {
-            Tools = _dispatcher.Handlers.Select(h => h.Schema).ToList(),
+            Tools = _dispatcher.Handlers.Where(h => h.McpExposed).Select(h => h.Schema).ToList(),
         });
     }
 
@@ -126,6 +128,9 @@ public class McpServer
         {
             return JsonRpcResponse.ErrorResponse(request.Id, -32602, "Invalid params: expected name and arguments");
         }
+
+        if (!_exposedTools.Contains(toolName))
+            return JsonRpcResponse.ErrorResponse(request.Id, -32601, $"Unknown tool: {toolName}");
 
         if (_autoIntake is not null)
         {

--- a/src/Eidet.Service/Mcp/McpServer.cs
+++ b/src/Eidet.Service/Mcp/McpServer.cs
@@ -129,6 +129,9 @@ public class McpServer
             return JsonRpcResponse.ErrorResponse(request.Id, -32602, "Invalid params: expected name and arguments");
         }
 
+        if (string.IsNullOrEmpty(toolName))
+            return JsonRpcResponse.ErrorResponse(request.Id, -32602, "Invalid params: expected name and arguments");
+
         if (!_exposedTools.Contains(toolName))
             return JsonRpcResponse.ErrorResponse(request.Id, -32601, $"Unknown tool: {toolName}");
 

--- a/src/Eidet.Service/Tools/Handlers/ConsolidateToolHandler.cs
+++ b/src/Eidet.Service/Tools/Handlers/ConsolidateToolHandler.cs
@@ -17,6 +17,7 @@ public sealed class ConsolidateToolHandler : IToolHandler
 
     public string Name => "eidet_consolidate";
     public string UsageOp => "Consolidate";
+    public bool McpExposed => false;
 
     public McpToolDefinition Schema { get; } = new()
     {

--- a/src/Eidet.Service/Tools/Handlers/EditToolHandler.cs
+++ b/src/Eidet.Service/Tools/Handlers/EditToolHandler.cs
@@ -19,6 +19,7 @@ public sealed class EditToolHandler : IToolHandler
 
     public string Name => "eidet_edit";
     public string UsageOp => "Store";
+    public bool McpExposed => false;
 
     public McpToolDefinition Schema { get; } = new()
     {

--- a/src/Eidet.Service/Tools/Handlers/HistoryToolHandler.cs
+++ b/src/Eidet.Service/Tools/Handlers/HistoryToolHandler.cs
@@ -15,6 +15,7 @@ public sealed class HistoryToolHandler : IToolHandler
 
     public string Name => "eidet_history";
     public string UsageOp => "History";
+    public bool McpExposed => false;
 
     public McpToolDefinition Schema { get; } = new()
     {

--- a/src/Eidet.Service/Tools/Handlers/IntakeToolHandler.cs
+++ b/src/Eidet.Service/Tools/Handlers/IntakeToolHandler.cs
@@ -17,6 +17,7 @@ public sealed class IntakeToolHandler : IToolHandler
 
     public string Name => "eidet_intake";
     public string UsageOp => "Intake";
+    public bool McpExposed => false;
 
     public McpToolDefinition Schema { get; } = new()
     {

--- a/src/Eidet.Service/Tools/Handlers/MaintenanceToolHandler.cs
+++ b/src/Eidet.Service/Tools/Handlers/MaintenanceToolHandler.cs
@@ -19,6 +19,7 @@ public sealed class MaintenanceToolHandler : IToolHandler
 
     public string Name => "eidet_maintenance";
     public string UsageOp => "Maintenance";
+    public bool McpExposed => false;
 
     public McpToolDefinition Schema { get; } = new()
     {

--- a/src/Eidet.Service/Tools/Handlers/PackExportToolHandler.cs
+++ b/src/Eidet.Service/Tools/Handlers/PackExportToolHandler.cs
@@ -17,6 +17,7 @@ public sealed class PackExportToolHandler : IToolHandler
 
     public string Name => "eidet_pack_export";
     public string UsageOp => "PackExport";
+    public bool McpExposed => false;
 
     public McpToolDefinition Schema { get; } = new()
     {

--- a/src/Eidet.Service/Tools/Handlers/PackImportToolHandler.cs
+++ b/src/Eidet.Service/Tools/Handlers/PackImportToolHandler.cs
@@ -21,6 +21,7 @@ public sealed class PackImportToolHandler : IToolHandler
 
     public string Name => "eidet_pack_import";
     public string UsageOp => "PackImport";
+    public bool McpExposed => false;
 
     public McpToolDefinition Schema { get; } = new()
     {

--- a/src/Eidet.Service/Tools/IToolHandler.cs
+++ b/src/Eidet.Service/Tools/IToolHandler.cs
@@ -15,6 +15,14 @@ public interface IToolHandler
     /// <summary>The UsageTracker operation label (e.g., <c>Store</c>).</summary>
     string UsageOp { get; }
 
+    /// <summary>
+    /// Whether this tool is advertised on the MCP surface (<c>tools/list</c>) and callable over MCP.
+    /// Defaults to <c>true</c>. Advanced/maintenance tools opt out so the agent-facing surface stays
+    /// to the core session flow; they remain available via the REST API and CLI, which use the full
+    /// dispatcher regardless of this flag.
+    /// </summary>
+    bool McpExposed => true;
+
     /// <summary>MCP tool definition co-located with the handler. Used by tools/list.</summary>
     McpToolDefinition Schema { get; }
 

--- a/tests/Eidet.Service.Tests/Commands/InstructionsCommandTests.cs
+++ b/tests/Eidet.Service.Tests/Commands/InstructionsCommandTests.cs
@@ -12,22 +12,29 @@ public class InstructionsCommandTests
     }
 
     [Fact]
-    public void GenerateInstructions_ContainsAllTools()
+    public void GenerateInstructions_ContainsCoreTools()
     {
         var instructions = InstructionsCommand.GenerateInstructions();
-        Assert.Contains("eidet_store", instructions);
-        Assert.Contains("eidet_recall", instructions);
         Assert.Contains("eidet_context", instructions);
-        Assert.Contains("eidet_forget", instructions);
+        Assert.Contains("eidet_recall", instructions);
+        Assert.Contains("eidet_store", instructions);
         Assert.Contains("eidet_feedback", instructions);
-        Assert.Contains("eidet_history", instructions);
-        Assert.Contains("eidet_intake", instructions);
+        Assert.Contains("eidet_forget", instructions);
         Assert.Contains("eidet_link", instructions);
-        Assert.Contains("eidet_consolidate", instructions);
-        Assert.Contains("eidet_maintenance", instructions);
-        Assert.Contains("eidet_export", instructions);
-        Assert.Contains("eidet_pack_export", instructions);
-        Assert.Contains("eidet_pack_import", instructions);
+    }
+
+    [Theory]
+    [InlineData("eidet_history")]
+    [InlineData("eidet_intake")]
+    [InlineData("eidet_consolidate")]
+    [InlineData("eidet_maintenance")]
+    [InlineData("eidet_edit")]
+    [InlineData("eidet_pack_export")]
+    [InlineData("eidet_pack_import")]
+    public void GenerateInstructions_OmitsAdvancedTools(string toolName)
+    {
+        var instructions = InstructionsCommand.GenerateInstructions();
+        Assert.DoesNotContain(toolName, instructions);
     }
 
     [Fact]

--- a/tests/Eidet.Service.Tests/Mcp/McpToolDefinitionsTests.cs
+++ b/tests/Eidet.Service.Tests/Mcp/McpToolDefinitionsTests.cs
@@ -9,17 +9,51 @@ using Eidet.Service.Tools.Handlers;
 namespace Eidet.Service.Tests.Mcp;
 
 /// <summary>
-/// Asserts the schema surface exposed by <c>tools/list</c>: tool count, naming convention,
-/// schema shape, and required fields. Source of truth is each handler's <c>Schema</c> property.
+/// Asserts the schema surface exposed by <c>tools/list</c>: which tools are advertised, tool count,
+/// naming convention, schema shape, and required fields. Source of truth is each handler's
+/// <c>Schema</c> and <c>McpExposed</c> properties.
 /// </summary>
 public class McpToolDefinitionsTests
 {
     private static readonly List<McpToolDefinition> Tools = AllHandlers().Select(h => h.Schema).ToList();
+    private static readonly List<McpToolDefinition> Exposed =
+        AllHandlers().Where(h => h.McpExposed).Select(h => h.Schema).ToList();
 
     [Fact]
-    public void All_Returns13Tools()
+    public void All_Registers13Handlers()
     {
         Assert.Equal(13, Tools.Count);
+    }
+
+    [Fact]
+    public void Exposed_Returns6Tools()
+    {
+        Assert.Equal(6, Exposed.Count);
+    }
+
+    [Theory]
+    [InlineData("eidet_store")]
+    [InlineData("eidet_recall")]
+    [InlineData("eidet_context")]
+    [InlineData("eidet_forget")]
+    [InlineData("eidet_feedback")]
+    [InlineData("eidet_link")]
+    public void Exposed_ContainsCoreTool(string toolName)
+    {
+        Assert.Contains(Exposed, t => t.Name == toolName);
+    }
+
+    [Theory]
+    [InlineData("eidet_history")]
+    [InlineData("eidet_intake")]
+    [InlineData("eidet_consolidate")]
+    [InlineData("eidet_maintenance")]
+    [InlineData("eidet_edit")]
+    [InlineData("eidet_pack_export")]
+    [InlineData("eidet_pack_import")]
+    public void Exposed_ExcludesAdvancedTool(string toolName)
+    {
+        Assert.DoesNotContain(Exposed, t => t.Name == toolName);
     }
 
     [Fact]


### PR DESCRIPTION
## Why

The advanced MCP tools (`history`, `intake`, `consolidate`, `maintenance`, `edit`, `pack_export`, `pack_import`) complicated the agent-facing tool list and bloated the Eidet instructions injected into every session's CLAUDE.md. The core session-flow tools provide enough for normal agent usage.

## What

Hide the advanced tools from MCP while keeping them **fully functional** via REST/CLI/Web UI and the scheduler — nothing is deleted.

- **`IToolHandler.McpExposed`** — default-implemented `=> true`; the 7 advanced handlers override `=> false`. `McpServer` filters `tools/list` and rejects `tools/call` for non-exposed tools. The shared `ToolDispatcher` still registers all 13 handlers, so REST keeps every operation.
- **MCP surface is now 6 tools** — the session flow (`context`, `recall`, `store`, `feedback`, `forget`) + `link`.
- **Docs/footprint trimmed** — `InstructionsCommand` table, `docs/mcp-tools.md` (advanced ops moved to a "Server-side operations" section), and the `CLAUDE.md` capability line.
- **Removed `eidet_export`** from docs/instructions — it was documented but never existed as a handler (pre-existing doc/code drift).

## Notes

- This also drops `maintenance` and `edit` from MCP (not in the session flow). Easy to re-expose any tool by flipping its `McpExposed` override.
- Installed `~/.claude/CLAUDE.md` files refresh via `eidet instructions --install` (marker-based replace).

## Tests

All 191 `Eidet.Service.Tests` pass. `McpToolDefinitionsTests` now asserts MCP exposes exactly 6 (13 handlers still registered); `InstructionsCommandTests` asserts advanced tools are omitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)