### PR TITLE
feat(loose-ends): park/resolve open-work (eidet_park / eidet_resolve)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ Design decisions live in `docs/specs/`:
 
 ## Current Capabilities
 
-- **6 MCP tools** (core session flow): context, recall, store, feedback, forget, link. Advanced operations (history, intake, consolidate, maintenance, edit, pack_export, pack_import) stay off the MCP surface — they run via the scheduler/maintenance pipeline and are reachable through the REST API, CLI, and Web UI. 13 tool handlers total, shared by REST + MCP via `ToolDispatcher`; MCP exposure is gated by `IToolHandler.McpExposed`.
+- **8 MCP tools**: 6 core session flow (context, recall, store, feedback, forget, link) + park/resolve (Loose Ends). Advanced operations (history, intake, consolidate, maintenance, edit, pack_export, pack_import) stay off the MCP surface — they run via the scheduler/maintenance pipeline and are reachable through the REST API, CLI, and Web UI. 15 tool handlers total, shared by REST + MCP via `ToolDispatcher`; MCP exposure is gated by `IToolHandler.McpExposed`.
 - **4 memory types**: Observation, Insight, Procedure, Heuristic — each with per-type retrieval budgets
 - **Storage**: RavenDB (embedded or external) with vector + full-text hybrid search on composite `SearchText` field
 - **Write gates**: `WriteValidator` chains rules (13 secret patterns + signal/low-signal + self-talk) — deterministic, local, always-on; single entry point from `MemoryService.StoreAsync` and `UpdateMemoryAsync`

--- a/docs/specs/LooseEndSpec.md
+++ b/docs/specs/LooseEndSpec.md
@@ -148,7 +148,7 @@ Park is deliberately low-friction, but **secret scanning is non-negotiable** (it
 Injected into `GetContextAsync` between L0 (`:417`) and L1 (`:423`):
 - Reserved sub-budget of **~120 tokens carved from the L1 budget** (never from L0/identity). If there are no open Loose Ends, L1 gets the full budget.
 - **Cap 3 items** in v1; rendered with a distinct `[~]` prefix so the agent reads them as open work, not facts.
-- **Ordering: `Priority` desc, then `CreatedAt` asc** (oldest-first within a priority tier) — surfaces the *stalest* high-priority work, which is the backlog-hygiene signal.
+- **Ordering: `Priority` ascending (1 = high, so high-priority sorts first), then `CreatedAt` asc** (oldest-first within a priority tier) — surfaces the *stalest* high-priority work, which is the backlog-hygiene signal.
 - L0 count header gains an addendum: `[Memory: … | 3 open loose ends]`.
 
 ### 2. Recall ride-along
@@ -281,7 +281,7 @@ Tests:
 
 | Phase | Scope |
 |-------|-------|
-| **v1 (MVP)** | `LooseEnd` domain + `ILooseEndStore` (Raven + in-memory) + `IPromotionPort` (mint-a-memory adapter) + `TimeProvider`. `eidet_park` / `eidet_resolve` (kind required). Wake-up slice (cap 3, ~120 tok, `[~]`, Priority desc → oldest). Recall ride-along on by default. Pull list via REST/UI. Promote-to-memory. |
+| **v1 (MVP)** | `LooseEnd` domain + `ILooseEndStore` (Raven + in-memory) + `IPromotionPort` (mint-a-memory adapter) + `TimeProvider`. `eidet_park` / `eidet_resolve` (kind required). Wake-up slice (cap 3, ~120 tok, `[~]`, high-priority → oldest). Recall ride-along on by default. Pull list via REST/UI. Promote-to-memory. |
 | **v1.1** | `GitHubIssuePromotionAdapter` (resolve-as-Promoted with an external ref links an issue instead of minting). Quality-dashboard **open count + aging** (the rot mitigation). Web UI Loose Ends panel. |
 | **v2** | Only on demonstrated demand: per-tag/area split (`Areas`), priority auto-bump for aging items, batch resolve. Reminders remain out of scope unless a per-item scheduler primitive is introduced separately. |
 
@@ -296,7 +296,7 @@ Tests:
 | 3 | **`kind` is required** on `eidet_resolve`; the C# convenience overload may default to `Done`. |
 | 4 | **Single `Tags` list** in v1 (no separate `Areas` axis); ride-along matches tag overlap. |
 | 5 | **Park = secret-scan only**, signal gate skipped; **promote = full gate** via `IPromotionPort`. No `ParkValidator` chain (one rule). |
-| 6 | **Wake-up slice**: cap 3 / ~120 tokens (carved from L1, never L0); ordered `Priority` desc then `CreatedAt` asc; `[~]` prefix; L0 count addendum. |
+| 6 | **Wake-up slice**: cap 3 / ~120 tokens (carved from L1, never L0); ordered `Priority` ascending (1 = high first) then `CreatedAt` asc; `[~]` prefix; L0 count addendum. |
 | 7 | **Recall ride-along on by default**, in a separated, capped result section. |
 | 8 | **One-call promote**; resolve mints the `MemoryEntry` (gated) and records `PromotedToMemoryId`, or links an `ExternalRef`. |
 | 9 | **Idempotent resolve** (re-resolve = no-op). Resolved Loose Ends are kept as audit, filtered from open views. |

--- a/src/Eidet.Core/LooseEnds/ILooseEndStore.cs
+++ b/src/Eidet.Core/LooseEnds/ILooseEndStore.cs
@@ -1,0 +1,17 @@
+namespace Eidet.Core.LooseEnds;
+
+/// <summary>
+/// Storage port for Loose Ends — a separate collection from <c>memories/*</c> so no maintenance
+/// stage ever enumerates open work. Raven adapter in prod, in-memory fake in tests.
+/// </summary>
+public interface ILooseEndStore
+{
+    Task<string> StoreAsync(LooseEnd e, CancellationToken ct = default);
+    Task<LooseEnd?> GetAsync(string id, CancellationToken ct = default);
+    Task UpdateAsync(LooseEnd e, CancellationToken ct = default);
+    Task<IReadOnlyList<LooseEnd>> ListOpenAsync(string repoId, int max, CancellationToken ct = default);
+    Task<IReadOnlyList<LooseEnd>> FindOpenByTagsAsync(string repoId, IReadOnlyList<string> tags, int max, CancellationToken ct = default);
+
+    /// <summary>Count of open Loose Ends for a repo — bounded server-side, never materializes the set.</summary>
+    Task<int> CountOpenAsync(string repoId, CancellationToken ct = default);
+}

--- a/src/Eidet.Core/LooseEnds/IPromotionPort.cs
+++ b/src/Eidet.Core/LooseEnds/IPromotionPort.cs
@@ -1,0 +1,19 @@
+using Eidet.Core.Domain;
+
+namespace Eidet.Core.LooseEnds;
+
+/// <summary>
+/// The ONLY edge from a Loose End into the gated memory write path. Promoting a confirmed Loose
+/// End either mints a <c>MemoryEntry</c> through the full secret+signal gate, or links an external
+/// issue without minting. Keeping this behind a port is the guardrail that stops a future caller
+/// from routing park through the gated builder (which would start rejecting the terse notes the
+/// feature exists to keep).
+/// </summary>
+public interface IPromotionPort
+{
+    Task<PromotionResult> PromoteAsync(LooseEnd e, PromoteOptions opts, CancellationToken ct = default);
+}
+
+public sealed record PromoteOptions(MemoryType Type, float Importance, string? ExternalRef);
+
+public sealed record PromotionResult(bool Success, string? MemoryId, string? ExternalRef, string? Reason);

--- a/src/Eidet.Core/LooseEnds/LooseEnd.cs
+++ b/src/Eidet.Core/LooseEnds/LooseEnd.cs
@@ -1,0 +1,30 @@
+namespace Eidet.Core.LooseEnds;
+
+public enum LooseEndState { Open, Resolved }
+public enum ResolutionKind { Done, Dropped, Promoted, Superseded }
+
+/// <summary>
+/// Open work an agent parked mid-task. A sibling of MemoryEntry, NOT a MemoryType.
+/// ID: "looseends/{repoId}/{shortHash}". Lives in its own RavenDB collection so no
+/// maintenance stage (FadeMem / consolidation / dedup / retention / TTL) ever touches it.
+/// </summary>
+public sealed class LooseEnd
+{
+    public string Id { get; set; } = "";
+    public string RepoId { get; set; } = "";            // Local layer only; no LayerId
+
+    public string Note { get; set; } = "";              // terse, speculative; secret-scanned, NOT signal-gated
+    public List<string> Tags { get; set; } = [];        // ride-along match keys (v1: one list, no separate "Areas")
+    public int Priority { get; set; } = 2;              // 1 high / 2 normal / 3 low — wake-up ordering only; never decays
+
+    public LooseEndState State { get; set; } = LooseEndState.Open;
+    public ResolutionKind? Resolution { get; set; }
+    public string? ResolutionNote { get; set; }
+    public string? PromotedToMemoryId { get; set; }     // set when Resolution == Promoted mints a MemoryEntry
+    public string? ExternalRef { get; set; }            // e.g. "gh#412" when promoted to an issue instead of a memory
+
+    public string Source { get; set; } = "claude-session";
+    public string? SourceSessionId { get; set; }
+    public DateTimeOffset CreatedAt { get; set; }
+    public DateTimeOffset? ResolvedAt { get; set; }
+}

--- a/src/Eidet.Core/LooseEnds/LooseEndIdGenerator.cs
+++ b/src/Eidet.Core/LooseEnds/LooseEndIdGenerator.cs
@@ -1,0 +1,19 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Eidet.Core.LooseEnds;
+
+/// <summary>
+/// Deterministic Loose End document IDs: "looseends/{repoId}/{shortHash}".
+/// shortHash = first 12 chars of SHA256(note + createdAt). No type segment — one kind.
+/// </summary>
+public static class LooseEndIdGenerator
+{
+    public static string Generate(string repoId, string note, DateTimeOffset createdAt)
+    {
+        var input = note + createdAt.ToString("O");
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(input));
+        var shortHash = Convert.ToHexString(hash)[..12].ToLowerInvariant();
+        return $"looseends/{repoId}/{shortHash}";
+    }
+}

--- a/src/Eidet.Core/LooseEnds/LooseEndService.cs
+++ b/src/Eidet.Core/LooseEnds/LooseEndService.cs
@@ -1,0 +1,193 @@
+using System.Text;
+using Eidet.Core.Domain;
+using Eidet.Core.Gates;
+using Eidet.Core.Memory;
+
+namespace Eidet.Core.LooseEnds;
+
+/// <summary>
+/// The deep facade over the three Loose End seams (<see cref="ILooseEndStore"/>,
+/// <see cref="IPromotionPort"/>, <see cref="TimeProvider"/>). Owns park (secret-scan only, signal
+/// gate skipped), idempotent resolve, the one-call promote bridge, and the deterministic wake-up
+/// slice + recall ride-along + pull surfaces. The promote path is the only one that re-enters the
+/// gated memory write funnel, and it does so exclusively through <see cref="IPromotionPort"/>.
+/// </summary>
+public sealed class LooseEndService
+{
+    // Wake-up slice render policy (v1): hard item cap and the distinct open-work prefix.
+    private const int WakeupItemCap = 3;
+    private const string WakeupPrefix = "[~] ";
+
+    private readonly ILooseEndStore _store;
+    private readonly IPromotionPort _promote;
+    private readonly TimeProvider _clock;
+
+    public LooseEndService(ILooseEndStore store, IPromotionPort promote, TimeProvider clock)
+    {
+        _store = store;
+        _promote = promote;
+        _clock = clock;
+    }
+
+    // ─── Park ─────────────────────────────────────────────────────────
+
+    /// <summary>80% surface — drop a terse note in one call.</summary>
+    public Task<ParkResult> ParkAsync(string repoId, string note, CancellationToken ct = default) =>
+        ParkAsync(new ParkOptions(repoId, note), ct);
+
+    /// <summary>20% surface — tags, priority, alternate source.</summary>
+    public async Task<ParkResult> ParkAsync(ParkOptions opts, CancellationToken ct = default)
+    {
+        // Park bypasses the signal gate by design (terse, speculative notes are the point) but
+        // secret scanning is always-on for every write surface in Eidet.
+        var secret = SecretScanRule.Check(opts.Note);
+        if (!secret.Passed)
+            return ParkResult.Rejected(secret.Reason ?? "rejected");
+
+        var repoId = RepoIdNormalizer.Normalize(opts.RepoId);
+        var now = _clock.GetUtcNow();
+        var end = new LooseEnd
+        {
+            Id = LooseEndIdGenerator.Generate(repoId, opts.Note, now),
+            RepoId = repoId,
+            Note = opts.Note,
+            Tags = opts.Tags?.ToList() ?? [],
+            Priority = opts.Priority,
+            Source = opts.Source,
+            CreatedAt = now,
+        };
+
+        var id = await _store.StoreAsync(end, ct);
+        return ParkResult.Parked(id);
+    }
+
+    // ─── Resolve ──────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Close a Loose End with a typed resolution kind. Idempotent: re-resolving an already-resolved
+    /// end is a no-op that returns its current state (it never re-mints on a second promote).
+    /// </summary>
+    public async Task<ResolveResult> ResolveAsync(
+        string id, ResolutionKind kind, ResolveOptions? o = null, CancellationToken ct = default)
+    {
+        var end = await _store.GetAsync(id, ct);
+        if (end is null)
+            return ResolveResult.NotFound(id);
+
+        if (end.State == LooseEndState.Resolved)
+            return ResolveResult.From(end); // idempotent no-op
+
+        var opts = o ?? new ResolveOptions();
+
+        if (kind == ResolutionKind.Promoted)
+        {
+            var promotion = await _promote.PromoteAsync(
+                end, new PromoteOptions(opts.PromoteType, opts.PromoteImportance, opts.ExternalRef), ct);
+            if (!promotion.Success)
+                return ResolveResult.Rejected(id, promotion.Reason ?? "promotion rejected");
+
+            end.PromotedToMemoryId = promotion.MemoryId;
+            end.ExternalRef = promotion.ExternalRef;
+        }
+
+        end.State = LooseEndState.Resolved;
+        end.Resolution = kind;
+        end.ResolutionNote = opts.Note;
+        end.ResolvedAt = _clock.GetUtcNow();
+        await _store.UpdateAsync(end, ct);
+
+        return ResolveResult.From(end);
+    }
+
+    // ─── Surfacing ──────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Pure, deterministic render of the open-work wake-up slice: cap 3, ordered by Priority
+    /// (1=high first) then CreatedAt asc (stalest high-priority first), each line prefixed <c>[~] </c>, never spending
+    /// more than <paramref name="maxTokens"/>. Returns "" when there are no open Loose Ends.
+    /// </summary>
+    public async Task<string> RenderWakeupSliceAsync(string repoId, int maxTokens, CancellationToken ct = default)
+    {
+        if (maxTokens <= 0) return "";
+
+        var normalized = RepoIdNormalizer.Normalize(repoId);
+        var open = await _store.ListOpenAsync(normalized, WakeupItemCap, ct);
+        return RenderSlice(open, maxTokens);
+    }
+
+    /// <summary>Open Loose Ends whose tags overlap the recall query — the recall ride-along surface.</summary>
+    public Task<IReadOnlyList<LooseEnd>> RideAlongAsync(
+        string repoId, IReadOnlyList<string> recallTags, CancellationToken ct = default)
+    {
+        if (recallTags.Count == 0)
+            return Task.FromResult<IReadOnlyList<LooseEnd>>([]);
+        return _store.FindOpenByTagsAsync(RepoIdNormalizer.Normalize(repoId), recallTags, WakeupItemCap, ct);
+    }
+
+    /// <summary>Explicit open-work pull list (human REST/UI surface).</summary>
+    public Task<IReadOnlyList<LooseEnd>> PullAsync(string repoId, int max = 20, CancellationToken ct = default) =>
+        _store.ListOpenAsync(RepoIdNormalizer.Normalize(repoId), max, ct);
+
+    /// <summary>Open-work count for the wake-up L0 addendum — avoids materializing the open set.</summary>
+    public Task<int> CountOpenAsync(string repoId, CancellationToken ct = default) =>
+        _store.CountOpenAsync(RepoIdNormalizer.Normalize(repoId), ct);
+
+    private static string RenderSlice(IReadOnlyList<LooseEnd> open, int maxTokens)
+    {
+        if (open.Count == 0) return "";
+
+        var ordered = open
+            .OrderBy(e => e.Priority)
+            .ThenBy(e => e.CreatedAt)
+            .Take(WakeupItemCap);
+
+        var sb = new StringBuilder();
+        var remaining = maxTokens;
+        foreach (var end in ordered)
+        {
+            var line = WakeupPrefix + end.Note;
+            var lineTokens = RecallScoring.EstimateTokens(line.Length);
+            if (lineTokens > remaining) break;
+            sb.AppendLine(line);
+            remaining -= lineTokens;
+        }
+        return sb.ToString();
+    }
+}
+
+/// <summary>20% surface for <see cref="LooseEndService.ParkAsync(ParkOptions, CancellationToken)"/>.</summary>
+public sealed record ParkOptions(string RepoId, string Note)
+{
+    public IReadOnlyList<string>? Tags { get; init; }
+    public int Priority { get; init; } = 2;
+    public string Source { get; init; } = "claude-session";
+}
+
+/// <summary>Options for <see cref="LooseEndService.ResolveAsync"/>. Promote fields honored only when kind == Promoted.</summary>
+public sealed record ResolveOptions
+{
+    public string? Note { get; init; }
+    public MemoryType PromoteType { get; init; } = MemoryType.Insight;
+    public float PromoteImportance { get; init; } = 0.5f;
+    public string? ExternalRef { get; init; }
+}
+
+/// <summary>Outcome of a park attempt: the parked id, or the rejection reason.</summary>
+public sealed record ParkResult(bool Success, string? Id, string? Reason)
+{
+    public static ParkResult Parked(string id) => new(true, id, null);
+    public static ParkResult Rejected(string reason) => new(false, null, reason);
+}
+
+/// <summary>Outcome of a resolve: the closed state, plus the minted memory id when promoted.</summary>
+public sealed record ResolveResult(
+    bool Success, string Id, LooseEndState State,
+    ResolutionKind? Kind = null, string? PromotedToMemoryId = null, string? Reason = null)
+{
+    public static ResolveResult From(LooseEnd e) =>
+        new(true, e.Id, e.State, e.Resolution, e.PromotedToMemoryId);
+    public static ResolveResult NotFound(string id) =>
+        new(false, id, LooseEndState.Open, Reason: "not found");
+    public static ResolveResult Rejected(string id, string reason) =>
+        new(false, id, LooseEndState.Open, Reason: reason);
+}

--- a/src/Eidet.Core/LooseEnds/LooseEndService.cs
+++ b/src/Eidet.Core/LooseEnds/LooseEndService.cs
@@ -132,18 +132,15 @@ public sealed class LooseEndService
     public Task<int> CountOpenAsync(string repoId, CancellationToken ct = default) =>
         _store.CountOpenAsync(RepoIdNormalizer.Normalize(repoId), ct);
 
+    // `open` arrives already ordered (Priority→CreatedAt) and capped at WakeupItemCap by the store —
+    // ordering is owned there so it stays in one place; this is pure token-budgeted rendering.
     private static string RenderSlice(IReadOnlyList<LooseEnd> open, int maxTokens)
     {
         if (open.Count == 0) return "";
 
-        var ordered = open
-            .OrderBy(e => e.Priority)
-            .ThenBy(e => e.CreatedAt)
-            .Take(WakeupItemCap);
-
         var sb = new StringBuilder();
         var remaining = maxTokens;
-        foreach (var end in ordered)
+        foreach (var end in open)
         {
             var line = WakeupPrefix + end.Note;
             var lineTokens = RecallScoring.EstimateTokens(line.Length);
@@ -182,10 +179,10 @@ public sealed record ParkResult(bool Success, string? Id, string? Reason)
 /// <summary>Outcome of a resolve: the closed state, plus the minted memory id when promoted.</summary>
 public sealed record ResolveResult(
     bool Success, string Id, LooseEndState State,
-    ResolutionKind? Kind = null, string? PromotedToMemoryId = null, string? Reason = null)
+    ResolutionKind? Kind = null, string? PromotedToMemoryId = null, string? ExternalRef = null, string? Reason = null)
 {
     public static ResolveResult From(LooseEnd e) =>
-        new(true, e.Id, e.State, e.Resolution, e.PromotedToMemoryId);
+        new(true, e.Id, e.State, e.Resolution, e.PromotedToMemoryId, e.ExternalRef);
     public static ResolveResult NotFound(string id) =>
         new(false, id, LooseEndState.Open, Reason: "not found");
     public static ResolveResult Rejected(string id, string reason) =>

--- a/src/Eidet.Core/LooseEnds/Promotion/MemoryServicePromotionAdapter.cs
+++ b/src/Eidet.Core/LooseEnds/Promotion/MemoryServicePromotionAdapter.cs
@@ -1,0 +1,46 @@
+using Eidet.Core.Services;
+
+namespace Eidet.Core.LooseEnds.Promotion;
+
+/// <summary>
+/// Prod <see cref="IPromotionPort"/>: promotes a confirmed Loose End into a real
+/// <see cref="MemoryEntry"/> through the full <see cref="MemoryService.StoreAsync(StoreOptions, CancellationToken)"/>
+/// gate (secret + signal scan, dedup, hooks). When <see cref="PromoteOptions.ExternalRef"/> is set,
+/// the note is linked to an external issue instead of minted — no memory is created and the gate is
+/// not entered. This is the single gate-split enforcement point: park never reaches StoreAsync, and
+/// promote only ever reaches it via this adapter.
+/// </summary>
+public sealed class MemoryServicePromotionAdapter : IPromotionPort
+{
+    private readonly MemoryService _memory;
+
+    public MemoryServicePromotionAdapter(MemoryService memory)
+    {
+        _memory = memory;
+    }
+
+    public async Task<PromotionResult> PromoteAsync(LooseEnd e, PromoteOptions opts, CancellationToken ct = default)
+    {
+        // Link-only: record the external ref, do not mint a memory.
+        if (!string.IsNullOrEmpty(opts.ExternalRef))
+            return new PromotionResult(true, MemoryId: null, opts.ExternalRef, Reason: null);
+
+        var result = await _memory.StoreAsync(new StoreOptions(e.RepoId, e.Note, opts.Type)
+        {
+            Importance = opts.Importance,
+            Tags = e.Tags,
+            Source = "promoted-loose-end",
+        }, ct);
+
+        // A near-duplicate means the knowledge already exists — promote onto the existing memory
+        // rather than stranding the Loose End open and dropping the duplicate id on the floor.
+        if (result.DuplicateId is not null)
+            return new PromotionResult(true, result.DuplicateId, ExternalRef: null, Reason: null);
+
+        if (!result.Success)
+            return new PromotionResult(false, MemoryId: null, ExternalRef: null,
+                Reason: result.Reason ?? "promotion rejected at the memory gate");
+
+        return new PromotionResult(true, result.Id, ExternalRef: null, Reason: null);
+    }
+}

--- a/src/Eidet.Core/LooseEnds/Promotion/MemoryServicePromotionAdapter.cs
+++ b/src/Eidet.Core/LooseEnds/Promotion/MemoryServicePromotionAdapter.cs
@@ -21,8 +21,9 @@ public sealed class MemoryServicePromotionAdapter : IPromotionPort
 
     public async Task<PromotionResult> PromoteAsync(LooseEnd e, PromoteOptions opts, CancellationToken ct = default)
     {
-        // Link-only: record the external ref, do not mint a memory.
-        if (!string.IsNullOrEmpty(opts.ExternalRef))
+        // Link-only: record the external ref, do not mint a memory. Treat whitespace-only as absent
+        // so a stray " " in promote_to can't silently close the end as a link with no real ref.
+        if (!string.IsNullOrWhiteSpace(opts.ExternalRef))
             return new PromotionResult(true, MemoryId: null, opts.ExternalRef, Reason: null);
 
         var result = await _memory.StoreAsync(new StoreOptions(e.RepoId, e.Note, opts.Type)

--- a/src/Eidet.Core/Services/MemoryService.cs
+++ b/src/Eidet.Core/Services/MemoryService.cs
@@ -34,6 +34,13 @@ public sealed class MemoryService
 
     public int StalenessWarningDays { get; set; } = 7;
 
+    /// <summary>
+    /// Optional Loose End surface for the wake-up slice in <see cref="GetContextAsync"/>. Settable
+    /// (not a ctor dependency) because the promotion adapter wraps this service, so a ctor edge
+    /// would be a construction cycle. When null the slice is empty (NullObject behavior).
+    /// </summary>
+    public LooseEnds.LooseEndService? LooseEnds { get; set; }
+
     public MemoryService(IEidetStore store, LayerService? layers = null, IHookRunner? hooks = null)
     {
         _store = store;
@@ -414,11 +421,33 @@ public sealed class MemoryService
             if (count > 0)
                 sb.Append($", {count} {type.ToString().ToLowerInvariant()}s");
         }
+
+        // Loose End wake-up slice: open work surfaces here *because it is open*, not by relevance.
+        // The L0 count addendum reflects the total open count; the slice itself is item- and
+        // token-capped within a sub-budget carved from L1 (never from L0/identity).
+        var openLooseEndCount = LooseEnds is not null
+            ? await LooseEnds.CountOpenAsync(normalizedRepoId, ct)
+            : 0;
+        if (openLooseEndCount > 0)
+            sb.Append($" | {openLooseEndCount} open loose ends");
+
         sb.AppendLine("]");
 
         var remainingTokens = maxTokens - RecallScoring.EstimateTokens(sb.Length);
         if (remainingTokens <= 0)
             return sb.ToString();
+
+        if (LooseEnds is not null && openLooseEndCount > 0)
+        {
+            const int looseEndSubBudget = 120;
+            var sliceBudget = Math.Max(0, Math.Min(looseEndSubBudget, remainingTokens));
+            var slice = await LooseEnds.RenderWakeupSliceAsync(normalizedRepoId, sliceBudget, ct);
+            if (slice.Length > 0)
+            {
+                sb.Append(slice);
+                remainingTokens -= RecallScoring.EstimateTokens(slice.Length);
+            }
+        }
 
         // L1: Top-K scored memories
         var candidates = await _store.GetTopScoredAsync(

--- a/src/Eidet.Core/Storage/RavenLooseEndStore.cs
+++ b/src/Eidet.Core/Storage/RavenLooseEndStore.cs
@@ -1,0 +1,84 @@
+using Eidet.Core.LooseEnds;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Linq;
+
+namespace Eidet.Core.Storage;
+
+/// <summary>
+/// RavenDB adapter for <see cref="ILooseEndStore"/>. The <see cref="LooseEnd"/> CLR type lands in
+/// its own <c>LooseEnds</c> collection regardless of the <c>looseends/...</c> string id, so no
+/// memory-maintenance stage (which all query <c>MemoryEntry</c>/<c>Memories_Search</c>) ever
+/// touches open work — the no-decay invariant is structural. No index in v1; RavenDB auto-indexes
+/// the where-clauses. Ordering is done client-side after fetch.
+/// </summary>
+public sealed class RavenLooseEndStore : ILooseEndStore
+{
+    private readonly IDocumentStore _store;
+
+    public RavenLooseEndStore(IDocumentStore store)
+    {
+        _store = store;
+    }
+
+    public async Task<string> StoreAsync(LooseEnd e, CancellationToken ct = default)
+    {
+        using var session = _store.OpenAsyncSession();
+        await session.StoreAsync(e, e.Id, ct);
+        await session.SaveChangesAsync(ct);
+        return e.Id;
+    }
+
+    public async Task<LooseEnd?> GetAsync(string id, CancellationToken ct = default)
+    {
+        using var session = _store.OpenAsyncSession();
+        return await session.LoadAsync<LooseEnd>(id, ct);
+    }
+
+    public async Task UpdateAsync(LooseEnd e, CancellationToken ct = default)
+    {
+        using var session = _store.OpenAsyncSession();
+        await session.StoreAsync(e, e.Id, ct);
+        await session.SaveChangesAsync(ct);
+    }
+
+    public async Task<IReadOnlyList<LooseEnd>> ListOpenAsync(string repoId, int max, CancellationToken ct = default)
+    {
+        // Order + page server-side (matches every other query in RavenEidetStore) so the wake-up
+        // hot path never streams the whole open set just to take the top few.
+        using var session = _store.OpenAsyncSession();
+        return await session.Query<LooseEnd>()
+            .Where(e => e.RepoId == repoId && e.State == LooseEndState.Open)
+            .OrderBy(e => e.Priority).ThenBy(e => e.CreatedAt)
+            .Take(max)
+            .ToListAsync(ct);
+    }
+
+    public async Task<int> CountOpenAsync(string repoId, CancellationToken ct = default)
+    {
+        using var session = _store.OpenAsyncSession();
+        return await session.Query<LooseEnd>()
+            .Where(e => e.RepoId == repoId && e.State == LooseEndState.Open)
+            .CountAsync(ct);
+    }
+
+    public async Task<IReadOnlyList<LooseEnd>> FindOpenByTagsAsync(
+        string repoId, IReadOnlyList<string> tags, int max, CancellationToken ct = default)
+    {
+        if (tags.Count == 0) return [];
+
+        using var session = _store.OpenAsyncSession();
+        var open = await session.Query<LooseEnd>()
+            .Where(e => e.RepoId == repoId && e.State == LooseEndState.Open)
+            .ToListAsync(ct);
+
+        // Tag overlap is cheap and the open set is small; filter client-side to avoid an index.
+        var wanted = new HashSet<string>(tags, StringComparer.OrdinalIgnoreCase);
+        var matched = open.Where(e => e.Tags.Any(wanted.Contains));
+        return Order(matched).Take(max).ToList();
+    }
+
+    // Wake-up ordering: highest priority first (Priority 1=high, so ascending), oldest first within
+    // a priority tier (surfaces the stalest high-priority work — the backlog-hygiene signal).
+    private static IEnumerable<LooseEnd> Order(IEnumerable<LooseEnd> ends) =>
+        ends.OrderBy(e => e.Priority).ThenBy(e => e.CreatedAt);
+}

--- a/src/Eidet.Core/Storage/RavenLooseEndStore.cs
+++ b/src/Eidet.Core/Storage/RavenLooseEndStore.cs
@@ -13,6 +13,9 @@ namespace Eidet.Core.Storage;
 /// </summary>
 public sealed class RavenLooseEndStore : ILooseEndStore
 {
+    // Upper bound on the open-set scan for tag matching — keeps the ride-along bounded on large backlogs.
+    private const int TagScanCap = 200;
+
     private readonly IDocumentStore _store;
 
     public RavenLooseEndStore(IDocumentStore store)
@@ -66,19 +69,18 @@ public sealed class RavenLooseEndStore : ILooseEndStore
     {
         if (tags.Count == 0) return [];
 
+        // Bound the fetch server-side to the highest-priority/stalest open work (same Priority→CreatedAt
+        // order used everywhere), then match tags client-side — keeps exact case-insensitive overlap
+        // without a dedicated index while stopping this ride-along (a hot path on every tagged recall)
+        // from streaming an unbounded backlog.
         using var session = _store.OpenAsyncSession();
-        var open = await session.Query<LooseEnd>()
+        var candidates = await session.Query<LooseEnd>()
             .Where(e => e.RepoId == repoId && e.State == LooseEndState.Open)
+            .OrderBy(e => e.Priority).ThenBy(e => e.CreatedAt)
+            .Take(TagScanCap)
             .ToListAsync(ct);
 
-        // Tag overlap is cheap and the open set is small; filter client-side to avoid an index.
         var wanted = new HashSet<string>(tags, StringComparer.OrdinalIgnoreCase);
-        var matched = open.Where(e => e.Tags.Any(wanted.Contains));
-        return Order(matched).Take(max).ToList();
+        return candidates.Where(e => e.Tags.Any(wanted.Contains)).Take(max).ToList();
     }
-
-    // Wake-up ordering: highest priority first (Priority 1=high, so ascending), oldest first within
-    // a priority tier (surfaces the stalest high-priority work — the backlog-hygiene signal).
-    private static IEnumerable<LooseEnd> Order(IEnumerable<LooseEnd> ends) =>
-        ends.OrderBy(e => e.Priority).ThenBy(e => e.CreatedAt);
 }

--- a/src/Eidet.Service/Api/EidetApi.cs
+++ b/src/Eidet.Service/Api/EidetApi.cs
@@ -23,6 +23,7 @@ public class EidetApiServer
     private readonly MemoryReadEndpoints _memoryRead;
     private readonly MemoryWriteEndpoints _memoryWrite;
     private readonly MemoryBulkEndpoints _memoryBulk;
+    private readonly LooseEndEndpoints _looseEndEndpoints;
     private readonly LayerEndpoints _layerEndpoints;
     private readonly MaintenanceEndpoints _maintenanceEndpoints;
     private readonly QualityEndpoint _qualityEndpoint;
@@ -43,11 +44,12 @@ public class EidetApiServer
         var svc = options.Memory;
         var intake = options.Intake;
         var dispatcher = ToolDispatcherFactory.Create(svc, intake, options.Consolidation, options.Maintenance,
-            options.Export, options.Layers, options.Usage);
+            options.LooseEnds, options.Export, options.Layers, options.Usage);
 
         _memoryRead = new MemoryReadEndpoints(svc, dispatcher, options.Usage, options.Layers);
         _memoryWrite = new MemoryWriteEndpoints(svc, dispatcher);
         _memoryBulk = new MemoryBulkEndpoints(dispatcher, options.Export, options.Usage);
+        _looseEndEndpoints = new LooseEndEndpoints(dispatcher, options.LooseEnds);
         _layerEndpoints = new LayerEndpoints(options.Layers, options.LayerSync);
         _maintenanceEndpoints = new MaintenanceEndpoints(dispatcher);
         _qualityEndpoint = new QualityEndpoint(options.Quality, options.Usage);
@@ -56,7 +58,7 @@ public class EidetApiServer
         _enrichEndpoint = new EnrichEndpoint(options.Enrichment);
         _portal = new PortalEndpoint(svc, options.Usage);
         _meta = new MetaEndpoints(svc, options.Enrichment, options.Config, _baseUrl, _startedAt);
-        _mcp = new McpEndpoint(options.Mcp, svc, intake, options.Consolidation, options.Maintenance);
+        _mcp = new McpEndpoint(options.Mcp, svc, intake, options.Consolidation, options.Maintenance, options.LooseEnds);
 
         _router = BuildRouter();
     }
@@ -150,6 +152,12 @@ public class EidetApiServer
         r.MapPost("/api/eidet/packs/import", (ctx, _, ct) => _memoryBulk.PackImport(ctx, ct));
         r.MapPost("/api/eidet/links", (ctx, _, ct) => _memoryWrite.CreateLink(ctx, ct));
         r.MapGet("/api/eidet/links", (ctx, _, ct) => _memoryRead.GetLinks(ctx, ct));
+
+        // Loose Ends (must register before the catch-all GET /api/eidet/{id})
+        r.Map("POST", p => p.StartsWith("/api/eidet/loose-ends/") && p.EndsWith("/resolve"),
+            (ctx, path, ct) => _looseEndEndpoints.Resolve(ctx, LooseEndEndpoints.ExtractIdFromResolvePath(path), ct));
+        r.MapPost("/api/eidet/loose-ends", (ctx, _, ct) => _looseEndEndpoints.Park(ctx, ct));
+        r.MapGet("/api/eidet/loose-ends", (ctx, _, ct) => _looseEndEndpoints.List(ctx, ct));
 
         // Layers
         r.MapGet("/api/eidet/layers", (ctx, _, ct) => _layerEndpoints.GetLayers(ctx, ct));

--- a/src/Eidet.Service/Api/EidetApiServerOptions.cs
+++ b/src/Eidet.Service/Api/EidetApiServerOptions.cs
@@ -1,5 +1,6 @@
 using Eidet.Core.Configuration;
 using Eidet.Core.Enrichment;
+using Eidet.Core.LooseEnds;
 using Eidet.Core.Maintenance;
 using Eidet.Core.Services;
 using Eidet.Service.Mcp;
@@ -19,6 +20,7 @@ public sealed record EidetApiServerOptions
     public required ConsolidationEngine Consolidation { get; init; }
     public required IMaintenanceRunner Maintenance { get; init; }
     public required ExportService Export { get; init; }
+    public required LooseEndService LooseEnds { get; init; }
     public required string BindAddress { get; init; }
     public required int Port { get; init; }
 

--- a/src/Eidet.Service/Api/Endpoints/LooseEndEndpoints.cs
+++ b/src/Eidet.Service/Api/Endpoints/LooseEndEndpoints.cs
@@ -1,0 +1,113 @@
+using System.Net;
+using System.Text.Json;
+using Eidet.Core.LooseEnds;
+using Eidet.Service.Tools;
+using Eidet.Service.Tools.Formatters;
+
+namespace Eidet.Service.Api.Endpoints;
+
+/// <summary>
+/// Loose End REST routes: park and resolve route through <see cref="ToolDispatcher"/> for parity
+/// with MCP; the open-work pull list calls <see cref="LooseEndService"/> directly (it is the
+/// off-MCP human surface). The id in the resolve path is itself slash-bearing
+/// (<c>looseends/{repo}/{hash}</c>), so it is carried as the path between the route prefix and
+/// the <c>/resolve</c> suffix.
+/// </summary>
+internal sealed class LooseEndEndpoints
+{
+    private readonly ToolDispatcher _dispatcher;
+    private readonly LooseEndService _looseEnds;
+
+    public LooseEndEndpoints(ToolDispatcher dispatcher, LooseEndService looseEnds)
+    {
+        _dispatcher = dispatcher;
+        _looseEnds = looseEnds;
+    }
+
+    public async Task Park(HttpListenerContext ctx, CancellationToken ct)
+    {
+        var repo = ctx.Request.QueryString["repo"];
+        if (string.IsNullOrEmpty(repo))
+        {
+            await HttpJson.WriteAsync(ctx, new { error = "Missing 'repo' parameter" }, 400);
+            return;
+        }
+
+        var req = await HttpJson.ReadAsync<ParkRequest>(ctx);
+        if (req is null || string.IsNullOrEmpty(req.Note))
+        {
+            await HttpJson.WriteAsync(ctx, new { error = "Missing required field: note" }, 400);
+            return;
+        }
+
+        var args = JsonSerializer.SerializeToElement(new
+        {
+            note = req.Note,
+            tags = req.Tags,
+            priority = req.Priority ?? 2,
+        }, HttpJson.Options);
+
+        var result = await _dispatcher.InvokeAsync(new ToolRequest("eidet_park", repo, args, "rest", ct));
+        await RestFormatter.WriteAsync(ctx, result, successStatus: 201);
+    }
+
+    public async Task Resolve(HttpListenerContext ctx, string id, CancellationToken ct)
+    {
+        if (string.IsNullOrEmpty(id))
+        {
+            await HttpJson.WriteAsync(ctx, new { error = "Invalid Loose End ID in path" }, 400);
+            return;
+        }
+
+        var req = await HttpJson.ReadAsync<ResolveRequest>(ctx);
+        if (req is null || string.IsNullOrEmpty(req.Kind))
+        {
+            await HttpJson.WriteAsync(ctx, new { error = "Missing required field: kind" }, 400);
+            return;
+        }
+
+        var args = JsonSerializer.SerializeToElement(new
+        {
+            id = Uri.UnescapeDataString(id),
+            kind = req.Kind,
+            note = req.Note,
+            promote_type = req.PromoteType,
+            promote_to = req.PromoteTo,
+        }, HttpJson.Options);
+
+        var repo = ctx.Request.QueryString["repo"] ?? "";
+        var result = await _dispatcher.InvokeAsync(new ToolRequest("eidet_resolve", repo, args, "rest", ct));
+        await RestFormatter.WriteAsync(ctx, result);
+    }
+
+    public async Task List(HttpListenerContext ctx, CancellationToken ct)
+    {
+        var repo = ctx.Request.QueryString["repo"];
+        if (string.IsNullOrEmpty(repo))
+        {
+            await HttpJson.WriteAsync(ctx, new { error = "Missing 'repo' parameter" }, 400);
+            return;
+        }
+
+        var open = await _looseEnds.PullAsync(repo, ct: ct);
+        await HttpJson.WriteAsync(ctx, new { repo, state = "open", looseEnds = open });
+    }
+
+    /// <summary>
+    /// Extract the Loose End ID from paths like <c>/api/eidet/loose-ends/{id}/resolve</c>. The id
+    /// itself contains slashes (<c>looseends/{repo}/{hash}</c>), so take everything between the
+    /// prefix and the <c>/resolve</c> suffix.
+    /// </summary>
+    public static string ExtractIdFromResolvePath(string path)
+    {
+        const string prefix = "/api/eidet/loose-ends/";
+        const string suffix = "/resolve";
+        if (path.StartsWith(prefix) && path.EndsWith(suffix) && path.Length > prefix.Length + suffix.Length)
+            return path[prefix.Length..^suffix.Length];
+        return "";
+    }
+
+    private sealed record ParkRequest(string? Note, List<string>? Tags, int? Priority);
+
+    private sealed record ResolveRequest(string? Kind, string? Note, string? PromoteType, string? PromoteTo);
+}

--- a/src/Eidet.Service/Api/Endpoints/LooseEndEndpoints.cs
+++ b/src/Eidet.Service/Api/Endpoints/LooseEndEndpoints.cs
@@ -89,7 +89,10 @@ internal sealed class LooseEndEndpoints
             return;
         }
 
-        var open = await _looseEnds.PullAsync(repo, ct: ct);
+        var limit = int.TryParse(ctx.Request.QueryString["limit"], out var parsed)
+            ? Math.Clamp(parsed, 1, 100)
+            : 20;
+        var open = await _looseEnds.PullAsync(repo, limit, ct);
         await HttpJson.WriteAsync(ctx, new { repo, state = "open", looseEnds = open });
     }
 

--- a/src/Eidet.Service/Api/Endpoints/McpEndpoint.cs
+++ b/src/Eidet.Service/Api/Endpoints/McpEndpoint.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Net;
 using System.Text.Json;
 using Eidet.Core;
+using Eidet.Core.LooseEnds;
 using Eidet.Core.Maintenance;
 using Eidet.Core.Services;
 using Eidet.Service.Mcp;
@@ -22,15 +23,17 @@ internal sealed class McpEndpoint
     private readonly IntakeService _intake;
     private readonly ConsolidationEngine _consolidation;
     private readonly IMaintenanceRunner _maintenance;
+    private readonly LooseEndService _looseEnds;
 
     public McpEndpoint(McpServer? mcpServer, MemoryService svc, IntakeService intake,
-        ConsolidationEngine consolidation, IMaintenanceRunner maintenance)
+        ConsolidationEngine consolidation, IMaintenanceRunner maintenance, LooseEndService looseEnds)
     {
         _mcpServer = mcpServer;
         _svc = svc;
         _intake = intake;
         _consolidation = consolidation;
         _maintenance = maintenance;
+        _looseEnds = looseEnds;
     }
 
     public async Task Handle(HttpListenerContext ctx, CancellationToken ct)
@@ -45,7 +48,7 @@ internal sealed class McpEndpoint
         var server = string.IsNullOrEmpty(repoOverride)
             ? _mcpServer
             : _pool.GetOrAdd(repoOverride, id =>
-                new McpServer(_svc, _intake, _consolidation, _maintenance, id));
+                new McpServer(_svc, _intake, _consolidation, _maintenance, _looseEnds, id));
 
         using var reader = new StreamReader(ctx.Request.InputStream, ctx.Request.ContentEncoding);
         var body = await reader.ReadToEndAsync(ct);

--- a/src/Eidet.Service/Commands/ContextCommand.cs
+++ b/src/Eidet.Service/Commands/ContextCommand.cs
@@ -1,4 +1,6 @@
 using Eidet.Core.Configuration;
+using Eidet.Core.LooseEnds;
+using Eidet.Core.LooseEnds.Promotion;
 using Eidet.Core.Services;
 using Eidet.Core.Storage;
 using Spectre.Console;
@@ -27,6 +29,12 @@ public sealed class ContextCommand : AsyncCommand<ContextCommand.Settings>
         var eidetStore = new RavenEidetStore(store);
         var layerSvc = new LayerService(eidetStore);
         var memorySvc = new MemoryService(eidetStore, layerSvc);
+
+        // Wire Loose Ends so `eidet context` shows the same wake-up slice + open-count addendum the
+        // agent receives via MCP/REST — otherwise this debug view silently diverges from real context.
+        var looseEndSvc = new LooseEndService(
+            new RavenLooseEndStore(store), new MemoryServicePromotionAdapter(memorySvc), TimeProvider.System);
+        memorySvc.LooseEnds = looseEndSvc;
 
         var repoId = settings.Repo ?? Directory.GetCurrentDirectory();
         var maxTokens = settings.MaxTokens ?? 600;

--- a/src/Eidet.Service/Commands/McpCommand.cs
+++ b/src/Eidet.Service/Commands/McpCommand.cs
@@ -1,6 +1,8 @@
 using Eidet.Core;
 using Eidet.Core.Configuration;
 using Eidet.Core.Enrichment;
+using Eidet.Core.LooseEnds;
+using Eidet.Core.LooseEnds.Promotion;
 using Eidet.Core.Maintenance;
 using Eidet.Core.Services;
 using Eidet.Core.Storage;
@@ -39,6 +41,11 @@ public sealed class McpCommand : AsyncCommand<McpCommand.Settings>
                 ? new HookRunner(config.Hooks)
                 : NullHookRunner.Instance;
             var memorySvc = new MemoryService(eidetStore, hooks: hookRunner);
+
+            var looseEndStore = new RavenLooseEndStore(store);
+            var looseEndSvc = new LooseEndService(looseEndStore, new MemoryServicePromotionAdapter(memorySvc), TimeProvider.System);
+            memorySvc.LooseEnds = looseEndSvc;
+
             var intakeSvc = new IntakeService(eidetStore, memorySvc);
             var consolidationEngine = new ConsolidationEngine(eidetStore, enrichment, memorySvc);
             IMaintenanceRunner maintenanceRunner = new MaintenanceOrchestrator(
@@ -49,7 +56,7 @@ public sealed class McpCommand : AsyncCommand<McpCommand.Settings>
             var layerSvc = new LayerService(eidetStore);
             var usageTracker = new UsageTracker(store);
             var workDir = settings.Repo ?? settings.WorkDir ?? Directory.GetCurrentDirectory();
-            var server = new McpServer(memorySvc, intakeSvc, consolidationEngine, maintenanceRunner, workDir,
+            var server = new McpServer(memorySvc, intakeSvc, consolidationEngine, maintenanceRunner, looseEndSvc, workDir,
                 autoIntake: config.Memory.AutoIntakeOnFirstSession, usage: usageTracker,
                 export: exportSvc, layers: layerSvc);
 

--- a/src/Eidet.Service/EidetHost.cs
+++ b/src/Eidet.Service/EidetHost.cs
@@ -1,6 +1,8 @@
 using Eidet.Core.Configuration;
 using Eidet.Core.Domain;
 using Eidet.Core.Enrichment;
+using Eidet.Core.LooseEnds;
+using Eidet.Core.LooseEnds.Promotion;
 using Eidet.Core.Maintenance;
 using Eidet.Core.Services;
 using Eidet.Core.Storage;
@@ -91,6 +93,15 @@ public sealed class EidetHost : IDisposable
             ? new HookRunner(config.Hooks) : NullHookRunner.Instance;
 
         var memorySvc = new MemoryService(eidetStore, layerSvc, hookRunner);
+
+        // Loose Ends wire AFTER memorySvc: the promotion adapter wraps memorySvc, and memorySvc
+        // needs looseEndSvc for the wake-up slice — so the slice is a settable property, not a
+        // ctor edge, to break that construction cycle.
+        var looseEndStore = new RavenLooseEndStore(store);
+        var promotion = new MemoryServicePromotionAdapter(memorySvc);
+        var looseEndSvc = new LooseEndService(looseEndStore, promotion, TimeProvider.System);
+        memorySvc.LooseEnds = looseEndSvc;
+
         var intakeSvc = new IntakeService(eidetStore, memory: memorySvc);
         var consolidationEngine = new ConsolidationEngine(eidetStore, enrichment, memory: memorySvc);
         IMaintenanceRunner maintenanceRunner = new MaintenanceOrchestrator(
@@ -100,7 +111,7 @@ public sealed class EidetHost : IDisposable
         var qualitySvc = new QualityService(eidetStore);
         var usageTracker = new UsageTracker(store);
         var layerSyncSvc = new LayerSyncService(eidetStore, layerSvc, memory: memorySvc);
-        var mcpServer = new McpServer(memorySvc, intakeSvc, consolidationEngine, maintenanceRunner,
+        var mcpServer = new McpServer(memorySvc, intakeSvc, consolidationEngine, maintenanceRunner, looseEndSvc,
             Directory.GetCurrentDirectory(), autoIntake: config.Memory.AutoIntakeOnFirstSession, usage: usageTracker,
             export: exportSvc, layers: layerSvc);
         var scheduler = new ScheduledTaskService(store, eidetStore, maintenanceRunner, consolidationEngine, config.Maintenance);
@@ -111,6 +122,7 @@ public sealed class EidetHost : IDisposable
             Consolidation = consolidationEngine,
             Maintenance = maintenanceRunner,
             Export = exportSvc,
+            LooseEnds = looseEndSvc,
             BindAddress = actualBind,
             Port = actualPort,
             Layers = layerSvc,

--- a/src/Eidet.Service/Mcp/McpServer.cs
+++ b/src/Eidet.Service/Mcp/McpServer.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Eidet.Core;
+using Eidet.Core.LooseEnds;
 using Eidet.Core.Maintenance;
 using Eidet.Core.Services;
 using Eidet.Service.Tools;
@@ -16,11 +17,11 @@ public class McpServer
     private readonly AutoIntakeOnContext? _autoIntake;
 
     public McpServer(MemoryService svc, IntakeService intake, ConsolidationEngine consolidation,
-        IMaintenanceRunner maintenance, string repoId, bool autoIntake = true,
+        IMaintenanceRunner maintenance, LooseEndService looseEnds, string repoId, bool autoIntake = true,
         UsageTracker? usage = null, ExportService? export = null, LayerService? layers = null)
     {
         _repoId = repoId;
-        _dispatcher = ToolDispatcherFactory.Create(svc, intake, consolidation, maintenance, export, layers, usage);
+        _dispatcher = ToolDispatcherFactory.Create(svc, intake, consolidation, maintenance, looseEnds, export, layers, usage);
         _exposedTools = _dispatcher.Handlers.Where(h => h.McpExposed).Select(h => h.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
         _autoIntake = autoIntake ? new AutoIntakeOnContext(svc, intake, repoId) : null;
 

--- a/src/Eidet.Service/Tools/Handlers/ParkToolHandler.cs
+++ b/src/Eidet.Service/Tools/Handlers/ParkToolHandler.cs
@@ -1,0 +1,74 @@
+using System.Text.Json.Nodes;
+using Eidet.Core.LooseEnds;
+using Eidet.Service.Mcp;
+
+namespace Eidet.Service.Tools.Handlers;
+
+/// <summary>
+/// Parks a Loose End through <see cref="LooseEndService.ParkAsync(ParkOptions, CancellationToken)"/>.
+/// Secret-scanned but not signal-gated — terse, speculative notes are the point. Rejection → 422.
+/// </summary>
+public sealed class ParkToolHandler : IToolHandler
+{
+    private readonly LooseEndService _svc;
+
+    public ParkToolHandler(LooseEndService svc) => _svc = svc;
+
+    public string Name => "eidet_park";
+    public string UsageOp => "Park";
+
+    public McpToolDefinition Schema { get; } = new()
+    {
+        Name = "eidet_park",
+        Description = "Park an open todo to revisit later. Stores a Loose End that won't decay or auto-expire until you resolve it. Use for terse mid-task notes ('possible bug in retry logic, revisit').",
+        InputSchema = BuildSchema(),
+    };
+
+    public async Task<ToolResult> ExecuteAsync(ToolRequest request)
+    {
+        var args = request.Arguments;
+
+        var note = ToolArgs.RequireString(args, "note");
+        var tags = ToolArgs.GetStringArray(args, "tags");
+        var priority = ToolArgs.GetInt(args, "priority", 2);
+
+        var result = await _svc.ParkAsync(new ParkOptions(request.RepoId, note)
+        {
+            Tags = tags.Count > 0 ? tags : null,
+            Priority = priority,
+        }, request.Ct);
+
+        if (!result.Success)
+            return ToolResult.Rejected(result.Reason!);
+
+        return ToolResult.Ok(
+            payload: new { id = result.Id, state = "open" },
+            summary: $"Parked: {result.Id}",
+            count: 1);
+    }
+
+    private static JsonObject BuildSchema() => new()
+    {
+        ["type"] = "object",
+        ["properties"] = new JsonObject
+        {
+            ["note"] = new JsonObject
+            {
+                ["type"] = "string",
+                ["description"] = "Terse note describing the open work to revisit (e.g. 'flaky test in auth path, revisit retry logic').",
+            },
+            ["tags"] = new JsonObject
+            {
+                ["type"] = "array",
+                ["description"] = "Tags used for recall ride-along matching.",
+                ["items"] = new JsonObject { ["type"] = "string" },
+            },
+            ["priority"] = new JsonObject
+            {
+                ["type"] = "integer",
+                ["description"] = "Wake-up ordering: 1 high, 2 normal (default), 3 low.",
+            },
+        },
+        ["required"] = new JsonArray { "note" },
+    };
+}

--- a/src/Eidet.Service/Tools/Handlers/RecallToolHandler.cs
+++ b/src/Eidet.Service/Tools/Handlers/RecallToolHandler.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Nodes;
 using Eidet.Core.Domain;
+using Eidet.Core.LooseEnds;
 using Eidet.Core.Services;
 using Eidet.Service.Mcp;
 
@@ -13,10 +14,12 @@ namespace Eidet.Service.Tools.Handlers;
 public sealed class RecallToolHandler : IToolHandler
 {
     private readonly MemoryService _svc;
+    private readonly LooseEndService? _looseEnds;
 
-    public RecallToolHandler(MemoryService svc)
+    public RecallToolHandler(MemoryService svc, LooseEndService? looseEnds = null)
     {
         _svc = svc;
+        _looseEnds = looseEnds;
     }
 
     public string Name => "eidet_recall";
@@ -45,31 +48,48 @@ public sealed class RecallToolHandler : IToolHandler
 
         var results = await _svc.RecallAsync(request.RepoId, opts, request.Ct);
 
-        if (results.Count == 0)
+        // Recall ride-along: open Loose Ends whose tags overlap the query surface in a SEPARATE
+        // section, never mixed into the relevance-ranked memory list (LooseEndSpec §Surfacing mode 2).
+        IReadOnlyList<LooseEnd> looseEnds = _looseEnds is not null && opts.Tags is { Count: > 0 }
+            ? await _looseEnds.RideAlongAsync(request.RepoId, opts.Tags, request.Ct)
+            : [];
+
+        if (results.Count == 0 && looseEnds.Count == 0)
             return ToolResult.Ok(
-                payload: new { repo = request.RepoId, query = queryText, results = Array.Empty<MemorySearchResult>() },
+                payload: new { repo = request.RepoId, query = queryText, results = Array.Empty<MemorySearchResult>(), looseEnds = Array.Empty<LooseEnd>() },
                 summary: "No memories found.",
                 count: 0);
 
-        var lines = new List<string> { $"{results.Count} memory(ies) found:" };
-        foreach (var r in results)
+        var lines = new List<string>();
+        if (results.Count > 0)
         {
-            var prefix = r.Type switch
+            lines.Add($"{results.Count} memory(ies) found:");
+            foreach (var r in results)
             {
-                MemoryType.Insight => "[I]",
-                MemoryType.Observation => "[O]",
-                MemoryType.Procedure => "[P]",
-                MemoryType.Heuristic => "[H]",
-                _ => "[?]",
-            };
-            var stale = r.StalenessWarning != null ? $" {r.StalenessWarning}" : "";
-            var display = r.OneLiner ?? r.Summary ?? Truncate(r.Content, 120);
-            lines.Add($"  {prefix} {display}{stale}");
-            lines.Add($"      id={r.Id} importance={r.Importance:F2} score={r.Score:F2}");
+                var prefix = r.Type switch
+                {
+                    MemoryType.Insight => "[I]",
+                    MemoryType.Observation => "[O]",
+                    MemoryType.Procedure => "[P]",
+                    MemoryType.Heuristic => "[H]",
+                    _ => "[?]",
+                };
+                var stale = r.StalenessWarning != null ? $" {r.StalenessWarning}" : "";
+                var display = r.OneLiner ?? r.Summary ?? Truncate(r.Content, 120);
+                lines.Add($"  {prefix} {display}{stale}");
+                lines.Add($"      id={r.Id} importance={r.Importance:F2} score={r.Score:F2}");
+            }
+        }
+
+        if (looseEnds.Count > 0)
+        {
+            lines.Add($"{looseEnds.Count} open loose end(s) matching your tags:");
+            foreach (var le in looseEnds)
+                lines.Add($"  [~] {le.Note} (id={le.Id}, priority={le.Priority})");
         }
 
         return ToolResult.Ok(
-            payload: new { repo = request.RepoId, query = queryText, results },
+            payload: new { repo = request.RepoId, query = queryText, results, looseEnds },
             summary: string.Join("\n", lines),
             count: results.Count);
     }

--- a/src/Eidet.Service/Tools/Handlers/RecallToolHandler.cs
+++ b/src/Eidet.Service/Tools/Handlers/RecallToolHandler.cs
@@ -53,10 +53,15 @@ public sealed class RecallToolHandler : IToolHandler
         IReadOnlyList<LooseEnd> looseEnds = _looseEnds is not null && opts.Tags is { Count: > 0 }
             ? await _looseEnds.RideAlongAsync(request.RepoId, opts.Tags, request.Ct)
             : [];
+        // Trim to a stable ride-along view — the raw LooseEnd carries internal lifecycle/source
+        // fields (State, Resolution, SourceSessionId, …) that don't belong on the recall wire.
+        var rideAlong = looseEnds
+            .Select(le => new RideAlongView(le.Id, le.Note, le.Priority, le.Tags))
+            .ToList();
 
-        if (results.Count == 0 && looseEnds.Count == 0)
+        if (results.Count == 0 && rideAlong.Count == 0)
             return ToolResult.Ok(
-                payload: new { repo = request.RepoId, query = queryText, results = Array.Empty<MemorySearchResult>(), looseEnds = Array.Empty<LooseEnd>() },
+                payload: new { repo = request.RepoId, query = queryText, results = Array.Empty<MemorySearchResult>(), looseEnds = rideAlong },
                 summary: "No memories found.",
                 count: 0);
 
@@ -81,21 +86,25 @@ public sealed class RecallToolHandler : IToolHandler
             }
         }
 
-        if (looseEnds.Count > 0)
+        if (rideAlong.Count > 0)
         {
-            lines.Add($"{looseEnds.Count} open loose end(s) matching your tags:");
-            foreach (var le in looseEnds)
+            lines.Add($"{rideAlong.Count} open loose end(s) matching your tags:");
+            foreach (var le in rideAlong)
                 lines.Add($"  [~] {le.Note} (id={le.Id}, priority={le.Priority})");
         }
 
         return ToolResult.Ok(
-            payload: new { repo = request.RepoId, query = queryText, results, looseEnds },
+            payload: new { repo = request.RepoId, query = queryText, results, looseEnds = rideAlong },
             summary: string.Join("\n", lines),
             count: results.Count);
     }
 
     private static string Truncate(string s, int max) =>
         s.Length <= max ? s : s[..max] + "…";
+
+    /// <summary>Trimmed recall ride-along projection — only the fields the agent needs to act on a
+    /// matching open Loose End, deliberately excluding internal lifecycle/source fields.</summary>
+    private sealed record RideAlongView(string Id, string Note, int Priority, IReadOnlyList<string> Tags);
 
     private static JsonObject BuildSchema()
     {

--- a/src/Eidet.Service/Tools/Handlers/ResolveToolHandler.cs
+++ b/src/Eidet.Service/Tools/Handlers/ResolveToolHandler.cs
@@ -1,0 +1,103 @@
+using System.Text.Json.Nodes;
+using Eidet.Core.Domain;
+using Eidet.Core.LooseEnds;
+using Eidet.Service.Mcp;
+
+namespace Eidet.Service.Tools.Handlers;
+
+/// <summary>
+/// Resolves a Loose End with a typed kind through <see cref="LooseEndService.ResolveAsync"/>.
+/// <c>kind</c> is required at the tool layer (a defaulted Done would silently mislabel abandoned
+/// work). Promote with a <c>promote_to</c> external ref links instead of minting; otherwise it
+/// mints a gated <see cref="MemoryEntry"/>. NotFound → 404, invalid kind → 400.
+/// </summary>
+public sealed class ResolveToolHandler : IToolHandler
+{
+    private readonly LooseEndService _svc;
+
+    public ResolveToolHandler(LooseEndService svc) => _svc = svc;
+
+    public string Name => "eidet_resolve";
+    public string UsageOp => "Resolve";
+
+    public McpToolDefinition Schema { get; } = new()
+    {
+        Name = "eidet_resolve",
+        Description = "Resolve a parked Loose End with a kind: done (handled), dropped (not worth doing), promoted (graduate into a gated memory or link an issue), or superseded (folded into another). Done-vs-dropped-vs-promoted is the quality signal — pick deliberately.",
+        InputSchema = BuildSchema(),
+    };
+
+    public async Task<ToolResult> ExecuteAsync(ToolRequest request)
+    {
+        var args = request.Arguments;
+
+        var id = ToolArgs.RequireString(args, "id");
+
+        var kindStr = ToolArgs.RequireString(args, "kind");
+        if (!Enum.TryParse<ResolutionKind>(kindStr, true, out var kind))
+            return ToolResult.BadRequest($"Invalid kind: {kindStr}. Use: done, dropped, promoted, superseded.");
+
+        var note = ToolArgs.GetString(args, "note");
+        var promoteType = ToolArgs.GetEnum<MemoryType>(args, "promote_type") ?? MemoryType.Insight;
+        var promoteTo = ToolArgs.GetString(args, "promote_to");
+
+        var result = await _svc.ResolveAsync(id, kind, new ResolveOptions
+        {
+            Note = note,
+            PromoteType = promoteType,
+            ExternalRef = promoteTo,
+        }, request.Ct);
+
+        if (!result.Success)
+        {
+            return result.Reason == "not found"
+                ? ToolResult.NotFound($"Loose End not found: {id}")
+                : ToolResult.Rejected(result.Reason!);
+        }
+
+        return ToolResult.Ok(
+            payload: new
+            {
+                id = result.Id,
+                state = "resolved",
+                kind = result.Kind?.ToString().ToLowerInvariant(),
+                promotedToMemoryId = result.PromotedToMemoryId,
+            },
+            summary: $"Resolved {result.Id} as {result.Kind?.ToString().ToLowerInvariant()}.",
+            count: 1);
+    }
+
+    private static JsonObject BuildSchema() => new()
+    {
+        ["type"] = "object",
+        ["properties"] = new JsonObject
+        {
+            ["id"] = new JsonObject
+            {
+                ["type"] = "string",
+                ["description"] = "Loose End ID to resolve.",
+            },
+            ["kind"] = new JsonObject
+            {
+                ["type"] = "string",
+                ["description"] = "Resolution kind: done, dropped, promoted, or superseded.",
+            },
+            ["note"] = new JsonObject
+            {
+                ["type"] = "string",
+                ["description"] = "Why this was resolved (especially useful for dropped).",
+            },
+            ["promote_type"] = new JsonObject
+            {
+                ["type"] = "string",
+                ["description"] = "When kind=promoted and minting a memory: observation, insight (default), procedure, or heuristic.",
+            },
+            ["promote_to"] = new JsonObject
+            {
+                ["type"] = "string",
+                ["description"] = "When kind=promoted: an external issue ref (e.g. 'gh#412') to link instead of minting a memory.",
+            },
+        },
+        ["required"] = new JsonArray { "id", "kind" },
+    };
+}

--- a/src/Eidet.Service/Tools/Handlers/ResolveToolHandler.cs
+++ b/src/Eidet.Service/Tools/Handlers/ResolveToolHandler.cs
@@ -62,6 +62,7 @@ public sealed class ResolveToolHandler : IToolHandler
                 state = "resolved",
                 kind = result.Kind?.ToString().ToLowerInvariant(),
                 promotedToMemoryId = result.PromotedToMemoryId,
+                externalRef = result.ExternalRef,
             },
             summary: $"Resolved {result.Id} as {result.Kind?.ToString().ToLowerInvariant()}.",
             count: 1);

--- a/src/Eidet.Service/Tools/ToolDispatcherFactory.cs
+++ b/src/Eidet.Service/Tools/ToolDispatcherFactory.cs
@@ -1,3 +1,4 @@
+using Eidet.Core.LooseEnds;
 using Eidet.Core.Maintenance;
 using Eidet.Core.Services;
 using Eidet.Service.Tools.Handlers;
@@ -5,7 +6,7 @@ using Eidet.Service.Tools.Handlers;
 namespace Eidet.Service.Tools;
 
 /// <summary>
-/// Builds the standard 13-handler <see cref="ToolDispatcher"/> shared by REST
+/// Builds the standard 15-handler <see cref="ToolDispatcher"/> shared by REST
 /// (<c>EidetApiServer</c>) and MCP (<c>McpServer</c>). Centralising the handler
 /// list keeps the two front-ends in lock-step — adding a new tool means editing
 /// one file, not two.
@@ -17,12 +18,13 @@ internal static class ToolDispatcherFactory
         IntakeService intake,
         ConsolidationEngine consolidation,
         IMaintenanceRunner maintenance,
+        LooseEndService looseEnds,
         ExportService? export = null,
         LayerService? layers = null,
         UsageTracker? usage = null) =>
         new([
             new StoreToolHandler(svc),
-            new RecallToolHandler(svc),
+            new RecallToolHandler(svc, looseEnds),
             new ForgetToolHandler(svc),
             new FeedbackToolHandler(svc),
             new HistoryToolHandler(svc),
@@ -34,5 +36,7 @@ internal static class ToolDispatcherFactory
             new IntakeToolHandler(intake),
             new PackExportToolHandler(export),
             new PackImportToolHandler(export, layers),
+            new ParkToolHandler(looseEnds),
+            new ResolveToolHandler(looseEnds),
         ], usage);
 }

--- a/tests/Eidet.Core.Tests/LooseEnds/LooseEndServiceTests.cs
+++ b/tests/Eidet.Core.Tests/LooseEnds/LooseEndServiceTests.cs
@@ -1,0 +1,338 @@
+using Eidet.Core.Domain;
+using Eidet.Core.LooseEnds;
+using Eidet.Core.LooseEnds.Promotion;
+using Eidet.Core.Services;
+using Eidet.Core.Tests.Services;
+
+namespace Eidet.Core.Tests.LooseEnds;
+
+/// <summary>
+/// End-to-end and invariant tests for the Loose End feature, driven entirely through
+/// <see cref="LooseEndService"/> over the in-memory ports + a deterministic clock. Covers the
+/// canonical cases named in LooseEndSpec.md §Implementation Sketch → Tests and the §Write Path /
+/// §Lifecycle / §Surfacing invariants.
+/// </summary>
+public class LooseEndServiceTests
+{
+    private static readonly DateTimeOffset T0 = new(2026, 6, 15, 12, 0, 0, TimeSpan.Zero);
+
+    // ─── 1. End-to-end happy path (real promotion adapter) ──────────────
+
+    [Fact]
+    public async Task Park_Surface_PromoteViaRealAdapter_MintsGatedMemory_AndDropsFromSlice()
+    {
+        var clock = new FakeTimeProvider(T0);
+        var endStore = new InMemoryLooseEndStore();
+        var memStore = new InMemoryEidetStore();
+        var memory = new MemoryService(memStore);
+        var promote = new MemoryServicePromotionAdapter(memory);
+        var svc = new LooseEndService(endStore, promote, clock);
+
+        var note = "Possible race in the retry backoff path under high concurrency, revisit later";
+        var parked = await svc.ParkAsync("repo-a", note);
+        Assert.True(parked.Success);
+        Assert.NotNull(parked.Id);
+
+        // The open Loose End surfaces in the wake-up slice with the [~] open-work prefix.
+        var sliceBefore = await svc.RenderWakeupSliceAsync("repo-a", 600);
+        Assert.Contains("[~] ", sliceBefore);
+        Assert.Contains(note, sliceBefore);
+
+        // Resolve as Promoted → re-enters the gated memory write path and mints a MemoryEntry.
+        var resolved = await svc.ResolveAsync(parked.Id!, ResolutionKind.Promoted);
+        Assert.True(resolved.Success);
+        Assert.Equal(LooseEndState.Resolved, resolved.State);
+        Assert.Equal(ResolutionKind.Promoted, resolved.Kind);
+        Assert.NotNull(resolved.PromotedToMemoryId);
+
+        // The minted memory is now in the memory store and recallable.
+        var recalled = await memory.RecallAsync("repo-a", "retry backoff race");
+        Assert.Single(recalled);
+        Assert.Equal(resolved.PromotedToMemoryId, recalled[0].Id);
+
+        // PromotedToMemoryId is persisted on the resolved Loose End.
+        var stored = await endStore.GetAsync(parked.Id!);
+        Assert.NotNull(stored);
+        Assert.Equal(resolved.PromotedToMemoryId, stored!.PromotedToMemoryId);
+
+        // The resolved end no longer surfaces in the wake-up slice.
+        var sliceAfter = await svc.RenderWakeupSliceAsync("repo-a", 600);
+        Assert.DoesNotContain(note, sliceAfter);
+    }
+
+    // ─── 2. Gate split — secret rejected ────────────────────────────────
+
+    [Fact]
+    public async Task Park_SecretNote_IsRejected_AndNotStored()
+    {
+        var svc = NewService(out var endStore, out _, new FakeTimeProvider(T0));
+
+        var result = await svc.ParkAsync("repo-a", "deploy key is AKIAIOSFODNN7EXAMPLE for the staging bucket");
+
+        Assert.False(result.Success);
+        Assert.Null(result.Id);
+        Assert.Contains("AWS access key", result.Reason);
+        Assert.Equal(0, endStore.Count);
+    }
+
+    // ─── 3. Gate split — terse/self-talk accepted ───────────────────────
+
+    [Theory]
+    [InlineData("revisit this")]                        // under the 20-char signal floor
+    [InlineData("i will fix the retry logic")]          // self-talk prefix
+    public async Task Park_TerseOrSelfTalkNote_IsAccepted_SignalGateSkipped(string note)
+    {
+        var svc = NewService(out var endStore, out _, new FakeTimeProvider(T0));
+
+        var result = await svc.ParkAsync("repo-a", note);
+
+        Assert.True(result.Success);
+        Assert.NotNull(result.Id);
+        Assert.Equal(1, endStore.Count);
+    }
+
+    // ─── 4. Promote re-enters the full gate (real adapter) ──────────────
+
+    [Fact]
+    public async Task Resolve_PromoteLowSignalNote_RejectedAtMemoryGate_StaysOpen()
+    {
+        var clock = new FakeTimeProvider(T0);
+        var endStore = new InMemoryLooseEndStore();
+        var memory = new MemoryService(new InMemoryEidetStore());
+        var promote = new MemoryServicePromotionAdapter(memory);
+        var svc = new LooseEndService(endStore, promote, clock);
+
+        // Terse self-talk parks fine (signal gate skipped) ...
+        var parked = await svc.ParkAsync("repo-a", "revisit this");
+        Assert.True(parked.Success);
+
+        // ... but promote re-enters the full signal gate, which rejects it.
+        var resolved = await svc.ResolveAsync(parked.Id!, ResolutionKind.Promoted);
+
+        Assert.False(resolved.Success);
+        Assert.NotNull(resolved.Reason);
+        Assert.Null(resolved.PromotedToMemoryId);
+
+        // Actual behavior: a rejected promote does NOT mark the end resolved — it stays open.
+        var stored = await endStore.GetAsync(parked.Id!);
+        Assert.NotNull(stored);
+        Assert.Equal(LooseEndState.Open, stored!.State);
+        Assert.Null(stored.Resolution);
+        Assert.Null(stored.ResolvedAt);
+
+        // It therefore still surfaces in the wake-up slice.
+        var slice = await svc.RenderWakeupSliceAsync("repo-a", 600);
+        Assert.Contains("revisit this", slice);
+    }
+
+    // ─── 5. Idempotent resolve ──────────────────────────────────────────
+
+    [Fact]
+    public async Task Resolve_Twice_IsNoOp_KeepsOriginalResolution_AndDoesNotRemint()
+    {
+        var clock = new FakeTimeProvider(T0);
+        var svc = NewService(out var endStore, out var promote, clock);
+
+        var parked = await svc.ParkAsync("repo-a", "tidy up the cache invalidation comments later");
+        Assert.True(parked.Success);
+
+        var first = await svc.ResolveAsync(parked.Id!, ResolutionKind.Done);
+        Assert.True(first.Success);
+        Assert.Equal(ResolutionKind.Done, first.Kind);
+        var firstResolvedAt = (await endStore.GetAsync(parked.Id!))!.ResolvedAt;
+        Assert.NotNull(firstResolvedAt);
+
+        clock.Advance(TimeSpan.FromHours(1));
+
+        // Second resolve, now as Promoted — must be a no-op returning current (Done) state.
+        var second = await svc.ResolveAsync(parked.Id!, ResolutionKind.Promoted);
+
+        Assert.True(second.Success);
+        Assert.Equal(LooseEndState.Resolved, second.State);
+        Assert.Equal(ResolutionKind.Done, second.Kind);    // unchanged — not re-labeled Promoted
+        Assert.Null(second.PromotedToMemoryId);
+
+        // No promotion was ever attempted — the promote port was never called, so no memory minted.
+        Assert.Equal(0, promote.CallCount);
+
+        // The original resolution kind and ResolvedAt are unchanged despite the advanced clock.
+        var stored = await endStore.GetAsync(parked.Id!);
+        Assert.Equal(ResolutionKind.Done, stored!.Resolution);
+        Assert.Equal(firstResolvedAt, stored.ResolvedAt);
+    }
+
+    // ─── 6. Wake-up cap & budget ────────────────────────────────────────
+
+    [Fact]
+    public async Task RenderWakeupSlice_CapsAtThree_WithPrefix_OldestFirstWithinTier()
+    {
+        var clock = new FakeTimeProvider(T0);
+        var svc = NewService(out _, out _, clock);
+
+        // Park 5 ends at the SAME priority; advance the clock between each so CreatedAt strictly
+        // increases. Same-tier ordering is unambiguous: oldest-first (CreatedAt asc).
+        async Task Park(string note)
+        {
+            await svc.ParkAsync(new ParkOptions("repo-a", note) { Priority = 2 });
+            clock.Advance(TimeSpan.FromMinutes(1));
+        }
+
+        await Park("oldest fix the flaky integration test");
+        await Park("second review the cache eviction path");
+        await Park("third audit the auth header parsing");
+        await Park("fourth check the migration ordering bug");
+        await Park("newest tidy the dead config flag");
+
+        var slice = await svc.RenderWakeupSliceAsync("repo-a", 600);
+
+        var lines = slice.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        Assert.Equal(3, lines.Length);                     // hard cap of 3
+
+        Assert.All(lines, l => Assert.StartsWith("[~] ", l)); // distinct open-work prefix
+
+        // Oldest-first within the tier: the three oldest parks, in creation order.
+        Assert.Contains("oldest fix the flaky integration test", lines[0]);
+        Assert.Contains("second review the cache eviction path", lines[1]);
+        Assert.Contains("third audit the auth header parsing", lines[2]);
+
+        // The two newest never made the cut.
+        Assert.DoesNotContain("dead config flag", slice);
+        Assert.DoesNotContain("migration ordering bug", slice);
+    }
+
+    [Fact]
+    public async Task RenderWakeupSlice_SurfacesHighPriorityFirst()
+    {
+        var clock = new FakeTimeProvider(T0);
+        var svc = NewService(out _, out _, clock);
+
+        async Task Park(string note, int priority)
+        {
+            await svc.ParkAsync(new ParkOptions("repo-a", note) { Priority = priority });
+            clock.Advance(TimeSpan.FromMinutes(1));
+        }
+
+        await Park("normal middle review the cache eviction path", 2);
+        await Park("low cleanup the dead config flag", 3);
+        await Park("high audit the auth header parsing", 1);
+
+        var slice = await svc.RenderWakeupSliceAsync("repo-a", 600);
+        var lines = slice.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+        // Intended: high (Priority 1) first, then normal (2), then low (3).
+        Assert.Contains("high audit the auth header parsing", lines[0]);
+        Assert.Contains("normal middle review the cache eviction path", lines[1]);
+        Assert.Contains("low cleanup the dead config flag", lines[2]);
+    }
+
+    [Fact]
+    public async Task RenderWakeupSlice_NeverExceedsTokenBudget()
+    {
+        var clock = new FakeTimeProvider(T0);
+        var svc = NewService(out _, out _, clock);
+
+        for (var i = 0; i < 5; i++)
+        {
+            await svc.ParkAsync("repo-a", $"this is a reasonably long parked note number {i} about some pending refactor work");
+            clock.Advance(TimeSpan.FromMinutes(1));
+        }
+
+        // A tight budget that fits at most one or two lines.
+        const int tinyBudget = 25;
+        var slice = await svc.RenderWakeupSliceAsync("repo-a", tinyBudget);
+
+        var estimatedTokens = (int)Math.Ceiling(slice.Length / 4.0);
+        Assert.True(estimatedTokens <= tinyBudget, $"slice spent {estimatedTokens} tokens, budget was {tinyBudget}");
+    }
+
+    [Fact]
+    public async Task RenderWakeupSlice_NoOpenEnds_ReturnsEmpty()
+    {
+        var svc = NewService(out _, out _, new FakeTimeProvider(T0));
+        var slice = await svc.RenderWakeupSliceAsync("repo-a", 600);
+        Assert.Equal("", slice);
+    }
+
+    // ─── 7. Recall ride-along ───────────────────────────────────────────
+
+    [Fact]
+    public async Task RideAlong_ReturnsOnlyOpenEndsWithOverlappingTags()
+    {
+        var clock = new FakeTimeProvider(T0);
+        var svc = NewService(out _, out _, clock);
+
+        var authEnd = await svc.ParkAsync(new ParkOptions("repo-a", "tighten the auth token refresh window")
+        {
+            Tags = ["auth", "security"],
+        });
+        clock.Advance(TimeSpan.FromMinutes(1));
+
+        await svc.ParkAsync(new ParkOptions("repo-a", "speed up the cache warm-up on cold start")
+        {
+            Tags = ["cache", "perf"],
+        });
+        clock.Advance(TimeSpan.FromMinutes(1));
+
+        // A resolved end with a matching tag must be excluded.
+        var resolvedEnd = await svc.ParkAsync(new ParkOptions("repo-a", "old auth note already handled")
+        {
+            Tags = ["auth"],
+        });
+        await svc.ResolveAsync(resolvedEnd.Id!, ResolutionKind.Done);
+
+        var matches = await svc.RideAlongAsync("repo-a", ["auth"]);
+
+        Assert.Single(matches);
+        Assert.Equal(authEnd.Id, matches[0].Id);
+    }
+
+    [Fact]
+    public async Task RideAlong_NoTags_ReturnsEmpty()
+    {
+        var svc = NewService(out _, out _, new FakeTimeProvider(T0));
+        await svc.ParkAsync(new ParkOptions("repo-a", "some open work with a tag") { Tags = ["x"] });
+
+        var matches = await svc.RideAlongAsync("repo-a", []);
+
+        Assert.Empty(matches);
+    }
+
+    // ─── 8. ID determinism ──────────────────────────────────────────────
+
+    [Fact]
+    public void IdGenerator_IsStableForSameInputs_AndDiffersWhenAnyInputChanges()
+    {
+        var now = T0;
+
+        var a = LooseEndIdGenerator.Generate("repo-a", "the note", now);
+        var same = LooseEndIdGenerator.Generate("repo-a", "the note", now);
+        Assert.Equal(a, same);
+
+        Assert.NotEqual(a, LooseEndIdGenerator.Generate("repo-b", "the note", now));
+        Assert.NotEqual(a, LooseEndIdGenerator.Generate("repo-a", "a different note", now));
+        Assert.NotEqual(a, LooseEndIdGenerator.Generate("repo-a", "the note", now.AddSeconds(1)));
+    }
+
+    [Fact]
+    public void IdGenerator_FormatIsLooseEndsRepoShortHash()
+    {
+        var id = LooseEndIdGenerator.Generate("repo-a", "the note", T0);
+
+        var parts = id.Split('/');
+        Assert.Equal(3, parts.Length);
+        Assert.Equal("looseends", parts[0]);
+        Assert.Equal("repo-a", parts[1]);
+        Assert.Equal(12, parts[2].Length);
+        Assert.Matches("^[0-9a-f]{12}$", parts[2]);
+    }
+
+    // ─── helpers ────────────────────────────────────────────────────────
+
+    private static LooseEndService NewService(
+        out InMemoryLooseEndStore endStore, out InMemoryPromotionAdapter promote, TimeProvider clock)
+    {
+        endStore = new InMemoryLooseEndStore();
+        promote = new InMemoryPromotionAdapter();
+        return new LooseEndService(endStore, promote, clock);
+    }
+}

--- a/tests/Eidet.Core.Tests/LooseEnds/LooseEndServiceTests.cs
+++ b/tests/Eidet.Core.Tests/LooseEnds/LooseEndServiceTests.cs
@@ -125,6 +125,53 @@ public class LooseEndServiceTests
         Assert.Contains("revisit this", slice);
     }
 
+    [Fact]
+    public async Task Resolve_PromoteWithExternalRef_LinksWithoutMinting_AndEchoesRef()
+    {
+        var clock = new FakeTimeProvider(T0);
+        var endStore = new InMemoryLooseEndStore();
+        var memory = new MemoryService(new InMemoryEidetStore());
+        var promote = new MemoryServicePromotionAdapter(memory);
+        var svc = new LooseEndService(endStore, promote, clock);
+
+        var parked = await svc.ParkAsync("repo-a", "track the upstream fix for the retry backoff race");
+
+        var resolved = await svc.ResolveAsync(parked.Id!, ResolutionKind.Promoted,
+            new ResolveOptions { ExternalRef = "gh#412" });
+
+        // Link-only: the external ref is recorded and echoed back, and no memory is minted.
+        Assert.True(resolved.Success);
+        Assert.Equal("gh#412", resolved.ExternalRef);
+        Assert.Null(resolved.PromotedToMemoryId);
+        Assert.Empty(await memory.RecallAsync("repo-a", "retry backoff race"));
+
+        var stored = await endStore.GetAsync(parked.Id!);
+        Assert.Equal("gh#412", stored!.ExternalRef);
+    }
+
+    [Fact]
+    public async Task Resolve_PromoteWithWhitespaceExternalRef_MintsMemory_NotBlankLink()
+    {
+        var clock = new FakeTimeProvider(T0);
+        var endStore = new InMemoryLooseEndStore();
+        var memory = new MemoryService(new InMemoryEidetStore());
+        var promote = new MemoryServicePromotionAdapter(memory);
+        var svc = new LooseEndService(endStore, promote, clock);
+
+        var parked = await svc.ParkAsync("repo-a",
+            "Possible race in the retry backoff path under high concurrency, revisit later");
+
+        // A stray whitespace-only promote_to must be treated as absent — mint the memory, never
+        // close the end as a link with a blank ref (which would silently drop the knowledge).
+        var resolved = await svc.ResolveAsync(parked.Id!, ResolutionKind.Promoted,
+            new ResolveOptions { ExternalRef = "   " });
+
+        Assert.True(resolved.Success);
+        Assert.NotNull(resolved.PromotedToMemoryId);
+        Assert.Null(resolved.ExternalRef);
+        Assert.Single(await memory.RecallAsync("repo-a", "retry backoff race"));
+    }
+
     // ─── 5. Idempotent resolve ──────────────────────────────────────────
 
     [Fact]

--- a/tests/Eidet.Core.Tests/LooseEnds/TestDoubles.cs
+++ b/tests/Eidet.Core.Tests/LooseEnds/TestDoubles.cs
@@ -1,0 +1,117 @@
+using Eidet.Core.LooseEnds;
+
+namespace Eidet.Core.Tests.LooseEnds;
+
+/// <summary>
+/// Minimal in-memory <see cref="ILooseEndStore"/> for Loose End tests. Mirrors the lock+dictionary
+/// style of <c>InMemoryEidetStore</c>. Ordering (Priority asc = high first, then CreatedAt asc) is
+/// applied on the open-view reads exactly as the Raven adapter does, so wake-up/pull ordering is testable here.
+/// </summary>
+internal sealed class InMemoryLooseEndStore : ILooseEndStore
+{
+    private readonly Dictionary<string, LooseEnd> _ends = new(StringComparer.OrdinalIgnoreCase);
+    private readonly object _lock = new();
+
+    public int Count
+    {
+        get { lock (_lock) return _ends.Count; }
+    }
+
+    public Task<string> StoreAsync(LooseEnd e, CancellationToken ct = default)
+    {
+        lock (_lock) _ends[e.Id] = e;
+        return Task.FromResult(e.Id);
+    }
+
+    public Task<LooseEnd?> GetAsync(string id, CancellationToken ct = default)
+    {
+        lock (_lock)
+        {
+            _ends.TryGetValue(id, out var e);
+            return Task.FromResult(e);
+        }
+    }
+
+    public Task UpdateAsync(LooseEnd e, CancellationToken ct = default)
+    {
+        lock (_lock) _ends[e.Id] = e;
+        return Task.CompletedTask;
+    }
+
+    public Task<IReadOnlyList<LooseEnd>> ListOpenAsync(string repoId, int max, CancellationToken ct = default)
+    {
+        lock (_lock)
+        {
+            var open = _ends.Values
+                .Where(e => string.Equals(e.RepoId, repoId, StringComparison.OrdinalIgnoreCase))
+                .Where(e => e.State == LooseEndState.Open);
+            return Task.FromResult<IReadOnlyList<LooseEnd>>(Order(open).Take(max).ToList());
+        }
+    }
+
+    public Task<IReadOnlyList<LooseEnd>> FindOpenByTagsAsync(
+        string repoId, IReadOnlyList<string> tags, int max, CancellationToken ct = default)
+    {
+        if (tags.Count == 0) return Task.FromResult<IReadOnlyList<LooseEnd>>([]);
+        lock (_lock)
+        {
+            var wanted = new HashSet<string>(tags, StringComparer.OrdinalIgnoreCase);
+            var matched = _ends.Values
+                .Where(e => string.Equals(e.RepoId, repoId, StringComparison.OrdinalIgnoreCase))
+                .Where(e => e.State == LooseEndState.Open)
+                .Where(e => e.Tags.Any(wanted.Contains));
+            return Task.FromResult<IReadOnlyList<LooseEnd>>(Order(matched).Take(max).ToList());
+        }
+    }
+
+    public Task<int> CountOpenAsync(string repoId, CancellationToken ct = default)
+    {
+        lock (_lock)
+        {
+            var count = _ends.Values.Count(e =>
+                string.Equals(e.RepoId, repoId, StringComparison.OrdinalIgnoreCase) &&
+                e.State == LooseEndState.Open);
+            return Task.FromResult(count);
+        }
+    }
+
+    private static IEnumerable<LooseEnd> Order(IEnumerable<LooseEnd> ends) =>
+        ends.OrderBy(e => e.Priority).ThenBy(e => e.CreatedAt);
+}
+
+/// <summary>
+/// Recording <see cref="IPromotionPort"/> test double. Captures the last promote call and returns a
+/// configurable <see cref="PromotionResult"/> (default: success minting a fake memory id) so the
+/// service-level promote wiring is testable without a real <c>MemoryService</c>.
+/// </summary>
+internal sealed class InMemoryPromotionAdapter : IPromotionPort
+{
+    public PromotionResult Next { get; set; } = new(true, "memories/fake/insight/abc123", null, null);
+    public LooseEnd? LastEnd { get; private set; }
+    public PromoteOptions? LastOptions { get; private set; }
+    public int CallCount { get; private set; }
+
+    public Task<PromotionResult> PromoteAsync(LooseEnd e, PromoteOptions opts, CancellationToken ct = default)
+    {
+        CallCount++;
+        LastEnd = e;
+        LastOptions = opts;
+        return Task.FromResult(Next);
+    }
+}
+
+/// <summary>
+/// Hand-rolled deterministic <see cref="TimeProvider"/> (no Microsoft.Extensions.TimeProvider.Testing
+/// dependency). Drives deterministic Loose End IDs and CreatedAt ordering. <see cref="Advance"/>
+/// moves the clock forward so parks get strictly increasing timestamps.
+/// </summary>
+internal sealed class FakeTimeProvider : TimeProvider
+{
+    private DateTimeOffset _now;
+
+    public FakeTimeProvider(DateTimeOffset start) => _now = start;
+
+    public override DateTimeOffset GetUtcNow() => _now;
+
+    public void Advance(TimeSpan by) => _now += by;
+}

--- a/tests/Eidet.Integration.Tests/Fixtures/EidetApiFixture.cs
+++ b/tests/Eidet.Integration.Tests/Fixtures/EidetApiFixture.cs
@@ -1,6 +1,8 @@
 using System.Net;
 using System.Net.Sockets;
 using Eidet.Core.Configuration;
+using Eidet.Core.LooseEnds;
+using Eidet.Core.LooseEnds.Promotion;
 using Eidet.Core.Maintenance;
 using Eidet.Core.Services;
 using Eidet.Core.Storage;
@@ -46,6 +48,10 @@ public class EidetApiFixture : IAsyncLifetime
             var exportSvc = new ExportService(eidetStore, memory: memorySvc);
             var qualitySvc = new QualityService(eidetStore);
 
+            var looseEndSvc = new LooseEndService(
+                new RavenLooseEndStore(_store), new MemoryServicePromotionAdapter(memorySvc), TimeProvider.System);
+            memorySvc.LooseEnds = looseEndSvc;
+
             var port = GetFreePort();
             BaseUrl = $"http://127.0.0.1:{port}";
 
@@ -58,6 +64,7 @@ public class EidetApiFixture : IAsyncLifetime
                 Consolidation = consolidationEngine,
                 Maintenance = maintenanceRunner,
                 Export = exportSvc,
+                LooseEnds = looseEndSvc,
                 BindAddress = "127.0.0.1",
                 Port = port,
                 Layers = layerSvc,

--- a/tests/Eidet.Service.Tests/Mcp/McpToolDefinitionsTests.cs
+++ b/tests/Eidet.Service.Tests/Mcp/McpToolDefinitionsTests.cs
@@ -1,10 +1,11 @@
+using Eidet.Core.LooseEnds;
 using Eidet.Core.Maintenance;
 using Eidet.Core.Domain;
 using Eidet.Core.Services;
 using Eidet.Core.Storage;
 using Eidet.Service.Mcp;
 using Eidet.Service.Tools;
-using Eidet.Service.Tools.Handlers;
+using Eidet.Service.Tests.Tools;
 
 namespace Eidet.Service.Tests.Mcp;
 
@@ -20,15 +21,23 @@ public class McpToolDefinitionsTests
         AllHandlers().Where(h => h.McpExposed).Select(h => h.Schema).ToList();
 
     [Fact]
-    public void All_Registers13Handlers()
+    public void All_Registers15Handlers()
     {
-        Assert.Equal(13, Tools.Count);
+        Assert.Equal(15, Tools.Count);
     }
 
     [Fact]
-    public void Exposed_Returns6Tools()
+    public void Exposed_Returns8Tools()
     {
-        Assert.Equal(6, Exposed.Count);
+        Assert.Equal(8, Exposed.Count);
+    }
+
+    [Theory]
+    [InlineData("eidet_park")]
+    [InlineData("eidet_resolve")]
+    public void Exposed_ContainsLooseEndTool(string toolName)
+    {
+        Assert.Contains(Exposed, t => t.Name == toolName);
     }
 
     [Theory]
@@ -99,6 +108,8 @@ public class McpToolDefinitionsTests
     [InlineData("eidet_edit")]
     [InlineData("eidet_pack_export")]
     [InlineData("eidet_pack_import")]
+    [InlineData("eidet_park")]
+    [InlineData("eidet_resolve")]
     public void All_ContainsTool(string toolName)
     {
         Assert.Contains(Tools, t => t.Name == toolName);
@@ -149,23 +160,11 @@ public class McpToolDefinitionsTests
         var consolidation = new ConsolidationEngine(store, enrichment: null, memory: svc);
         var intake = new IntakeService(store, svc);
         var maintenance = new StubMaintenanceRunner();
+        var looseEnds = new LooseEndService(new FakeLooseEndStore(), new FakePromotionPort(), TimeProvider.System);
 
-        return
-        [
-            new StoreToolHandler(svc),
-            new RecallToolHandler(svc),
-            new ForgetToolHandler(svc),
-            new FeedbackToolHandler(svc),
-            new HistoryToolHandler(svc),
-            new ContextToolHandler(svc),
-            new LinkToolHandler(svc),
-            new ConsolidateToolHandler(consolidation),
-            new MaintenanceToolHandler(maintenance),
-            new EditToolHandler(svc),
-            new IntakeToolHandler(intake),
-            new PackExportToolHandler(null),
-            new PackImportToolHandler(null, null),
-        ];
+        // Drive off the real factory so this test tracks the shipped dispatcher surface and can't
+        // silently drift from it (a hand-maintained list previously fell behind park/resolve).
+        return ToolDispatcherFactory.Create(svc, intake, consolidation, maintenance, looseEnds).Handlers;
     }
 
     private sealed class StubMaintenanceRunner : IMaintenanceRunner

--- a/tests/Eidet.Service.Tests/Tools/LooseEndTestDoubles.cs
+++ b/tests/Eidet.Service.Tests/Tools/LooseEndTestDoubles.cs
@@ -1,0 +1,53 @@
+using Eidet.Core.LooseEnds;
+
+namespace Eidet.Service.Tests.Tools;
+
+/// <summary>Dictionary-backed <see cref="ILooseEndStore"/> for the Park/Resolve handler tests.</summary>
+internal sealed class FakeLooseEndStore : ILooseEndStore
+{
+    public List<LooseEnd> All { get; } = [];
+
+    public Task<string> StoreAsync(LooseEnd e, CancellationToken ct = default)
+    {
+        All.Add(e);
+        return Task.FromResult(e.Id);
+    }
+
+    public Task<LooseEnd?> GetAsync(string id, CancellationToken ct = default) =>
+        Task.FromResult(All.FirstOrDefault(e => e.Id == id));
+
+    public Task UpdateAsync(LooseEnd e, CancellationToken ct = default)
+    {
+        var idx = All.FindIndex(x => x.Id == e.Id);
+        if (idx >= 0) All[idx] = e;
+        return Task.CompletedTask;
+    }
+
+    public Task<IReadOnlyList<LooseEnd>> ListOpenAsync(string repoId, int max, CancellationToken ct = default) =>
+        Task.FromResult<IReadOnlyList<LooseEnd>>(All
+            .Where(e => e.RepoId == repoId && e.State == LooseEndState.Open)
+            .OrderBy(e => e.Priority).ThenBy(e => e.CreatedAt)
+            .Take(max).ToList());
+
+    public Task<IReadOnlyList<LooseEnd>> FindOpenByTagsAsync(
+        string repoId, IReadOnlyList<string> tags, int max, CancellationToken ct = default)
+    {
+        if (tags.Count == 0) return Task.FromResult<IReadOnlyList<LooseEnd>>([]);
+        var wanted = new HashSet<string>(tags, StringComparer.OrdinalIgnoreCase);
+        return Task.FromResult<IReadOnlyList<LooseEnd>>(All
+            .Where(e => e.RepoId == repoId && e.State == LooseEndState.Open)
+            .Where(e => e.Tags.Any(wanted.Contains))
+            .OrderBy(e => e.Priority).ThenBy(e => e.CreatedAt)
+            .Take(max).ToList());
+    }
+
+    public Task<int> CountOpenAsync(string repoId, CancellationToken ct = default) =>
+        Task.FromResult(All.Count(e => e.RepoId == repoId && e.State == LooseEndState.Open));
+}
+
+/// <summary>Promote port that always succeeds with a fake memory id (handler tests don't exercise the gate).</summary>
+internal sealed class FakePromotionPort : IPromotionPort
+{
+    public Task<PromotionResult> PromoteAsync(LooseEnd e, PromoteOptions opts, CancellationToken ct = default) =>
+        Task.FromResult(new PromotionResult(true, "memories/test-repo/insight/abc123", null, null));
+}

--- a/tests/Eidet.Service.Tests/Tools/LooseEndTestDoubles.cs
+++ b/tests/Eidet.Service.Tests/Tools/LooseEndTestDoubles.cs
@@ -45,9 +45,14 @@ internal sealed class FakeLooseEndStore : ILooseEndStore
         Task.FromResult(All.Count(e => e.RepoId == repoId && e.State == LooseEndState.Open));
 }
 
-/// <summary>Promote port that always succeeds with a fake memory id (handler tests don't exercise the gate).</summary>
+/// <summary>
+/// Promote port that mirrors the real adapter's branch without the gate: a non-blank external ref
+/// links (no memory id), otherwise it mints a fake memory id. Handler tests don't exercise the gate.
+/// </summary>
 internal sealed class FakePromotionPort : IPromotionPort
 {
     public Task<PromotionResult> PromoteAsync(LooseEnd e, PromoteOptions opts, CancellationToken ct = default) =>
-        Task.FromResult(new PromotionResult(true, "memories/test-repo/insight/abc123", null, null));
+        Task.FromResult(string.IsNullOrWhiteSpace(opts.ExternalRef)
+            ? new PromotionResult(true, "memories/test-repo/insight/abc123", null, null)
+            : new PromotionResult(true, MemoryId: null, opts.ExternalRef, null));
 }

--- a/tests/Eidet.Service.Tests/Tools/ParkToolHandlerTests.cs
+++ b/tests/Eidet.Service.Tests/Tools/ParkToolHandlerTests.cs
@@ -1,0 +1,78 @@
+using System.Text.Json;
+using Eidet.Core.LooseEnds;
+using Eidet.Service.Tools;
+using Eidet.Service.Tools.Handlers;
+
+namespace Eidet.Service.Tests.Tools;
+
+public class ParkToolHandlerTests
+{
+    [Fact]
+    public async Task Park_ValidNote_ReturnsOkWithOpenState()
+    {
+        var handler = NewHandler(out var store);
+
+        var result = await Invoke(handler, new
+        {
+            note = "flaky integration test in the auth path, revisit the retry logic",
+            tags = new[] { "auth", "testing" },
+            priority = 1,
+        });
+
+        Assert.Equal(ToolStatus.Ok, result.Status);
+        Assert.Equal(1, result.ResultCount);
+        Assert.Contains("Parked:", result.HumanSummary);
+
+        // Payload carries { id, state = "open" }; tags + priority landed on the stored end.
+        var stored = Assert.Single(store.All);
+        Assert.Equal(LooseEndState.Open, stored.State);
+        Assert.Equal(1, stored.Priority);
+        Assert.Equal(["auth", "testing"], stored.Tags);
+    }
+
+    [Fact]
+    public async Task Park_DefaultPriority_IsNormal()
+    {
+        var handler = NewHandler(out var store);
+
+        var result = await Invoke(handler, new { note = "review the cache eviction policy on cold start" });
+
+        Assert.Equal(ToolStatus.Ok, result.Status);
+        Assert.Equal(2, store.All.Single().Priority);
+    }
+
+    [Fact]
+    public async Task Park_MissingNote_ThrowsMissingArgument()
+    {
+        var handler = NewHandler(out _);
+
+        await Assert.ThrowsAsync<MissingToolArgumentException>(async () =>
+            await Invoke(handler, new { tags = new[] { "x" } }));
+    }
+
+    [Fact]
+    public async Task Park_SecretNote_ReturnsRejected()
+    {
+        var handler = NewHandler(out var store);
+
+        var result = await Invoke(handler, new { note = "deploy key AKIAIOSFODNN7EXAMPLE for the bucket" });
+
+        Assert.Equal(ToolStatus.Rejected, result.Status);
+        Assert.Empty(store.All);
+    }
+
+    private static ParkToolHandler NewHandler(out FakeLooseEndStore store)
+    {
+        store = new FakeLooseEndStore();
+        var svc = new LooseEndService(store, new FakePromotionPort(), TimeProvider.System);
+        return new ParkToolHandler(svc);
+    }
+
+    private static Task<ToolResult> Invoke(ParkToolHandler handler, object args) =>
+        handler.ExecuteAsync(new ToolRequest(
+            "eidet_park",
+            "test-repo",
+            JsonSerializer.SerializeToElement(args),
+            "test",
+            CancellationToken.None));
+}

--- a/tests/Eidet.Service.Tests/Tools/RecallToolHandlerTests.cs
+++ b/tests/Eidet.Service.Tests/Tools/RecallToolHandlerTests.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Eidet.Core.Domain;
+using Eidet.Core.LooseEnds;
 using Eidet.Core.Services;
 using Eidet.Core.Storage;
 using Eidet.Service.Tools;
@@ -47,6 +48,45 @@ public class RecallToolHandlerTests
         Assert.Contains("1 memory(ies) found:", result.HumanSummary);
         Assert.Contains("[I] RavenDB persistence", result.HumanSummary);
         Assert.Contains("id=memories/r/insight/abc", result.HumanSummary);
+    }
+
+    [Fact]
+    public async Task Recall_WithMatchingLooseEndTags_IncludesRideAlongSection()
+    {
+        var endStore = new FakeLooseEndStore();
+        var looseEnds = new LooseEndService(endStore, new FakePromotionPort(), TimeProvider.System);
+        await looseEnds.ParkAsync(new ParkOptions("test-repo", "revisit the retry backoff in the auth client")
+        {
+            Tags = ["auth", "retry"],
+        });
+
+        var svc = new MemoryService(new RecallStore());
+        var handler = new RecallToolHandler(svc, looseEnds);
+
+        var result = await Invoke(handler, new { query = "auth", tags = new[] { "auth" } });
+
+        Assert.Equal(ToolStatus.Ok, result.Status);
+        Assert.Contains("open loose end(s) matching your tags", result.HumanSummary);
+        Assert.Contains("[~] revisit the retry backoff in the auth client", result.HumanSummary);
+    }
+
+    [Fact]
+    public async Task Recall_NoTags_OmitsRideAlongSection()
+    {
+        var endStore = new FakeLooseEndStore();
+        var looseEnds = new LooseEndService(endStore, new FakePromotionPort(), TimeProvider.System);
+        await looseEnds.ParkAsync(new ParkOptions("test-repo", "revisit the retry backoff in the auth client")
+        {
+            Tags = ["auth"],
+        });
+
+        var svc = new MemoryService(new RecallStore());
+        var handler = new RecallToolHandler(svc, looseEnds);
+
+        // No tags on the query → ride-along is tag-gated, so nothing surfaces and the result is empty.
+        var result = await Invoke(handler, new { query = "auth" });
+
+        Assert.DoesNotContain("loose end", result.HumanSummary);
     }
 
     [Fact]

--- a/tests/Eidet.Service.Tests/Tools/ResolveToolHandlerTests.cs
+++ b/tests/Eidet.Service.Tests/Tools/ResolveToolHandlerTests.cs
@@ -24,6 +24,24 @@ public class ResolveToolHandlerTests
     }
 
     [Fact]
+    public async Task Resolve_PromoteWithExternalRef_EchoesRefInPayload_WithoutMinting()
+    {
+        var handler = NewHandler(out var store);
+        var id = await Park(store, "track the upstream fix for the retry backoff race");
+
+        var result = await Invoke(handler, new { id, kind = "promoted", promote_to = "gh#412" });
+
+        Assert.Equal(ToolStatus.Ok, result.Status);
+
+        var payload = JsonSerializer.SerializeToElement(result.Payload);
+        Assert.Equal("gh#412", payload.GetProperty("externalRef").GetString());
+        Assert.Equal("resolved", payload.GetProperty("state").GetString());
+        Assert.Equal(JsonValueKind.Null, payload.GetProperty("promotedToMemoryId").ValueKind);
+
+        Assert.Equal("gh#412", (await store.GetAsync(id))!.ExternalRef);
+    }
+
+    [Fact]
     public async Task Resolve_InvalidKind_ReturnsBadRequest()
     {
         var handler = NewHandler(out var store);

--- a/tests/Eidet.Service.Tests/Tools/ResolveToolHandlerTests.cs
+++ b/tests/Eidet.Service.Tests/Tools/ResolveToolHandlerTests.cs
@@ -1,0 +1,104 @@
+using System.Text.Json;
+using Eidet.Core.LooseEnds;
+using Eidet.Service.Tools;
+using Eidet.Service.Tools.Handlers;
+
+namespace Eidet.Service.Tests.Tools;
+
+public class ResolveToolHandlerTests
+{
+    [Fact]
+    public async Task Resolve_ValidKind_ReturnsOkWithResolvedState()
+    {
+        var handler = NewHandler(out var store);
+        var id = await Park(store, "tidy up the migration ordering before the next release");
+
+        var result = await Invoke(handler, new { id, kind = "done" });
+
+        Assert.Equal(ToolStatus.Ok, result.Status);
+        Assert.Contains("Resolved", result.HumanSummary);
+
+        var stored = await store.GetAsync(id);
+        Assert.Equal(LooseEndState.Resolved, stored!.State);
+        Assert.Equal(ResolutionKind.Done, stored.Resolution);
+    }
+
+    [Fact]
+    public async Task Resolve_InvalidKind_ReturnsBadRequest()
+    {
+        var handler = NewHandler(out var store);
+        var id = await Park(store, "audit the auth header parsing for edge cases");
+
+        var result = await Invoke(handler, new { id, kind = "finished" });
+
+        Assert.Equal(ToolStatus.BadRequest, result.Status);
+        Assert.Contains("Invalid kind", result.HumanSummary);
+
+        // Nothing was resolved.
+        var stored = await store.GetAsync(id);
+        Assert.Equal(LooseEndState.Open, stored!.State);
+    }
+
+    [Fact]
+    public async Task Resolve_MissingKind_ThrowsMissingArgument()
+    {
+        var handler = NewHandler(out var store);
+        var id = await Park(store, "follow up on the cache warm-up regression");
+
+        await Assert.ThrowsAsync<MissingToolArgumentException>(async () =>
+            await Invoke(handler, new { id }));
+    }
+
+    [Fact]
+    public async Task Resolve_MissingKind_ViaDispatcher_IsBadRequest()
+    {
+        var handler = NewHandler(out var store);
+        var id = await Park(store, "follow up on the cache warm-up regression");
+        var dispatcher = new ToolDispatcher([handler]);
+
+        var result = await dispatcher.InvokeAsync(new ToolRequest(
+            "eidet_resolve", "test-repo",
+            JsonSerializer.SerializeToElement(new { id }), "test", CancellationToken.None));
+
+        Assert.Equal(ToolStatus.BadRequest, result.Status);
+    }
+
+    [Fact]
+    public async Task Resolve_UnknownId_ReturnsNotFound()
+    {
+        var handler = NewHandler(out _);
+
+        var result = await Invoke(handler, new { id = "looseends/test-repo/deadbeef0000", kind = "done" });
+
+        Assert.Equal(ToolStatus.NotFound, result.Status);
+        Assert.Contains("not found", result.HumanSummary, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static ResolveToolHandler NewHandler(out FakeLooseEndStore store)
+    {
+        store = new FakeLooseEndStore();
+        var svc = new LooseEndService(store, new FakePromotionPort(), TimeProvider.System);
+        return new ResolveToolHandler(svc);
+    }
+
+    private static async Task<string> Park(FakeLooseEndStore store, string note)
+    {
+        var end = new LooseEnd
+        {
+            Id = $"looseends/test-repo/{Guid.NewGuid():N}"[..40],
+            RepoId = "test-repo",
+            Note = note,
+            CreatedAt = DateTimeOffset.UtcNow,
+        };
+        await store.StoreAsync(end);
+        return end.Id;
+    }
+
+    private static Task<ToolResult> Invoke(ResolveToolHandler handler, object args) =>
+        handler.ExecuteAsync(new ToolRequest(
+            "eidet_resolve",
+            "test-repo",
+            JsonSerializer.SerializeToElement(args),
+            "test",
+            CancellationToken.None));
+}


### PR DESCRIPTION
## Summary

Implements **LooseEndSpec v1** ([`docs/specs/LooseEndSpec.md`](../blob/feat/loose-ends/docs/specs/LooseEndSpec.md)) — a first-class **Loose End**: a way for an agent to *park* a terse, low-context, still-actionable note mid-task (a suspected bug, out-of-scope work) and reliably get it back until it is explicitly *resolved*. Open work, not recalled knowledge.

A Loose End is a sibling of `MemoryEntry`, **not** a 5th `MemoryType` and not a status flag — it lives in its own `looseends/*` collection, so the "no decay / no consolidation / no dedup" invariant is **structural** (no maintenance stage ever enumerates it), not a set of exemption flags.

## What's included (v1 MVP)

- **Domain** — `LooseEnd` doc + `LooseEndState` / `ResolutionKind` (`Done`/`Dropped`/`Promoted`/`Superseded`); deterministic `looseends/{repoId}/{shortHash}` ids.
- **Three ports** — `ILooseEndStore` (Raven + in-memory), `IPromotionPort` (the **sole** edge into the gated `MemoryService.StoreAsync`), and `TimeProvider` for deterministic ids/ordering.
- **`LooseEndService`** facade — one-call park (secret-scan only, signal gate **skipped** by design), idempotent typed resolve, one-call promote-to-memory.
- **MCP surface 6 → 8** — `eidet_park` + `eidet_resolve` (`kind` **required** at the tool layer). Human list/browse stays REST-only.
- **REST** — `POST /api/eidet/loose-ends`, `POST /api/eidet/loose-ends/{id}/resolve`, `GET /api/eidet/loose-ends?state=open`.
- **Three surfacing modes** — wake-up slice in `GetContextAsync` (cap 3, ~120 tok carved from L1, high-priority-first then oldest, `[~]` prefix, L0 open-count addendum); recall ride-along (tag overlap, separate result section); explicit REST pull list.

## The gate split (security-relevant)

Park is low-friction but **secret scanning is always-on**: `ParkAsync` calls `SecretScanRule.Check` directly and skips the signal gate (terse/speculative notes are the point). **Promote re-enters the full gate** — a promoted memory goes through `MemoryService.StoreAsync` (secret + signal, dedup, hooks) via `IPromotionPort`, the single enforcement point. Park never reaches `StoreAsync`.

## How it was built

Shipped through the `/implement-issue` pipeline: implement → test → parallel code-review + spec-conformance audit → fix. The two audits surfaced 2 blocking + 2 should-fix items, **all addressed in this PR**:

1. **(blocking)** Wake-up ordering was `OrderByDescending(Priority)` on a `1=high/3=low` scale — surfaced *low*-priority first. Flipped to ascending; corrected the spec's contradicting "Priority desc" wording.
2. **(blocking)** Recall ride-along existed on the service but wasn't wired into `eidet_recall` — now wired as a separate, capped section.
3. **(should-fix)** Wake-up no longer materializes the open set for a count (added server-side `CountOpenAsync`; `ListOpenAsync` orders/pages server-side).
4. **(should-fix)** Promote-onto-duplicate now resolves onto the existing memory instead of stranding the end open.

## Tests

Build clean (0 warnings). **Core 505/505**, **Service 203/203** — includes end-to-end park→slice→promote, the gate-split (secret rejected / terse accepted / promote re-gated), idempotent resolve, wake-up cap+budget+ordering, and recall ride-along.

🤖 Generated with [Claude Code](https://claude.com/claude-code)