### PR TITLE
feat(recall): hybrid fusion + rerank-before-truncate + dual-clock recency (#33 spine)

### DIFF
--- a/src/Eidet.Core/Maintenance/FadeMemCurve.cs
+++ b/src/Eidet.Core/Maintenance/FadeMemCurve.cs
@@ -30,4 +30,24 @@ public static class FadeMemCurve
         var decayFactor = Math.Pow(2, -shapedAge);
         return Math.Max(Floor, (float)(importance * decayFactor));
     }
+
+    /// <summary>
+    /// Dual-clock recency in 0..1 using the per-type curve: a memory is "fresh" if it was either
+    /// created or last accessed recently, so the more-recent clock dominates. When
+    /// <paramref name="lastAccessedAt"/> is null only creation age is considered.
+    /// Deterministic, no decay floor (this is a recency signal, not decayed importance).
+    /// </summary>
+    public static double Recency(DateTime createdAt, DateTime? lastAccessedAt, DateTime now, MemoryType type)
+    {
+        var (halfLife, shape) = Defaults[type];
+        var createdRecency = DecayUnit(Math.Max(0, (now - createdAt).TotalDays), halfLife, shape);
+        if (lastAccessedAt is not { } accessed)
+            return createdRecency;
+        var accessRecency = DecayUnit(Math.Max(0, (now - accessed).TotalDays), halfLife, shape);
+        return Math.Max(createdRecency, accessRecency);
+    }
+
+    /// <summary>Bare 0..1 decay (no importance scale, no floor) shared by <see cref="Recency"/>.</summary>
+    private static double DecayUnit(double ageDays, double halfLifeDays, double shape) =>
+        Math.Pow(2, -Math.Pow(ageDays / halfLifeDays, shape));
 }

--- a/src/Eidet.Core/Memory/RecallExplanation.cs
+++ b/src/Eidet.Core/Memory/RecallExplanation.cs
@@ -1,0 +1,11 @@
+namespace Eidet.Core.Memory;
+
+/// <summary>
+/// Diagnostic breakdown of a recall fusion, produced by <c>MemoryService.ExplainRecallAsync</c>.
+/// Surfaces the per-candidate component scores BEFORE type budgeting and the de-boost/staleness
+/// pass, so callers can see exactly how each candidate was ranked. Never touches the recall cache.
+/// </summary>
+public sealed record RecallExplanation(IReadOnlyList<RecallExplanationRow> Rows, double AlphaUsed, int CandidatePool);
+
+/// <summary>One candidate's fusion components: normalized arm scores plus recency + UCB contributions and the total.</summary>
+public sealed record RecallExplanationRow(string Id, double Lex, double Vec, double Recency, double Ucb, double Fused);

--- a/src/Eidet.Core/Memory/RecallScoring.cs
+++ b/src/Eidet.Core/Memory/RecallScoring.cs
@@ -1,11 +1,28 @@
 using Eidet.Core.Domain;
+using Eidet.Core.Maintenance;
+using Eidet.Core.Storage;
 
 namespace Eidet.Core.Memory;
 
 /// <summary>
+/// Tuning knobs for hybrid fusion. <see cref="Alpha"/> blends lexical vs vector arms
+/// (lexical weight); <see cref="Kappa"/> scales the UCB exploration bonus; <see cref="TotalN"/>
+/// is the candidate-pool feedback total (Σ Echo+Fizzle) the caller supplies for the UCB term.
+/// </summary>
+public readonly record struct RecallWeights(double Alpha, double Kappa, long TotalN)
+{
+    public static RecallWeights Default => new(Alpha: 0.5, Kappa: 0.3, TotalN: 0);
+}
+
+/// <summary>Per-candidate fusion breakdown: normalized arm scores, recency + UCB components, and the total.</summary>
+public readonly record struct FusedCandidate(
+    MemoryEntry Entry, double Lex, double Vec, double Recency, double Ucb, double Fused);
+
+/// <summary>
 /// Pure scoring + budgeting helpers for the recall and L1-context pipelines.
-/// FadeMem-style recency curve with a 7-day half-life; importance and access frequency
-/// fold in as additive weights. Type budgets enforce ENGRAM-style diversity.
+/// <see cref="Fuse"/> is the single home of the hybrid recall ranking math (min-max-normalized
+/// lexical+vector blend + UCB exploration + dual-clock FadeMem recency). FadeMem-style recency
+/// folds both creation and last-access clocks; type budgets enforce ENGRAM-style diversity.
 /// </summary>
 public static class RecallScoring
 {
@@ -16,12 +33,85 @@ public static class RecallScoring
         var importance = (double)entry.Importance;
         var confidence = (double)entry.Confidence;
 
-        var daysSinceCreation = Math.Max(0, (now - entry.CreatedAt).TotalDays);
-        var recency = Math.Exp(-0.693 * daysSinceCreation / RecencyHalfLifeDays);
+        // Dual-clock recency on the L1 wake-up curve: a memory accessed recently stays fresh even
+        // if created long ago, so the more-recent clock dominates (null LastAccessedAt → creation
+        // only). This keeps the fixed 7-day half-life the wake-up context has always used — distinct
+        // from the per-type FadeMem curve recall fusion uses (see Fuse); the two surfaces rank for
+        // different purposes and are deliberately not unified.
+        var recency = SevenDayRecency(entry.CreatedAt, now);
+        if (entry.LastAccessedAt is { } accessed)
+            recency = Math.Max(recency, SevenDayRecency(accessed, now));
 
         var frequency = Math.Min(1.0, entry.AccessCount / 10.0);
 
         return importance * 0.3 + confidence * 0.15 + recency * 0.25 + frequency * 0.3;
+    }
+
+    private static double SevenDayRecency(DateTime clock, DateTime now) =>
+        Math.Exp(-0.693 * Math.Max(0, (now - clock).TotalDays) / RecencyHalfLifeDays);
+
+    /// <summary>
+    /// The single source of the hybrid recall ranking. Min-max-normalizes each arm independently
+    /// (empty arm → 0 for every candidate; single-candidate or all-equal arm → 1.0 to dodge a
+    /// divide-by-zero), outer-joins the two arms by <see cref="MemoryEntry.Id"/>, then scores each
+    /// candidate as <c>Alpha·normLex + (1-Alpha)·normVec + UCB + recency</c> where UCB =
+    /// <c>Kappa·sqrt(ln(TotalN+1)/(Echo+Fizzle+1))</c> rewards rarely-surfaced memories and recency
+    /// is the per-type dual-clock FadeMem curve. Returns candidates sorted by fused score descending.
+    /// </summary>
+    public static List<FusedCandidate> Fuse(
+        IReadOnlyList<ScoredHit> lex, IReadOnlyList<ScoredHit> vec, RecallWeights w, DateTime now)
+    {
+        var normLex = Normalize(lex);
+        var normVec = Normalize(vec);
+
+        var entries = new Dictionary<string, MemoryEntry>(StringComparer.OrdinalIgnoreCase);
+        foreach (var hit in lex) entries.TryAdd(hit.Entry.Id, hit.Entry);
+        foreach (var hit in vec) entries.TryAdd(hit.Entry.Id, hit.Entry);
+
+        var lnN = Math.Log(w.TotalN + 1);
+
+        var fused = new List<FusedCandidate>(entries.Count);
+        foreach (var (id, entry) in entries)
+        {
+            var l = normLex.GetValueOrDefault(id);
+            var v = normVec.GetValueOrDefault(id);
+            var ucb = w.Kappa * Math.Sqrt(lnN / (entry.EchoCount + entry.FizzleCount + 1));
+            var recency = FadeMemCurve.Recency(entry.CreatedAt, entry.LastAccessedAt, now, entry.Type);
+            var score = w.Alpha * l + (1 - w.Alpha) * v + ucb + recency;
+            fused.Add(new FusedCandidate(entry, l, v, recency, ucb, score));
+        }
+
+        fused.Sort((a, b) => b.Fused.CompareTo(a.Fused));
+        return fused;
+    }
+
+    /// <summary>Convenience projection: fuse, then map to <see cref="MemorySearchResult"/> carrying the fused score.</summary>
+    public static List<MemorySearchResult> FuseAndScore(
+        IReadOnlyList<ScoredHit> lex, IReadOnlyList<ScoredHit> vec, RecallWeights w, DateTime now) =>
+        Fuse(lex, vec, w, now).Select(c => ToSearchResult(c.Entry, (float)c.Fused)).ToList();
+
+    /// <summary>
+    /// Min-max normalizes an arm's raw scores to 0..1 keyed by entry id. Empty arm → empty map
+    /// (every candidate degrades to 0 for this arm); all-equal scores (max==min, includes the
+    /// single-candidate case) → 1.0 to avoid a divide-by-zero.
+    /// </summary>
+    private static Dictionary<string, double> Normalize(IReadOnlyList<ScoredHit> arm)
+    {
+        var map = new Dictionary<string, double>(arm.Count, StringComparer.OrdinalIgnoreCase);
+        if (arm.Count == 0) return map;
+
+        var min = double.MaxValue;
+        var max = double.MinValue;
+        foreach (var hit in arm)
+        {
+            if (hit.Score < min) min = hit.Score;
+            if (hit.Score > max) max = hit.Score;
+        }
+
+        var range = max - min;
+        foreach (var hit in arm)
+            map[hit.Entry.Id] = range > 0 ? (hit.Score - min) / range : 1.0;
+        return map;
     }
 
     public static List<MemorySearchResult> ApplyTypeBudgets(List<MemorySearchResult> results, int limit)

--- a/src/Eidet.Core/Services/MemoryService.cs
+++ b/src/Eidet.Core/Services/MemoryService.cs
@@ -361,20 +361,14 @@ public sealed class MemoryService
             return cached;
 
         var repoIds = scope.RepoIds.ToList();
-        var textTask = _store.FullTextSearchAsync(repoIds, query, ct);
-        var vectorTask = _store.VectorSearchAsync(repoIds, query, ct);
-        await Task.WhenAll(textTask, vectorTask);
-
-        var merged = new List<MemorySearchResult>();
-        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        foreach (var entry in textTask.Result)
-            if (seen.Add(entry.Id))
-                merged.Add(RecallScoring.ToSearchResult(entry, score: 1.0f));
-        foreach (var entry in vectorTask.Result)
-            if (seen.Add(entry.Id))
-                merged.Add(RecallScoring.ToSearchResult(entry, score: 0.9f));
+        var lexTask = _store.SearchScoredAsync(SearchArm.Lexical, repoIds, query, ct);
+        var vecTask = _store.SearchScoredAsync(SearchArm.Vector, repoIds, query, ct);
+        await Task.WhenAll(lexTask, vecTask);
 
         var now = DateTime.UtcNow;
+        var weights = RecallWeights.Default with { TotalN = ComputeTotalN(lexTask.Result, vecTask.Result) };
+        var merged = RecallScoring.FuseAndScore(lexTask.Result, vecTask.Result, weights, now);
+
         var staleAfter = StalenessWarningDays;
         foreach (var result in merged)
         {
@@ -402,6 +396,41 @@ public sealed class MemoryService
         _cache.Set(cacheKey, observed, budgeted);
 
         return budgeted;
+    }
+
+    /// <summary>
+    /// Diagnostic recall: runs the SAME fuse pipeline as <see cref="RecallInternalAsync"/> (resolve
+    /// scope → two scored arms → <see cref="RecallScoring.Fuse"/>) and returns the per-candidate
+    /// component breakdown instead of budgeted results. Bypasses the recall cache and fires no hooks —
+    /// it must not perturb live recall state.
+    /// </summary>
+    public async Task<RecallExplanation> ExplainRecallAsync(
+        string repoId, RecallOptions opts, CancellationToken ct = default)
+    {
+        var query = ToMemoryQuery(opts);
+        var scope = await ResolveScopeAsync(repoId, opts.CrossRepo, ct);
+        var repoIds = scope.RepoIds.ToList();
+
+        var lexTask = _store.SearchScoredAsync(SearchArm.Lexical, repoIds, query, ct);
+        var vecTask = _store.SearchScoredAsync(SearchArm.Vector, repoIds, query, ct);
+        await Task.WhenAll(lexTask, vecTask);
+
+        var weights = RecallWeights.Default with { TotalN = ComputeTotalN(lexTask.Result, vecTask.Result) };
+        var fused = RecallScoring.Fuse(lexTask.Result, vecTask.Result, weights, DateTime.UtcNow);
+
+        var rows = fused
+            .Select(c => new RecallExplanationRow(c.Entry.Id, c.Lex, c.Vec, c.Recency, c.Ucb, c.Fused))
+            .ToList();
+        return new RecallExplanation(rows, weights.Alpha, rows.Count);
+    }
+
+    /// <summary>Σ (Echo+Fizzle) over the lex∪vec union (dedup by id) — the UCB exploration denominator base.</summary>
+    private static long ComputeTotalN(IReadOnlyList<ScoredHit> lex, IReadOnlyList<ScoredHit> vec)
+    {
+        var seen = new Dictionary<string, MemoryEntry>(StringComparer.OrdinalIgnoreCase);
+        foreach (var hit in lex) seen.TryAdd(hit.Entry.Id, hit.Entry);
+        foreach (var hit in vec) seen.TryAdd(hit.Entry.Id, hit.Entry);
+        return seen.Values.Sum(e => (long)e.EchoCount + e.FizzleCount);
     }
 
     public async Task<string> GetContextAsync(string repoId, int maxTokens = 600, CancellationToken ct = default)
@@ -515,7 +544,9 @@ public sealed class MemoryService
     private async Task BumpAccessCountsAsync(List<MemorySearchResult> results, string repoId, CancellationToken ct)
     {
         // Access tracking is a justified exemption from cache invalidation: AccessCount /
-        // LastAccessedAt are not in the cache key and do not affect recall scoring.
+        // LastAccessedAt are not in the recall cache key. LastAccessedAt does feed dual-clock
+        // recency (#33), so a cached recall can be marginally stale on recency — bounded and
+        // acceptable within the cache's short TTL; invalidating on every recall would defeat it.
         // The dedicated patch-only ctx prevents this path from accidentally writing other fields.
         var ctx = new AccessTrackingCtx(_store);
         try
@@ -828,8 +859,8 @@ public readonly struct BulkMutationCtx
 /// Access-tracking gate. Exposes only the patch-only <c>BumpAsync</c> method — the API
 /// itself cannot be tricked into writing fields other than <c>AccessCount</c> and
 /// <c>LastAccessedAt</c>. Used by the recall path's access-count side-effect, which is a
-/// justified exemption from cache invalidation (the patched fields are not in the cache key
-/// and do not affect recall scoring).
+/// justified exemption from cache invalidation (the patched fields are not in the recall cache
+/// key; the recency staleness LastAccessedAt can introduce is bounded by the short cache TTL).
 /// </summary>
 internal readonly struct AccessTrackingCtx
 {

--- a/src/Eidet.Core/Storage/IEidetStore.cs
+++ b/src/Eidet.Core/Storage/IEidetStore.cs
@@ -2,6 +2,12 @@ using Eidet.Core.Domain;
 
 namespace Eidet.Core.Storage;
 
+/// <summary>One hit from a single search arm, carrying that arm's raw relevance score.</summary>
+public readonly record struct ScoredHit(MemoryEntry Entry, double Score);
+
+/// <summary>The two arms of hybrid search — lexical (full-text) and semantic (vector).</summary>
+public enum SearchArm { Lexical, Vector }
+
 public interface IEidetStore
 {
     Task<MemoryEntry?> GetAsync(string id, CancellationToken ct = default);
@@ -11,15 +17,40 @@ public interface IEidetStore
 
     /// <summary>
     /// Patch the access-tracking fields (<c>AccessCount</c>, <c>LastAccessedAt</c>) without
-    /// touching any other field. Cache-invariant safe: these fields are not in the recall
-    /// cache key and do not affect recall scoring, so writes through this path do not
-    /// invalidate the recall cache. The default implementation is a no-op so test fakes
-    /// don't have to opt in unless they care about access tracking.
+    /// touching any other field. These fields are not in the recall cache key, so writes through
+    /// this path do not invalidate the recall cache; <c>LastAccessedAt</c> does feed dual-clock
+    /// recency, so a cached recall may be marginally stale on recency — bounded by the short cache
+    /// TTL. The default implementation is a no-op so test fakes don't have to opt in unless they
+    /// care about access tracking.
     /// </summary>
     Task PatchAccessAsync(string entryId, DateTime lastAccessedAt, CancellationToken ct = default) =>
         Task.CompletedTask;
     Task<List<MemoryEntry>> FullTextSearchAsync(IReadOnlyList<string> repoIds, MemoryQuery query, CancellationToken ct = default);
     Task<List<MemoryEntry>> VectorSearchAsync(IReadOnlyList<string> repoIds, MemoryQuery query, CancellationToken ct = default);
+
+    /// <summary>
+    /// One arm of hybrid search, ranked, with the backend's raw relevance surfaced as
+    /// <see cref="ScoredHit.Score"/> (RavenDB's lexical <c>@index-score</c> for the lexical arm,
+    /// vector similarity for the vector arm). The caller fuses the two arms.
+    /// Vector arm returns [] when embeddings are unconfigured (caller degrades to lexical-only).
+    /// The default implementation delegates to the arm's existing entity method and assigns a
+    /// rank-decay score (<c>1, 1/2, 1/3, …</c>) so fakes that don't surface real scores still
+    /// produce a sensible ordering without opting in.
+    /// </summary>
+    Task<IReadOnlyList<ScoredHit>> SearchScoredAsync(
+        SearchArm arm, IReadOnlyList<string> repoIds, MemoryQuery query, CancellationToken ct = default) =>
+        SearchScoredViaRankDecayAsync(arm, repoIds, query, ct);
+
+    /// <summary>Shared rank-decay fallback used by the default impl and by arms that can't surface a per-hit score.</summary>
+    private async Task<IReadOnlyList<ScoredHit>> SearchScoredViaRankDecayAsync(
+        SearchArm arm, IReadOnlyList<string> repoIds, MemoryQuery query, CancellationToken ct)
+    {
+        var entries = arm == SearchArm.Lexical
+            ? await FullTextSearchAsync(repoIds, query, ct)
+            : await VectorSearchAsync(repoIds, query, ct);
+        return entries.Select((e, rank) => new ScoredHit(e, 1.0 / (rank + 1))).ToList();
+    }
+
     Task<MemoryEntry?> FindDuplicateAsync(string repoId, string content, float threshold, CancellationToken ct = default);
 
     /// <summary>

--- a/src/Eidet.Core/Storage/RavenEidetStore.cs
+++ b/src/Eidet.Core/Storage/RavenEidetStore.cs
@@ -71,7 +71,21 @@ public class RavenEidetStore : IEidetStore
     }
 
     public async Task<List<MemoryEntry>> FullTextSearchAsync(
-        IReadOnlyList<string> repoIds, MemoryQuery query, CancellationToken ct = default)
+        IReadOnlyList<string> repoIds, MemoryQuery query, CancellationToken ct = default) =>
+        (await SearchScoredAsync(SearchArm.Lexical, repoIds, query, ct)).Select(h => h.Entry).ToList();
+
+    public async Task<List<MemoryEntry>> VectorSearchAsync(
+        IReadOnlyList<string> repoIds, MemoryQuery query, CancellationToken ct = default) =>
+        (await SearchScoredAsync(SearchArm.Vector, repoIds, query, ct)).Select(h => h.Entry).ToList();
+
+    public Task<IReadOnlyList<ScoredHit>> SearchScoredAsync(
+        SearchArm arm, IReadOnlyList<string> repoIds, MemoryQuery query, CancellationToken ct = default) =>
+        arm == SearchArm.Lexical
+            ? LexicalScoredAsync(repoIds, query, ct)
+            : VectorScoredAsync(repoIds, query, ct);
+
+    private async Task<IReadOnlyList<ScoredHit>> LexicalScoredAsync(
+        IReadOnlyList<string> repoIds, MemoryQuery query, CancellationToken ct)
     {
         using var session = _store.OpenAsyncSession();
         // WhereIn MUST come before Search to ensure AND semantics.
@@ -81,14 +95,16 @@ public class RavenEidetStore : IEidetStore
             .AsyncDocumentQuery<MemoryEntry, Memories_Search>()
             .WhereIn("RepoId", repoIds)
             .AndAlso()
-            .Search("SearchText", query.Text);
+            .Search("SearchText", query.Text)
+            .OrderByScore();
 
         documentQuery = ApplyFilters(documentQuery, query);
-        return await documentQuery.Take(query.Limit * 2).ToListAsync(ct); // Over-fetch 2× for merge quality
+        var hits = await documentQuery.Take(query.Limit * 2).ToListAsync(ct); // Over-fetch 2× for merge quality
+        return ToScoredHits(session, hits);
     }
 
-    public async Task<List<MemoryEntry>> VectorSearchAsync(
-        IReadOnlyList<string> repoIds, MemoryQuery query, CancellationToken ct = default)
+    private async Task<IReadOnlyList<ScoredHit>> VectorScoredAsync(
+        IReadOnlyList<string> repoIds, MemoryQuery query, CancellationToken ct)
     {
         try
         {
@@ -103,12 +119,32 @@ public class RavenEidetStore : IEidetStore
                     numberOfCandidates: 30);
 
             documentQuery = ApplyFilters(documentQuery, query);
-            return await documentQuery.Take(query.Limit).ToListAsync(ct);
+            var hits = await documentQuery.Take(query.Limit).ToListAsync(ct);
+            return ToScoredHits(session, hits);
         }
         catch
         {
             return []; // Vector search may fail if embeddings not configured
         }
+    }
+
+    /// <summary>
+    /// Reads each hit's raw relevance from the already-materialized session metadata
+    /// (<c>@index-score</c>). Falls back to rank-decay (<c>1, 1/2, 1/3, …</c>) for any hit whose
+    /// score the backend doesn't surface, so an arm never throws over a missing score.
+    /// </summary>
+    private static IReadOnlyList<ScoredHit> ToScoredHits(IAsyncDocumentSession session, List<MemoryEntry> hits)
+    {
+        var scored = new List<ScoredHit>(hits.Count);
+        for (var rank = 0; rank < hits.Count; rank++)
+        {
+            var entry = hits[rank];
+            double score;
+            try { score = session.Advanced.GetMetadataFor(entry).GetDouble("@index-score"); }
+            catch { score = 1.0 / (rank + 1); }
+            scored.Add(new ScoredHit(entry, score));
+        }
+        return scored;
     }
 
     public async Task<MemoryEntry?> FindDuplicateAsync(

--- a/src/Eidet.Core/Storage/RavenEidetStore.cs
+++ b/src/Eidet.Core/Storage/RavenEidetStore.cs
@@ -131,7 +131,9 @@ public class RavenEidetStore : IEidetStore
     /// <summary>
     /// Reads each hit's raw relevance from the already-materialized session metadata
     /// (<c>@index-score</c>). Falls back to rank-decay (<c>1, 1/2, 1/3, …</c>) for any hit whose
-    /// score the backend doesn't surface, so an arm never throws over a missing score.
+    /// score the backend doesn't surface (e.g. the vector arm), so an arm never throws over a
+    /// missing score. A missing key is the expected case and is handled without an exception (no
+    /// per-hit throw cost); the narrow catch covers only a present-but-unconvertible value.
     /// </summary>
     private static IReadOnlyList<ScoredHit> ToScoredHits(IAsyncDocumentSession session, List<MemoryEntry> hits)
     {
@@ -139,9 +141,15 @@ public class RavenEidetStore : IEidetStore
         for (var rank = 0; rank < hits.Count; rank++)
         {
             var entry = hits[rank];
+            var rankDecay = 1.0 / (rank + 1);
+            var metadata = session.Advanced.GetMetadataFor(entry);
             double score;
-            try { score = session.Advanced.GetMetadataFor(entry).GetDouble("@index-score"); }
-            catch { score = 1.0 / (rank + 1); }
+            if (!metadata.ContainsKey("@index-score"))
+                score = rankDecay;
+            else
+                try { score = metadata.GetDouble("@index-score"); }
+                catch (Exception ex) when (ex is InvalidCastException or FormatException or OverflowException)
+                { score = rankDecay; }
             scored.Add(new ScoredHit(entry, score));
         }
         return scored;

--- a/tests/Eidet.Core.Tests/Memory/RecallFusionTests.cs
+++ b/tests/Eidet.Core.Tests/Memory/RecallFusionTests.cs
@@ -1,0 +1,540 @@
+using Eidet.Core.Domain;
+using Eidet.Core.Maintenance;
+using Eidet.Core.Memory;
+using Eidet.Core.Services;
+using Eidet.Core.Storage;
+using Eidet.Core.Tests.Services;
+
+namespace Eidet.Core.Tests.Memory;
+
+/// <summary>
+/// Tests for the Recall pipeline v2 contract (issue #33, spine items 1-5): min-max-normalized
+/// hybrid fusion (Alpha=0.5 lexical/vector blend) + UCB exploration (Kappa=0.3) + dual-clock
+/// FadeMem recency, replacing the old flat 1.0/0.9 constant scoring.
+///
+/// The headline guarantee: a "gold" candidate with strong combined relevance survives truncation
+/// and ranks top-k after fusion, where flat scoring would have lost it.
+///
+/// Section A — pure fusion math (RecallScoring.Fuse / FuseAndScore, no Raven, the CI oracle guard).
+/// Section B — the default SearchScoredAsync rank-decay shim (≈19 fakes work untouched).
+/// Section C — MemoryService.ExplainRecallAsync diagnostics.
+/// Section D — end-to-end fused ranking through MemoryService.RecallAsync.
+/// </summary>
+public class RecallFusionTests
+{
+    // ─── Fixed "now" so the recency clock is deterministic across the suite ───
+    private static readonly DateTime Now = new(2026, 6, 20, 0, 0, 0, DateTimeKind.Utc);
+
+    /// <summary>
+    /// Builds a MemoryEntry with knobs the fusion math reads. Defaults are "neutral":
+    /// just-created (recency ≈ 1), no feedback. Id doubles as the search key.
+    /// </summary>
+    private static MemoryEntry Entry(
+        string id,
+        MemoryType type = MemoryType.Insight,
+        DateTime? createdAt = null,
+        DateTime? lastAccessedAt = null,
+        int echo = 0,
+        int fizzle = 0,
+        string repoId = "repo-a") => new()
+    {
+        Id = id,
+        RepoId = repoId,
+        Type = type,
+        Content = id,
+        CreatedAt = createdAt ?? Now,
+        LastAccessedAt = lastAccessedAt,
+        EchoCount = echo,
+        FizzleCount = fizzle,
+        IsLatest = true,
+        Validity = new Validity { ValidFrom = createdAt ?? Now },
+        Importance = 0.5f,
+    };
+
+    private static bool IsFinite(double d) => !double.IsNaN(d) && !double.IsInfinity(d);
+
+    // ════════════════════════════════════════════════════════════════════════
+    // Section A — pure fusion math (the CI oracle guard)
+    // ════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// A1 — THE test the issue requires. Gold has strong COMBINED relevance: it is decent (not top)
+    /// in the lexical arm AND the strongest in the vector arm. Each distractor is strong in exactly
+    /// ONE arm. Under the old flat per-arm constant scoring (1.0 lex / 0.9 vec) gold was just another
+    /// lexical 1.0 — indistinguishable from the lexical-only distractors and a truncation casualty.
+    /// Min-max fusion lifts gold above every single-arm distractor; it survives a small-limit budget
+    /// and lands top-k.
+    /// </summary>
+    [Fact]
+    public void Fuse_GoldSurvivesTruncation_RanksTopK_whereFlatScoringWouldLoseIt()
+    {
+        var gold = Entry("gold");
+        var lexOnly1 = Entry("lexOnly1");
+        var lexOnly2 = Entry("lexOnly2");
+        var vecOnly1 = Entry("vecOnly1");
+
+        // Lexical arm: gold is mid-pack (normLex = 0.5), two distractors bracket it.
+        var lex = new List<ScoredHit>
+        {
+            new(lexOnly1, 10.0), // normLex 1.0 — but absent from vec ⇒ normVec 0
+            new(gold, 7.5),      // normLex 0.5
+            new(lexOnly2, 5.0),  // normLex 0.0
+        };
+
+        // Vector arm: gold is the strongest; one vec-only distractor is mid.
+        var vec = new List<ScoredHit>
+        {
+            new(gold, 10.0),     // normVec 1.0
+            new(vecOnly1, 5.0),  // normVec 0.0 (min of arm) — absent from lex ⇒ normLex 0
+        };
+
+        var fused = RecallScoring.Fuse(lex, vec, RecallWeights.Default, Now);
+
+        // Gold: 0.5·0.5 + 0.5·1.0 + recency = 0.75 + recency — beats every single-arm distractor:
+        //   lexOnly1: 0.5·1.0 + 0 + recency = 0.5 + recency
+        //   any vec-only / lex-only peaks at 0.5 + recency.
+        Assert.Equal("gold", fused[0].Entry.Id);
+
+        // And it survives a downstream small-limit budget pass (limit 2 of 4 candidates).
+        var results = RecallScoring.FuseAndScore(lex, vec, RecallWeights.Default, Now);
+        var budgeted = RecallScoring.ApplyTypeBudgets(results, limit: 2);
+        Assert.Contains(budgeted, r => r.Id == "gold");
+        Assert.Equal("gold", budgeted[0].Id);
+    }
+
+    /// <summary>
+    /// A2a — robust degrade: an empty lexical arm with a populated vector arm still returns results,
+    /// ordered by the vector arm.
+    /// </summary>
+    [Fact]
+    public void Fuse_EmptyLexArm_ReturnsResultsOrderedByVecArm()
+    {
+        var a = Entry("a");
+        var b = Entry("b");
+        var c = Entry("c");
+
+        var lex = new List<ScoredHit>();
+        var vec = new List<ScoredHit>
+        {
+            new(a, 1.0),
+            new(b, 5.0),
+            new(c, 9.0),
+        };
+
+        var fused = RecallScoring.Fuse(lex, vec, RecallWeights.Default, Now);
+
+        Assert.Equal(3, fused.Count);
+        // All recency/UCB equal ⇒ ordering is driven entirely by the normalized vec arm.
+        Assert.Equal(new[] { "c", "b", "a" }, fused.Select(f => f.Entry.Id).ToArray());
+        // Every lex component is 0 (empty arm → 0 for all).
+        Assert.All(fused, f => Assert.Equal(0.0, f.Lex));
+    }
+
+    /// <summary>
+    /// A2b — all-equal / single-candidate arm (max==min) must not divide by zero: that arm
+    /// contributes a finite normalized 1.0, and NO component is NaN/Infinity.
+    /// </summary>
+    [Fact]
+    public void Fuse_AllEqualArm_NoNaNorInfinity_NormalizesToOne()
+    {
+        var a = Entry("a");
+        var b = Entry("b");
+
+        // Lexical arm: both equal (range == 0) → each normalizes to 1.0.
+        var lex = new List<ScoredHit> { new(a, 7.0), new(b, 7.0) };
+        // Vector arm: single candidate (max==min) → normalizes to 1.0.
+        var vec = new List<ScoredHit> { new(a, 3.0) };
+
+        var fused = RecallScoring.Fuse(lex, vec, RecallWeights.Default, Now);
+
+        Assert.All(fused, f =>
+        {
+            Assert.True(IsFinite(f.Lex), $"Lex not finite for {f.Entry.Id}");
+            Assert.True(IsFinite(f.Vec), $"Vec not finite for {f.Entry.Id}");
+            Assert.True(IsFinite(f.Recency), $"Recency not finite for {f.Entry.Id}");
+            Assert.True(IsFinite(f.Ucb), $"Ucb not finite for {f.Entry.Id}");
+            Assert.True(IsFinite(f.Fused), $"Fused not finite for {f.Entry.Id}");
+        });
+
+        // Both lexical hits normalize to 1.0; the single vector hit normalizes to 1.0.
+        Assert.Equal(1.0, fused.Single(f => f.Entry.Id == "a").Lex);
+        Assert.Equal(1.0, fused.Single(f => f.Entry.Id == "b").Lex);
+        Assert.Equal(1.0, fused.Single(f => f.Entry.Id == "a").Vec);
+    }
+
+    /// <summary>
+    /// A3 — outer-join over lex∪vec: a lex-only entry and a vec-only entry both appear; the
+    /// lex-only entry's Vec component is 0 and the vec-only entry's Lex component is 0.
+    /// </summary>
+    [Fact]
+    public void Fuse_OuterJoin_LexOnlyAndVecOnlyBothAppear_WithZeroOtherArm()
+    {
+        var lexOnly = Entry("lexOnly");
+        var vecOnly = Entry("vecOnly");
+
+        var lex = new List<ScoredHit> { new(lexOnly, 4.0) };
+        var vec = new List<ScoredHit> { new(vecOnly, 4.0) };
+
+        var fused = RecallScoring.Fuse(lex, vec, RecallWeights.Default, Now);
+
+        Assert.Equal(2, fused.Count);
+        var l = fused.Single(f => f.Entry.Id == "lexOnly");
+        var v = fused.Single(f => f.Entry.Id == "vecOnly");
+
+        Assert.Equal(0.0, l.Vec);          // present only in lex arm
+        Assert.Equal(0.0, v.Lex);          // present only in vec arm
+        Assert.True(l.Lex > 0.0);          // single-candidate arm normalizes to 1.0
+        Assert.True(v.Vec > 0.0);
+    }
+
+    /// <summary>
+    /// A4 — UCB exploration. With TotalN>0, between two entries identical in every arm/recency
+    /// dimension but differing only in feedback counts, the one with FEWER (Echo+Fizzle) earns a
+    /// higher UCB term and ranks higher.
+    /// </summary>
+    [Fact]
+    public void Fuse_UCB_FewerFeedback_GetsHigherExplorationBonus()
+    {
+        var rarelySeen = Entry("rarelySeen", echo: 0, fizzle: 0);     // denominator 1
+        var oftenSeen = Entry("oftenSeen", echo: 40, fizzle: 10);    // denominator 51
+
+        // Identical in both arms so ONLY the UCB term can break the tie.
+        var lex = new List<ScoredHit> { new(rarelySeen, 5.0), new(oftenSeen, 5.0) };
+        var vec = new List<ScoredHit> { new(rarelySeen, 5.0), new(oftenSeen, 5.0) };
+
+        // TotalN must be > 0 for ln(TotalN+1) > 0 to give UCB any weight.
+        var weights = RecallWeights.Default with { TotalN = 50 };
+        var fused = RecallScoring.Fuse(lex, vec, weights, Now);
+
+        var rare = fused.Single(f => f.Entry.Id == "rarelySeen");
+        var often = fused.Single(f => f.Entry.Id == "oftenSeen");
+
+        Assert.True(rare.Ucb > often.Ucb, $"rare UCB ({rare.Ucb}) should exceed often UCB ({often.Ucb})");
+        Assert.True(rare.Fused > often.Fused);
+        Assert.Equal("rarelySeen", fused[0].Entry.Id);
+    }
+
+    /// <summary>
+    /// A4b — with RecallWeights.Default (TotalN=0), ln(TotalN+1)=ln(1)=0, so the UCB term is 0
+    /// for every candidate regardless of feedback counts.
+    /// </summary>
+    [Fact]
+    public void Fuse_DefaultWeights_TotalNZero_UcbIsZeroForAll()
+    {
+        var a = Entry("a", echo: 0, fizzle: 0);
+        var b = Entry("b", echo: 99, fizzle: 99);
+
+        var lex = new List<ScoredHit> { new(a, 5.0), new(b, 5.0) };
+        var vec = new List<ScoredHit> { new(a, 5.0), new(b, 5.0) };
+
+        var fused = RecallScoring.Fuse(lex, vec, RecallWeights.Default, Now);
+
+        Assert.All(fused, f => Assert.Equal(0.0, f.Ucb));
+    }
+
+    /// <summary>
+    /// A5 — dual-clock recency through Fuse: an OLD entry (created long ago) with a RECENT
+    /// LastAccessedAt out-scores (on the recency component) an equally-old entry whose
+    /// LastAccessedAt is null, all arms equal.
+    /// </summary>
+    [Fact]
+    public void Fuse_DualClockRecency_RecentlyAccessedOldEntry_OutscoresStaleOldEntry()
+    {
+        var longAgo = Now.AddDays(-300);
+
+        var reAccessed = Entry("reAccessed", type: MemoryType.Insight,
+            createdAt: longAgo, lastAccessedAt: Now.AddDays(-1));
+        var dormant = Entry("dormant", type: MemoryType.Insight,
+            createdAt: longAgo, lastAccessedAt: null);
+
+        // Identical arms so ONLY recency differs.
+        var lex = new List<ScoredHit> { new(reAccessed, 5.0), new(dormant, 5.0) };
+        var vec = new List<ScoredHit> { new(reAccessed, 5.0), new(dormant, 5.0) };
+
+        var fused = RecallScoring.Fuse(lex, vec, RecallWeights.Default, Now);
+
+        var re = fused.Single(f => f.Entry.Id == "reAccessed");
+        var dorm = fused.Single(f => f.Entry.Id == "dormant");
+
+        Assert.True(re.Recency > dorm.Recency, $"reAccessed recency ({re.Recency}) should exceed dormant ({dorm.Recency})");
+        Assert.True(re.Fused > dorm.Fused);
+        Assert.Equal("reAccessed", fused[0].Entry.Id);
+    }
+
+    /// <summary>
+    /// A5b — direct FadeMemCurve.Recency unit test: null LastAccessedAt falls back to creation-only
+    /// and equals the value of an entry whose only clock is creation. Also: in 0..1, and a recent
+    /// creation is fresher than an old one.
+    /// </summary>
+    [Fact]
+    public void FadeMemCurve_Recency_NullLastAccessed_FallsBackToCreationOnly()
+    {
+        var created = Now.AddDays(-45);
+
+        var nullAccess = FadeMemCurve.Recency(created, lastAccessedAt: null, Now, MemoryType.Insight);
+        // An explicit lastAccessed equal to creation must yield the same value (max of two equals).
+        var equalAccess = FadeMemCurve.Recency(created, lastAccessedAt: created, Now, MemoryType.Insight);
+        Assert.Equal(nullAccess, equalAccess, precision: 12);
+
+        // 0..1 range.
+        Assert.InRange(nullAccess, 0.0, 1.0);
+
+        // A fresh creation is more recent than the 45-day-old one.
+        var fresh = FadeMemCurve.Recency(Now, lastAccessedAt: null, Now, MemoryType.Insight);
+        Assert.True(fresh > nullAccess);
+
+        // Dual clock takes the more-recent clock: a recent access lifts an old creation.
+        var lifted = FadeMemCurve.Recency(created, lastAccessedAt: Now, Now, MemoryType.Insight);
+        Assert.True(lifted > nullAccess, $"recent access ({lifted}) should beat creation-only ({nullAccess})");
+        Assert.Equal(fresh, lifted, precision: 12); // accessed now == created now
+    }
+
+    /// <summary>
+    /// A6 — determinism: two calls with identical inputs yield identical ordering AND identical
+    /// component scores.
+    /// </summary>
+    [Fact]
+    public void Fuse_IsDeterministic_AcrossRepeatedCalls()
+    {
+        var entries = Enumerable.Range(0, 8).Select(i =>
+            Entry($"e{i}", echo: i, fizzle: 7 - i, createdAt: Now.AddDays(-i))).ToList();
+
+        var lex = entries.Select((e, i) => new ScoredHit(e, 10.0 - i)).ToList();
+        var vec = entries.Select((e, i) => new ScoredHit(e, (i % 3) + 1.0)).ToList();
+        var weights = RecallWeights.Default with { TotalN = 30 };
+
+        var first = RecallScoring.Fuse(lex, vec, weights, Now);
+        var second = RecallScoring.Fuse(lex, vec, weights, Now);
+
+        Assert.Equal(first.Count, second.Count);
+        for (var i = 0; i < first.Count; i++)
+        {
+            Assert.Equal(first[i].Entry.Id, second[i].Entry.Id);
+            Assert.Equal(first[i].Fused, second[i].Fused);
+            Assert.Equal(first[i].Lex, second[i].Lex);
+            Assert.Equal(first[i].Vec, second[i].Vec);
+            Assert.Equal(first[i].Ucb, second[i].Ucb);
+            Assert.Equal(first[i].Recency, second[i].Recency);
+        }
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // Section B — default SearchScoredAsync rank-decay shim
+    // ════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// B7 — a fake that overrides only FullTextSearchAsync/VectorSearchAsync (the existing
+    /// InMemoryEidetStore) gets rank-decayed ScoredHits via the DEFAULT SearchScoredAsync:
+    /// the first entity-method result has the highest score and scores strictly decrease.
+    /// Confirms the ≈19 existing fakes keep working without opting in.
+    /// </summary>
+    [Fact]
+    public async Task DefaultSearchScored_RankDecays_FirstHitHighest_StrictlyDecreasing()
+    {
+        var store = new InMemoryEidetStore();
+        // Store three matching entries; substring search will return them all.
+        await store.StoreAsync(MakeStored("memories/repo-a/insight/1", "kubernetes ingress nginx"));
+        await store.StoreAsync(MakeStored("memories/repo-a/insight/2", "kubernetes cluster gke"));
+        await store.StoreAsync(MakeStored("memories/repo-a/insight/3", "kubernetes nodes autoscale"));
+
+        var query = new MemoryQuery { Text = "kubernetes", Limit = 10 };
+        // Call through the interface so the DEFAULT interface method is exercised.
+        IEidetStore asInterface = store;
+        var hits = await asInterface.SearchScoredAsync(SearchArm.Lexical, ["repo-a"], query);
+
+        Assert.Equal(3, hits.Count);
+        // Rank-decay 1, 1/2, 1/3 → strictly decreasing, first is highest.
+        for (var i = 1; i < hits.Count; i++)
+            Assert.True(hits[i].Score < hits[i - 1].Score,
+                $"score at {i} ({hits[i].Score}) should be < score at {i - 1} ({hits[i - 1].Score})");
+        Assert.Equal(1.0, hits[0].Score);
+    }
+
+    private static MemoryEntry MakeStored(string id, string content) => new()
+    {
+        Id = id,
+        RepoId = "repo-a",
+        Type = MemoryType.Insight,
+        Content = content,
+        CreatedAt = Now,
+        Validity = new Validity { ValidFrom = Now },
+        IsLatest = true,
+        Importance = 0.5f,
+    };
+
+    // ════════════════════════════════════════════════════════════════════════
+    // Section C — ExplainRecallAsync diagnostics
+    // ════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// C8 — ExplainRecallAsync returns one row per candidate with the full component breakdown,
+    /// AlphaUsed == 0.5, and CandidatePool == |lex∪vec|.
+    /// </summary>
+    [Fact]
+    public async Task ExplainRecall_ReturnsPerCandidateBreakdown_Alpha05_PoolEqualsUnion()
+    {
+        var store = new InMemoryScoredStore();
+        // lex arm: a, b, c ; vec arm: c, d  →  union {a,b,c,d} = 4
+        store.SetArm(SearchArm.Lexical, ("a", 9.0), ("b", 6.0), ("c", 3.0));
+        store.SetArm(SearchArm.Vector, ("c", 8.0), ("d", 2.0));
+        store.Seed(Entry("a"), Entry("b"), Entry("c"), Entry("d"));
+
+        var svc = new MemoryService(store);
+        var explanation = await svc.ExplainRecallAsync("repo-a", new RecallOptions("anything"));
+
+        Assert.Equal(0.5, explanation.AlphaUsed);
+        Assert.Equal(4, explanation.CandidatePool);
+        Assert.Equal(4, explanation.Rows.Count);
+
+        // Every row carries finite components and the fused total.
+        Assert.All(explanation.Rows, row =>
+        {
+            Assert.False(string.IsNullOrEmpty(row.Id));
+            Assert.True(IsFinite(row.Lex) && IsFinite(row.Vec) && IsFinite(row.Recency) && IsFinite(row.Ucb) && IsFinite(row.Fused));
+        });
+
+        // The lex-only "a" (highest raw lex) has Lex==1.0 and Vec==0; the vec-only "d" has Vec>0, Lex==0.
+        var rowA = explanation.Rows.Single(r => r.Id == "a");
+        var rowD = explanation.Rows.Single(r => r.Id == "d");
+        Assert.Equal(1.0, rowA.Lex);
+        Assert.Equal(0.0, rowA.Vec);
+        Assert.Equal(0.0, rowD.Lex);
+        Assert.True(rowD.Vec >= 0.0);
+    }
+
+    /// <summary>
+    /// C9 — ExplainRecallAsync must not consult or poison the recall cache. We Explain first, then
+    /// store a new matching memory, then Recall — the new entry must surface. If Explain had warmed
+    /// or shared the cache, the subsequent Recall could serve a stale (pre-store) result.
+    /// </summary>
+    [Fact]
+    public async Task ExplainRecall_DoesNotPoisonRecallCache()
+    {
+        var store = new InMemoryEidetStore();
+        var svc = new MemoryService(store);
+
+        // Explain over an empty store (no candidates).
+        var explained = await svc.ExplainRecallAsync("repo-a", new RecallOptions("redis caching"));
+        Assert.Empty(explained.Rows);
+
+        // Store a matching memory AFTER explain.
+        var stored = await svc.StoreAsync("repo-a", "redis caching with 5-min ttl", MemoryType.Insight);
+        Assert.True(stored.Success);
+
+        // A normal recall must observe the new entry — proving Explain did not seed a stale cache.
+        var recalled = await svc.RecallAsync("repo-a", "redis caching");
+        Assert.Single(recalled);
+        Assert.Equal(stored.Id, recalled[0].Id);
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // Section D — end-to-end fused ranking through MemoryService.RecallAsync
+    // ════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// D10 — through MemoryService.RecallAsync backed by scripted per-arm scores, the returned order
+    /// reflects FUSED ranking, not insertion/flat order: gold (lexically tied but vector-strong)
+    /// ranks above a lexically-tied-but-vector-weak distractor.
+    /// </summary>
+    [Fact]
+    public async Task RecallAsync_OrderReflectsFusedRanking_NotFlatOrInsertionOrder()
+    {
+        var store = new InMemoryScoredStore();
+        // Both gold and distractor have the SAME lexical score (a lexical tie). Under the old flat
+        // 1.0 lexical scoring these would be indistinguishable. Gold wins on the vector arm.
+        store.SetArm(SearchArm.Lexical, ("distractor", 7.0), ("gold", 7.0));
+        store.SetArm(SearchArm.Vector, ("gold", 9.0)); // distractor absent from vec arm
+        // Insertion order deliberately puts distractor first.
+        store.Seed(Entry("distractor"), Entry("gold"));
+
+        var svc = new MemoryService(store);
+        var results = await svc.RecallAsync("repo-a", "query");
+
+        Assert.Equal(2, results.Count);
+        Assert.Equal("gold", results[0].Id);   // fused ranking, not insertion order
+        Assert.Equal("distractor", results[1].Id);
+        Assert.True(results[0].Score > results[1].Score);
+    }
+}
+
+/// <summary>
+/// Test double implementing <see cref="IEidetStore.SearchScoredAsync"/> DIRECTLY with scripted
+/// per-arm raw scores — so fusion (not the rank-decay shim) drives ranking. Only the surface
+/// <see cref="MemoryService"/> recall/explain touches is implemented; everything else throws or
+/// returns empty. Mirrors the in-memory-fake style of <c>MemoryServiceBoundaryTests</c>.
+/// </summary>
+internal sealed class InMemoryScoredStore : IEidetStore
+{
+    private readonly Dictionary<SearchArm, List<(string Id, double Score)>> _arms = new()
+    {
+        [SearchArm.Lexical] = [],
+        [SearchArm.Vector] = [],
+    };
+    private readonly Dictionary<string, MemoryEntry> _entries = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Script an arm's hits as (id, rawScore) pairs, ordered as the backend would return them.</summary>
+    public void SetArm(SearchArm arm, params (string Id, double Score)[] hits) =>
+        _arms[arm] = hits.ToList();
+
+    /// <summary>Register the entry objects the scripted ids refer to (carries recency/feedback knobs).</summary>
+    public void Seed(params MemoryEntry[] entries)
+    {
+        foreach (var e in entries) _entries[e.Id] = e;
+    }
+
+    public Task<IReadOnlyList<ScoredHit>> SearchScoredAsync(
+        SearchArm arm, IReadOnlyList<string> repoIds, MemoryQuery query, CancellationToken ct = default)
+    {
+        var hits = _arms[arm]
+            .Where(h => _entries.ContainsKey(h.Id))
+            .Select(h => new ScoredHit(_entries[h.Id], h.Score))
+            .ToList();
+        return Task.FromResult<IReadOnlyList<ScoredHit>>(hits);
+    }
+
+    // ── Surface MemoryService.RecallAsync / ExplainRecallAsync also touches ──
+    public Task<MemoryEntry?> GetAsync(string id, CancellationToken ct = default)
+    {
+        _entries.TryGetValue(id, out var e);
+        return Task.FromResult(e);
+    }
+
+    public Task<string> StoreAsync(MemoryEntry entry, CancellationToken ct = default)
+    {
+        _entries[entry.Id] = entry;
+        return Task.FromResult(entry.Id);
+    }
+
+    // The fused arms are scripted, so the legacy entity methods are never the source of truth here;
+    // they only exist to satisfy the interface (and BumpAccessCounts background path stays harmless).
+    public Task<List<MemoryEntry>> FullTextSearchAsync(IReadOnlyList<string> repoIds, MemoryQuery query, CancellationToken ct = default) =>
+        Task.FromResult(new List<MemoryEntry>());
+    public Task<List<MemoryEntry>> VectorSearchAsync(IReadOnlyList<string> repoIds, MemoryQuery query, CancellationToken ct = default) =>
+        Task.FromResult(new List<MemoryEntry>());
+
+    public Task UpdateAsync(MemoryEntry entry, CancellationToken ct = default)
+    {
+        _entries[entry.Id] = entry;
+        return Task.CompletedTask;
+    }
+    public Task<bool> ForgetAsync(string id, CancellationToken ct = default) => Task.FromResult(false);
+    public Task<MemoryEntry?> FindDuplicateAsync(string repoId, string content, float threshold, CancellationToken ct = default) =>
+        Task.FromResult<MemoryEntry?>(null);
+    public Task<Dictionary<MemoryType, int>> GetCountsByTypeAsync(string repoId, CancellationToken ct = default) =>
+        Task.FromResult(new Dictionary<MemoryType, int>());
+    public Task<List<MemoryEntry>> GetTopScoredAsync(string repoId, MemoryType[] types, int limit, CancellationToken ct = default) =>
+        Task.FromResult(new List<MemoryEntry>());
+    public Task<bool> TestConnectionAsync(CancellationToken ct = default) => Task.FromResult(true);
+    public Task<DatabaseInfo?> GetDatabaseInfoAsync(CancellationToken ct = default) => Task.FromResult<DatabaseInfo?>(null);
+    public Task EnsureIndexesAsync(CancellationToken ct = default) => Task.CompletedTask;
+    public Task<List<string>> GetDistinctRepoIdsAsync(CancellationToken ct = default) =>
+        Task.FromResult(_entries.Values.Select(e => e.RepoId).Distinct().ToList());
+    public Task<List<MemoryEntry>> BrowseAsync(string repoId, int skip, int take, MemoryType? type = null, CancellationToken ct = default) =>
+        Task.FromResult(new List<MemoryEntry>());
+    public Task<string> StoreMountedLayerAsync(MemoryLayer layer, CancellationToken ct = default) => Task.FromResult(layer.Id);
+    public Task<bool> UnmountLayerAsync(string layerId, CancellationToken ct = default) => Task.FromResult(false);
+    public Task<List<MemoryLayer>> GetMountedLayersAsync(string repoId, CancellationToken ct = default) => Task.FromResult(new List<MemoryLayer>());
+    public Task<MemoryLayer?> GetLayerAsync(string layerId, CancellationToken ct = default) => Task.FromResult<MemoryLayer?>(null);
+    public Task<List<MemoryEntry>> GetByLayerIdAsync(string layerId, CancellationToken ct = default) => Task.FromResult(new List<MemoryEntry>());
+    public Task<bool> HardDeleteAsync(string id, CancellationToken ct = default) => Task.FromResult(_entries.Remove(id));
+}


### PR DESCRIPTION
## Summary
First implementation pass of #33 (Recall pipeline v2) — the **spine** (checklist items 1-5). Recall previously merged full-text + vector hits by discarding RavenDB's relevance scores and assigning flat constants (1.0 / 0.9), so ordering at the token-budget cut was effectively arbitrary. This surfaces real per-arm relevance and fuses it **before** truncation.

## What's in
- **Scored store boundary** — `IEidetStore.SearchScoredAsync(arm)` + `ScoredHit`/`SearchArm`. A default rank-decay interface impl keeps all ~19 existing fakes working untouched; `RavenEidetStore` overrides it to surface `@index-score` (per-hit rank-decay fallback), and the entity methods delegate to it (no duplicate query logic).
- **Pure fusion** — `RecallScoring.Fuse` (single source of the ranking math): min-max-normalized lexical+vector blend (α = 0.5 fixed) + UCB exploration `κ·√(ln(N+1)/(echo+fizzle+1))` + per-type dual-clock FadeMem recency; reranks **before** `ApplyTypeBudgets`.
- **Dual-clock recency** — `FadeMemCurve.Recency` (per-type, used by fusion) and `ComputeL1Score` (folds `LastAccessedAt` under its existing 7-day wake-up curve).
- **Diagnostic** — `ExplainRecallAsync → RecallExplanation` (`{lex, vec, fused, recency, ucb}` + `AlphaUsed` + `CandidatePool`), bypasses the recall cache + hooks.
- **Tests** — 13 fusion tests incl. the issue's required oracle *gold-survives-truncation* guard. Full Core suite green (**520/520**).

## Deferred (per the issue's mandatory sequencing safety valve)
- **#6** per-repo `AlphaLex` EWMA alpha-learning + alpha-bucketed cache key — gated behind real-repo oracle validation, which can't happen pre-merge. α stays fixed at 0.5.
- **#7** bounded `ExpandNeighborsAsync` graph-neighbor expansion.

## Quality gates
Built via a 4-agent pipeline (implement → test → review → verify):
- **Verifier:** conforms 5/5; deferred items 6/7 did not leak; rejected designs A1 (in-store join) / A2 (stage-plugin) absent; build clean.
- **Reviewer:** one blocking item — an out-of-scope `ComputeL1Score` rewire to the per-type curve that broke a pre-existing test. **Resolved** by confining the per-type curve to recall fusion and folding the dual clock under `ComputeL1Score`'s existing 7-day wake-up curve, keeping the pre-existing test green. Cache-exemption comments updated (`LastAccessedAt` now feeds recency).

Partial of #33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LejT5wHAhq2pKSaYA4hZdf
