### PR TITLE
feat(benchmark): deterministic retrieval scorecard, v2 fusion vs flat baseline (#36)

### DIFF
--- a/Eidet.slnx
+++ b/Eidet.slnx
@@ -7,5 +7,6 @@
     <Project Path="tests/Eidet.Core.Tests/Eidet.Core.Tests.csproj" />
     <Project Path="tests/Eidet.Service.Tests/Eidet.Service.Tests.csproj" />
     <Project Path="tests/Eidet.Integration.Tests/Eidet.Integration.Tests.csproj" />
+    <Project Path="tests/Eidet.Benchmark.Tests/Eidet.Benchmark.Tests.csproj" />
   </Folder>
 </Solution>

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -1,0 +1,35 @@
+# Eidet Retrieval Benchmark Scorecard
+
+This measures the part of recall Eidet **owns**: ranking, hybrid fusion, and type-budget
+quality on a curated, adversarial in-repo dataset. Each gold case scripts per-arm raw
+scores `(lex, vec)`; the runner feeds them through the **real** `RecallScoring.Fuse` +
+`ApplyTypeBudgets` pipeline and compares the v2 fusion ranker against a **flat baseline**
+(the pre-#33 scoring: lexical hits = 1.0, vector-only hits = 0.9, no normalization, no UCB,
+no recency) over the same dataset. The lift is fusion recovering gold that flat scoring
+loses at the truncation boundary.
+
+It does **not** measure embedding quality (RavenDB owns embeddings, which can't run
+deterministically in CI), and it is **not** the external SWE Context Bench leaderboard —
+that is a deferred epic. This is a deterministic, no-LLM, CI regression guard.
+
+## v2 Fusion vs Flat Baseline
+
+| Capability | Cases | Metric | v2 Fusion | Flat Baseline | Delta |
+|---|---|---|---|---|---|
+| Recall | 12 | Recall@k | 0.833 | 0.375 | +0.458 |
+|  |  | MRR | 0.889 | 0.472 | +0.417 |
+|  |  | nDCG@k | 0.833 | 0.286 | +0.547 |
+|  |  | Gold survival | 0.792 | 0.417 | +0.375 |
+| StateUpdating | 1 | Recall@k | 1.000 | 1.000 | +0.000 |
+|  |  | MRR | 1.000 | 1.000 | +0.000 |
+|  |  | nDCG@k | 1.000 | 1.000 | +0.000 |
+|  |  | Gold survival | 1.000 | 1.000 | +0.000 |
+| **Overall** | 13 | Recall@k | 0.846 | 0.423 | +0.423 |
+|  |  | MRR | 0.897 | 0.513 | +0.385 |
+|  |  | nDCG@k | 0.846 | 0.341 | +0.505 |
+|  |  | Gold survival | 0.808 | 0.462 | +0.346 |
+
+## Capabilities not evaluated
+
+- **CausalInference** — N/A — requires LLM-in-loop; deferred to the SWE Context Bench epic (issue #36 follow-up).
+- **StateAbstraction** — N/A — requires LLM-in-loop; deferred to the SWE Context Bench epic (issue #36 follow-up).

--- a/src/Eidet.Core/Benchmark/AmaCapability.cs
+++ b/src/Eidet.Core/Benchmark/AmaCapability.cs
@@ -1,0 +1,15 @@
+namespace Eidet.Core.Benchmark;
+
+/// <summary>
+/// The four AMA-Bench capability headings the scorecard reports under. A deterministic, no-LLM
+/// ranking harness genuinely exercises only <see cref="Recall"/> and <see cref="StateUpdating"/>;
+/// <see cref="CausalInference"/> and <see cref="StateAbstraction"/> require an LLM in the loop and
+/// are reported as not-evaluated (see <c>BenchmarkReport.ToMarkdown</c>).
+/// </summary>
+public enum AmaCapability
+{
+    Recall,
+    CausalInference,
+    StateUpdating,
+    StateAbstraction,
+}

--- a/src/Eidet.Core/Benchmark/BenchmarkCase.cs
+++ b/src/Eidet.Core/Benchmark/BenchmarkCase.cs
@@ -1,0 +1,18 @@
+using Eidet.Core.Storage;
+
+namespace Eidet.Core.Benchmark;
+
+/// <summary>
+/// One gold case: a query's scripted candidate pool with per-arm raw scores, the relevant
+/// (gold) ids, the AMA-Bench capability it exercises, and the retrieval budget <see cref="K"/>.
+/// The runner feeds <see cref="Lex"/>/<see cref="Vec"/> through the real ranking math and scores
+/// the result against <see cref="GoldIds"/>. A case is self-contained — no external data, no clock
+/// beyond the <c>now</c> the runner supplies — so every metric is reproducible.
+/// </summary>
+public sealed record BenchmarkCase(
+    string Id,
+    AmaCapability Capability,
+    IReadOnlyList<ScoredHit> Lex,
+    IReadOnlyList<ScoredHit> Vec,
+    IReadOnlySet<string> GoldIds,
+    int K);

--- a/src/Eidet.Core/Benchmark/BenchmarkRunner.cs
+++ b/src/Eidet.Core/Benchmark/BenchmarkRunner.cs
@@ -1,0 +1,110 @@
+using Eidet.Core.Memory;
+using Eidet.Core.Storage;
+
+namespace Eidet.Core.Benchmark;
+
+/// <summary>
+/// Runs a gold dataset through two rankers on the SAME candidate pools and reports the lift:
+/// the v2 hybrid fusion pipeline (<see cref="RecallScoring.Fuse"/> → <see cref="RecallScoring.ApplyTypeBudgets"/>)
+/// versus the pre-#33 flat baseline (lexical hit = 1.0, vector-only hit = 0.9, no normalization /
+/// UCB / recency → the same budget pass). Hides all metric math behind a single
+/// <see cref="Run"/> call: callers pass cases and a fixed <c>now</c>, and get a deterministic
+/// <see cref="BenchmarkReport"/>.
+/// </summary>
+public static class BenchmarkRunner
+{
+    /// <summary>Flat baseline arm scores (the pre-#33 constants this benchmark proves fusion beats).</summary>
+    private const double FlatLexicalScore = 1.0;
+    private const double FlatVectorScore = 0.9;
+
+    /// <summary>Per-case metrics under one ranker, tagged with the case's capability and gold size.</summary>
+    private readonly record struct CaseResult(
+        AmaCapability Capability, double RecallAtK, double Mrr, double NdcgAtK, double GoldSurvival);
+
+    public static BenchmarkReport Run(IReadOnlyList<BenchmarkCase> cases, DateTime now)
+    {
+        var fused = new List<CaseResult>(cases.Count);
+        var baseline = new List<CaseResult>(cases.Count);
+
+        foreach (var c in cases)
+        {
+            fused.Add(Score(c, RankFused(c, now)));
+            baseline.Add(Score(c, RankBaseline(c)));
+        }
+
+        return new BenchmarkReport(Aggregate(fused), Aggregate(baseline));
+    }
+
+    /// <summary>v2 ranking: real min-max fusion + UCB + recency, then the type-budget truncation.</summary>
+    private static (IReadOnlyList<string> Ranked, IReadOnlyList<string> Budgeted) RankFused(
+        BenchmarkCase c, DateTime now)
+    {
+        var weights = RecallWeights.Default with { TotalN = ComputeTotalN(c.Lex, c.Vec) };
+        // Fuse once; derive both the full ranking and the post-budget projection from it.
+        var fused = RecallScoring.Fuse(c.Lex, c.Vec, weights, now);
+        var ranked = fused.Select(f => f.Entry.Id).ToList();
+        var results = fused.Select(f => RecallScoring.ToSearchResult(f.Entry, (float)f.Fused)).ToList();
+        var budgeted = RecallScoring.ApplyTypeBudgets(results, c.K).Select(r => r.Id).ToList();
+        return (ranked, budgeted);
+    }
+
+    /// <summary>
+    /// Pre-#33 flat ranking, reproduced faithfully: <see cref="RecallInternalAsync"/> merged lexical
+    /// hits (in backend relevance order) at a flat 1.0, then vector-only hits (in their order) at a
+    /// flat 0.9, and <see cref="RecallScoring.ApplyTypeBudgets"/>'s <c>OrderByDescending(Score)</c> is
+    /// a STABLE sort — so that merge order IS the tiebreak. There was no id-based ordering; introducing
+    /// one would handicap the baseline beyond its real behavior and inflate the measured lift.
+    /// </summary>
+    private static (IReadOnlyList<string> Ranked, IReadOnlyList<string> Budgeted) RankBaseline(BenchmarkCase c)
+    {
+        var lexIds = c.Lex.Select(h => h.Entry.Id).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var merged = new List<Domain.MemorySearchResult>(c.Lex.Count + c.Vec.Count);
+        foreach (var hit in c.Lex)
+            merged.Add(RecallScoring.ToSearchResult(hit.Entry, (float)FlatLexicalScore));
+        foreach (var hit in c.Vec)
+            if (!lexIds.Contains(hit.Entry.Id)) // a lexical hit keeps its 1.0; vector-only takes 0.9
+                merged.Add(RecallScoring.ToSearchResult(hit.Entry, (float)FlatVectorScore));
+
+        // merged is already in score-descending, merge-stable order (all 1.0s before all 0.9s),
+        // matching what the stable ApplyTypeBudgets sort would produce.
+        var ranked = merged.Select(r => r.Id).ToList();
+        var budgeted = RecallScoring.ApplyTypeBudgets(merged, c.K).Select(r => r.Id).ToList();
+        return (ranked, budgeted);
+    }
+
+    private static CaseResult Score(
+        BenchmarkCase c, (IReadOnlyList<string> Ranked, IReadOnlyList<string> Budgeted) ids)
+    {
+        var goldInBudget = ids.Budgeted.Count(id => c.GoldIds.Contains(id));
+        var survival = c.GoldIds.Count == 0 ? 0.0 : (double)goldInBudget / c.GoldIds.Count;
+
+        return new CaseResult(
+            c.Capability,
+            RetrievalMetrics.RecallAtK(ids.Ranked, c.GoldIds, c.K),
+            RetrievalMetrics.ReciprocalRank(ids.Ranked, c.GoldIds),
+            RetrievalMetrics.NdcgAtK(ids.Ranked, c.GoldIds, c.K),
+            survival);
+    }
+
+    private static List<CapabilityScore> Aggregate(IReadOnlyList<CaseResult> results) =>
+        results
+            .GroupBy(r => r.Capability)
+            .OrderBy(g => g.Key)
+            .Select(g => new CapabilityScore(
+                g.Key,
+                g.Count(),
+                g.Average(r => r.RecallAtK),
+                g.Average(r => r.Mrr),
+                g.Average(r => r.NdcgAtK),
+                g.Average(r => r.GoldSurvival)))
+            .ToList();
+
+    /// <summary>Σ (Echo+Fizzle) over lex∪vec (dedup by id) — the UCB exploration denominator base.</summary>
+    private static long ComputeTotalN(IReadOnlyList<ScoredHit> lex, IReadOnlyList<ScoredHit> vec)
+    {
+        var seen = new Dictionary<string, Domain.MemoryEntry>(StringComparer.OrdinalIgnoreCase);
+        foreach (var hit in lex) seen.TryAdd(hit.Entry.Id, hit.Entry);
+        foreach (var hit in vec) seen.TryAdd(hit.Entry.Id, hit.Entry);
+        return seen.Values.Sum(e => (long)e.EchoCount + e.FizzleCount);
+    }
+}

--- a/src/Eidet.Core/Benchmark/RetrievalMetrics.cs
+++ b/src/Eidet.Core/Benchmark/RetrievalMetrics.cs
@@ -1,0 +1,56 @@
+namespace Eidet.Core.Benchmark;
+
+/// <summary>
+/// Pure binary-relevance IR metrics over a ranked id list and a gold set. Every function defines
+/// its edge cases out of existence: empty gold yields 0 (a vacuous query scores nothing, never
+/// throws or returns NaN), k clamps to the list length, and a missing hit contributes 0 rather
+/// than an exception. All results are finite and in <c>[0, 1]</c>.
+/// </summary>
+public static class RetrievalMetrics
+{
+    /// <summary>|gold ∩ top-k of <paramref name="ranked"/>| / |gold|. Empty gold → 0. A gold id is
+    /// counted at most once even if it appears multiple times in the ranking, so the result can never
+    /// exceed 1.0 (the [0,1] contract holds even for a ranking with duplicate ids).</summary>
+    public static double RecallAtK(IReadOnlyList<string> ranked, IReadOnlySet<string> gold, int k)
+    {
+        if (gold.Count == 0) return 0.0;
+        var limit = Math.Clamp(k, 0, ranked.Count);
+        var matched = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        for (var i = 0; i < limit; i++)
+            if (gold.Contains(ranked[i])) matched.Add(ranked[i]);
+        return (double)matched.Count / gold.Count;
+    }
+
+    /// <summary>1 / (1-based rank of the first gold hit), 0 if none appears. Aggregate → MRR.</summary>
+    public static double ReciprocalRank(IReadOnlyList<string> ranked, IReadOnlySet<string> gold)
+    {
+        if (gold.Count == 0) return 0.0;
+        for (var i = 0; i < ranked.Count; i++)
+            if (gold.Contains(ranked[i])) return 1.0 / (i + 1);
+        return 0.0;
+    }
+
+    /// <summary>
+    /// Standard binary-relevance nDCG@k: DCG over the top-k (gain 1 per gold hit, <c>1/log2(i+2)</c>
+    /// discount) divided by the ideal DCG of <c>min(|gold|, k)</c> perfectly-ranked hits. Empty gold
+    /// or a zero ideal → 0.
+    /// </summary>
+    public static double NdcgAtK(IReadOnlyList<string> ranked, IReadOnlySet<string> gold, int k)
+    {
+        if (gold.Count == 0) return 0.0;
+        var limit = Math.Clamp(k, 0, ranked.Count);
+
+        var dcg = 0.0;
+        var credited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        for (var i = 0; i < limit; i++)
+            if (gold.Contains(ranked[i]) && credited.Add(ranked[i]))
+                dcg += 1.0 / Math.Log2(i + 2);
+
+        var idealHits = Math.Min(gold.Count, k);
+        var idcg = 0.0;
+        for (var i = 0; i < idealHits; i++)
+            idcg += 1.0 / Math.Log2(i + 2);
+
+        return idcg > 0 ? dcg / idcg : 0.0;
+    }
+}

--- a/src/Eidet.Core/Benchmark/Scorecard.cs
+++ b/src/Eidet.Core/Benchmark/Scorecard.cs
@@ -1,0 +1,143 @@
+using System.Globalization;
+using System.Text;
+
+namespace Eidet.Core.Benchmark;
+
+/// <summary>Aggregated (mean) metrics for one capability heading across its cases.</summary>
+public sealed record CapabilityScore(
+    AmaCapability Capability,
+    int Cases,
+    double RecallAtK,
+    double Mrr,
+    double NdcgAtK,
+    double GoldSurvival);
+
+/// <summary>
+/// The benchmark outcome: the v2-fusion scorecard, the flat-baseline scorecard run over the SAME
+/// dataset, and a deterministic <see cref="ToMarkdown"/> comparison. <see cref="ToMarkdown"/> is a
+/// pure function of the two scorecards — no timestamps, no environment — so the committed
+/// <c>docs/benchmark.md</c> can be asserted byte-equal in CI.
+/// </summary>
+public sealed record BenchmarkReport(
+    IReadOnlyList<CapabilityScore> Fused,
+    IReadOnlyList<CapabilityScore> Baseline)
+{
+    /// <summary>
+    /// Capabilities a deterministic ranking harness cannot honestly score (they require an
+    /// LLM in the loop) — rendered in the "not evaluated" section rather than fabricated.
+    /// </summary>
+    private static readonly AmaCapability[] NotEvaluated =
+        [AmaCapability.CausalInference, AmaCapability.StateAbstraction];
+
+    private const string DeferralReason =
+        "requires LLM-in-loop; deferred to the SWE Context Bench epic (issue #36 follow-up)";
+
+    /// <summary>
+    /// Renders the scorecard markdown: a per-capability + overall comparison table (v2 vs baseline
+    /// with deltas) and the not-evaluated note. Deterministic given the report — identical inputs
+    /// always produce identical bytes.
+    /// </summary>
+    public string ToMarkdown()
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("# Eidet Retrieval Benchmark Scorecard");
+        sb.AppendLine();
+        sb.AppendLine(
+            "This measures the part of recall Eidet **owns**: ranking, hybrid fusion, and type-budget");
+        sb.AppendLine(
+            "quality on a curated, adversarial in-repo dataset. Each gold case scripts per-arm raw");
+        sb.AppendLine(
+            "scores `(lex, vec)`; the runner feeds them through the **real** `RecallScoring.Fuse` +");
+        sb.AppendLine(
+            "`ApplyTypeBudgets` pipeline and compares the v2 fusion ranker against a **flat baseline**");
+        sb.AppendLine(
+            "(the pre-#33 scoring: lexical hits = 1.0, vector-only hits = 0.9, no normalization, no UCB,");
+        sb.AppendLine(
+            "no recency) over the same dataset. The lift is fusion recovering gold that flat scoring");
+        sb.AppendLine("loses at the truncation boundary.");
+        sb.AppendLine();
+        sb.AppendLine(
+            "It does **not** measure embedding quality (RavenDB owns embeddings, which can't run");
+        sb.AppendLine(
+            "deterministically in CI), and it is **not** the external SWE Context Bench leaderboard —");
+        sb.AppendLine("that is a deferred epic. This is a deterministic, no-LLM, CI regression guard.");
+        sb.AppendLine();
+
+        sb.AppendLine("## v2 Fusion vs Flat Baseline");
+        sb.AppendLine();
+        sb.AppendLine("| Capability | Cases | Metric | v2 Fusion | Flat Baseline | Delta |");
+        sb.AppendLine("|---|---|---|---|---|---|");
+
+        foreach (var fused in Fused)
+        {
+            var baseline = FindBaseline(fused.Capability);
+            AppendCapabilityRows(sb, fused, baseline);
+        }
+
+        AppendCapabilityRows(sb, Overall(Fused), Overall(Baseline), label: "**Overall**");
+
+        sb.AppendLine();
+        sb.AppendLine("## Capabilities not evaluated");
+        sb.AppendLine();
+        foreach (var capability in NotEvaluated)
+            sb.AppendLine($"- **{capability}** — N/A — {DeferralReason}.");
+
+        return sb.ToString();
+    }
+
+    private CapabilityScore FindBaseline(AmaCapability capability) =>
+        Baseline.FirstOrDefault(b => b.Capability == capability)
+        ?? new CapabilityScore(capability, 0, 0, 0, 0, 0);
+
+    private static void AppendCapabilityRows(
+        StringBuilder sb, CapabilityScore fused, CapabilityScore baseline, string? label = null)
+    {
+        var name = label ?? fused.Capability.ToString();
+        AppendMetricRow(sb, name, fused.Cases, "Recall@k", fused.RecallAtK, baseline.RecallAtK, first: true);
+        AppendMetricRow(sb, name, fused.Cases, "MRR", fused.Mrr, baseline.Mrr);
+        AppendMetricRow(sb, name, fused.Cases, "nDCG@k", fused.NdcgAtK, baseline.NdcgAtK);
+        AppendMetricRow(sb, name, fused.Cases, "Gold survival", fused.GoldSurvival, baseline.GoldSurvival);
+    }
+
+    private static void AppendMetricRow(
+        StringBuilder sb, string name, int cases, string metric,
+        double fused, double baseline, bool first = false)
+    {
+        // Only the first metric row of a capability carries the name + case count; the rest are
+        // blank so the table reads as a grouped block.
+        var nameCell = first ? name : "";
+        var casesCell = first ? cases.ToString(CultureInfo.InvariantCulture) : "";
+        sb.AppendLine(
+            $"| {nameCell} | {casesCell} | {metric} | {Fmt(fused)} | {Fmt(baseline)} | {Delta(fused, baseline)} |");
+    }
+
+    private static CapabilityScore Overall(IReadOnlyList<CapabilityScore> scores)
+    {
+        // Case-weighted means so a capability with more cases counts proportionally. The Capability
+        // field is a don't-care here — this aggregate is rendered under the "**Overall**" label, never
+        // by its capability — so Recall is reused purely as a placeholder.
+        var totalCases = scores.Sum(s => s.Cases);
+        if (totalCases == 0)
+            return new CapabilityScore(AmaCapability.Recall, 0, 0, 0, 0, 0);
+
+        double Weighted(Func<CapabilityScore, double> pick) =>
+            scores.Sum(s => pick(s) * s.Cases) / totalCases;
+
+        return new CapabilityScore(
+            AmaCapability.Recall, totalCases,
+            Weighted(s => s.RecallAtK),
+            Weighted(s => s.Mrr),
+            Weighted(s => s.NdcgAtK),
+            Weighted(s => s.GoldSurvival));
+    }
+
+    private static string Fmt(double value) =>
+        value.ToString("F3", CultureInfo.InvariantCulture);
+
+    private static string Delta(double fused, double baseline)
+    {
+        var delta = fused - baseline;
+        var sign = delta >= 0 ? "+" : "";
+        return sign + delta.ToString("F3", CultureInfo.InvariantCulture);
+    }
+}

--- a/tests/Eidet.Benchmark.Tests/BenchInMemoryStore.cs
+++ b/tests/Eidet.Benchmark.Tests/BenchInMemoryStore.cs
@@ -1,0 +1,173 @@
+using Eidet.Core.Domain;
+using Eidet.Core.Storage;
+
+namespace Eidet.Benchmark.Tests;
+
+/// <summary>
+/// Minimal in-memory <see cref="IEidetStore"/> for the FAMA forget/supersede behavioral guard.
+/// Replicated here (rather than depending on <c>Eidet.Core.Tests</c>'s internal fake) and made to
+/// match the RavenDB store's <em>visibility</em> contract on the surfaces the guard exercises:
+/// the recall arms exclude anything with <c>Validity.ValidUntil</c> set (the filter
+/// <c>RavenEidetStore.ApplyFilters</c> applies), and <see cref="GetTopScoredAsync"/> /
+/// <see cref="GetCountsByTypeAsync"/> additionally require <c>IsLatest</c> — so a forgotten or
+/// superseded entry is invisible to recall and context exactly as in production.
+///
+/// Layer support is real enough to fan a cross-repo recall across a mounted layer's
+/// <c>ApplicableRepos</c>, so the guard can prove stale-suppression holds across the repo union.
+/// </summary>
+internal sealed class BenchInMemoryStore : IEidetStore
+{
+    private readonly Dictionary<string, MemoryEntry> _entries = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, MemoryLayer> _layers = new(StringComparer.OrdinalIgnoreCase);
+    private readonly object _lock = new();
+
+    public Task<MemoryEntry?> GetAsync(string id, CancellationToken ct = default)
+    {
+        lock (_lock)
+        {
+            _entries.TryGetValue(id, out var e);
+            return Task.FromResult(e);
+        }
+    }
+
+    public Task<string> StoreAsync(MemoryEntry entry, CancellationToken ct = default)
+    {
+        lock (_lock) _entries[entry.Id] = entry;
+        return Task.FromResult(entry.Id);
+    }
+
+    public Task UpdateAsync(MemoryEntry entry, CancellationToken ct = default)
+    {
+        lock (_lock) _entries[entry.Id] = entry;
+        return Task.CompletedTask;
+    }
+
+    public Task<bool> ForgetAsync(string id, CancellationToken ct = default)
+    {
+        lock (_lock)
+        {
+            if (!_entries.TryGetValue(id, out var e)) return Task.FromResult(false);
+            e.Validity.ValidUntil = DateTime.UtcNow;
+            return Task.FromResult(true);
+        }
+    }
+
+    public Task<List<MemoryEntry>> FullTextSearchAsync(
+        IReadOnlyList<string> repoIds, MemoryQuery query, CancellationToken ct = default)
+    {
+        lock (_lock)
+        {
+            var terms = query.Text.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            var results = _entries.Values
+                .Where(e => repoIds.Contains(e.RepoId, StringComparer.OrdinalIgnoreCase))
+                .Where(e => query.IncludeExpired || e.Validity.ValidUntil is null)
+                .Where(e => terms.Length == 0 ||
+                            terms.Any(t => e.Content.Contains(t, StringComparison.OrdinalIgnoreCase)))
+                .Take(query.Limit * 2)
+                .ToList();
+            return Task.FromResult(results);
+        }
+    }
+
+    public Task<List<MemoryEntry>> VectorSearchAsync(
+        IReadOnlyList<string> repoIds, MemoryQuery query, CancellationToken ct = default) =>
+        Task.FromResult(new List<MemoryEntry>());
+
+    public Task<MemoryEntry?> FindDuplicateAsync(
+        string repoId, string content, float threshold, CancellationToken ct = default) =>
+        Task.FromResult<MemoryEntry?>(null);
+
+    public Task<Dictionary<MemoryType, int>> GetCountsByTypeAsync(string repoId, CancellationToken ct = default)
+    {
+        lock (_lock)
+        {
+            var counts = _entries.Values
+                .Where(e => string.Equals(e.RepoId, repoId, StringComparison.OrdinalIgnoreCase))
+                .Where(e => e.IsLatest && e.Validity.ValidUntil is null)
+                .GroupBy(e => e.Type)
+                .ToDictionary(g => g.Key, g => g.Count());
+            return Task.FromResult(counts);
+        }
+    }
+
+    public Task<List<MemoryEntry>> GetTopScoredAsync(
+        string repoId, MemoryType[] types, int limit, CancellationToken ct = default)
+    {
+        lock (_lock)
+        {
+            var results = _entries.Values
+                .Where(e => string.Equals(e.RepoId, repoId, StringComparison.OrdinalIgnoreCase))
+                .Where(e => types.Contains(e.Type))
+                .Where(e => e.IsLatest && e.Validity.ValidUntil is null)
+                .OrderByDescending(e => e.Importance)
+                .Take(limit)
+                .ToList();
+            return Task.FromResult(results);
+        }
+    }
+
+    public Task<bool> TestConnectionAsync(CancellationToken ct = default) => Task.FromResult(true);
+    public Task<DatabaseInfo?> GetDatabaseInfoAsync(CancellationToken ct = default) => Task.FromResult<DatabaseInfo?>(null);
+    public Task EnsureIndexesAsync(CancellationToken ct = default) => Task.CompletedTask;
+
+    public Task<List<string>> GetDistinctRepoIdsAsync(CancellationToken ct = default)
+    {
+        lock (_lock) return Task.FromResult(_entries.Values.Select(e => e.RepoId).Distinct().ToList());
+    }
+
+    public Task<List<MemoryEntry>> BrowseAsync(
+        string repoId, int skip, int take, MemoryType? type = null, CancellationToken ct = default)
+    {
+        lock (_lock)
+        {
+            var q = _entries.Values
+                .Where(e => string.Equals(e.RepoId, repoId, StringComparison.OrdinalIgnoreCase))
+                .Where(e => e.Validity.ValidUntil is null);
+            if (type.HasValue) q = q.Where(e => e.Type == type.Value);
+            return Task.FromResult(q.Skip(skip).Take(take).ToList());
+        }
+    }
+
+    // ── Layers: enough to fan a cross-repo recall across ApplicableRepos ──
+    public Task<string> StoreMountedLayerAsync(MemoryLayer layer, CancellationToken ct = default)
+    {
+        lock (_lock) _layers[layer.Id] = layer;
+        return Task.FromResult(layer.Id);
+    }
+
+    public Task<bool> UnmountLayerAsync(string layerId, CancellationToken ct = default)
+    {
+        lock (_lock) return Task.FromResult(_layers.Remove(layerId));
+    }
+
+    public Task<List<MemoryLayer>> GetMountedLayersAsync(string repoId, CancellationToken ct = default)
+    {
+        lock (_lock)
+        {
+            // "" means "all layers" (matches the real store's universal-scope query); a concrete
+            // repo returns the layers whose ApplicableRepos include it.
+            var layers = _layers.Values
+                .Where(l => repoId.Length == 0 ||
+                            l.ApplicableRepos.Contains(repoId, StringComparer.OrdinalIgnoreCase))
+                .ToList();
+            return Task.FromResult(layers);
+        }
+    }
+
+    public Task<MemoryLayer?> GetLayerAsync(string layerId, CancellationToken ct = default)
+    {
+        lock (_lock)
+        {
+            _layers.TryGetValue(layerId, out var l);
+            return Task.FromResult(l);
+        }
+    }
+
+    public Task<List<MemoryEntry>> GetByLayerIdAsync(string layerId, CancellationToken ct = default) =>
+        Task.FromResult(new List<MemoryEntry>());
+
+    public Task<bool> HardDeleteAsync(string id, CancellationToken ct = default)
+    {
+        lock (_lock) return Task.FromResult(_entries.Remove(id));
+    }
+}

--- a/tests/Eidet.Benchmark.Tests/BenchmarkScorecardTests.cs
+++ b/tests/Eidet.Benchmark.Tests/BenchmarkScorecardTests.cs
@@ -1,0 +1,93 @@
+using Eidet.Core.Benchmark;
+
+namespace Eidet.Benchmark.Tests;
+
+/// <summary>
+/// The CI regression guard for the retrieval scorecard: v2 fusion must strictly beat the flat baseline
+/// on every metric of the adversarial Recall dataset, the absolute Fused numbers must clear
+/// conservative floors, fusion must NOT score a perfect 1.0 (the dataset includes cases it cannot
+/// solve, so the headline can't read as a self-drawn curve), every metric must be finite and in
+/// [0, 1], and the run must be deterministic.
+/// </summary>
+public class BenchmarkScorecardTests
+{
+    private static BenchmarkReport RunRecall() =>
+        BenchmarkRunner.Run(GoldDataset.Cases, GoldDataset.Now);
+
+    private static CapabilityScore Recall(IReadOnlyList<CapabilityScore> scores) =>
+        scores.Single(s => s.Capability == AmaCapability.Recall);
+
+    [Fact]
+    public void Fusion_StrictlyBeatsFlatBaseline_OnEveryMetric()
+    {
+        var report = RunRecall();
+        var fused = Recall(report.Fused);
+        var baseline = Recall(report.Baseline);
+
+        Assert.True(fused.RecallAtK > baseline.RecallAtK,
+            $"fused recall@k ({fused.RecallAtK}) must exceed baseline ({baseline.RecallAtK})");
+        Assert.True(fused.GoldSurvival > baseline.GoldSurvival,
+            $"fused gold survival ({fused.GoldSurvival}) must exceed baseline ({baseline.GoldSurvival})");
+        Assert.True(fused.Mrr > baseline.Mrr,
+            $"fused MRR ({fused.Mrr}) must exceed baseline ({baseline.Mrr})");
+        Assert.True(fused.NdcgAtK > baseline.NdcgAtK,
+            $"fused nDCG@k ({fused.NdcgAtK}) must exceed baseline ({baseline.NdcgAtK})");
+    }
+
+    [Fact]
+    public void FusedRecall_ClearsConservativeFloors_ButIsNotPerfect()
+    {
+        var fused = Recall(RunRecall().Fused);
+
+        // Conservative floors below the current Fused numbers — a guard against ranking regressions,
+        // not a tight pin. (Current: recall 0.833, survival 0.792, MRR 0.889, nDCG 0.833.)
+        Assert.True(fused.RecallAtK >= 0.75, $"fused recall@k was {fused.RecallAtK}");
+        Assert.True(fused.GoldSurvival >= 0.70, $"fused gold survival was {fused.GoldSurvival}");
+        Assert.True(fused.Mrr >= 0.80, $"fused MRR was {fused.Mrr}");
+        Assert.True(fused.NdcgAtK >= 0.75, $"fused nDCG@k was {fused.NdcgAtK}");
+
+        // The dataset MUST contain cases fusion cannot fully solve — otherwise a perfect score would
+        // read as grading on a self-drawn curve. This locks in the honesty of the headline number.
+        Assert.True(fused.RecallAtK < 1.0,
+            "dataset should include cases fusion does not fully solve (no perfect-1.0 curve)");
+    }
+
+    [Fact]
+    public void AllMetrics_AreFinite_AndInUnitInterval()
+    {
+        var report = RunRecall();
+        foreach (var score in report.Fused.Concat(report.Baseline))
+        {
+            AssertUnit(score.RecallAtK);
+            AssertUnit(score.Mrr);
+            AssertUnit(score.NdcgAtK);
+            AssertUnit(score.GoldSurvival);
+        }
+    }
+
+    [Fact]
+    public void Run_IsDeterministic_AcrossRepeatedCalls()
+    {
+        var a = RunRecall();
+        var b = RunRecall();
+        Assert.Equal(a.ToMarkdown(), b.ToMarkdown());
+    }
+
+    [Fact]
+    public async Task FullScorecard_IncludingStateUpdating_RendersDeterministically()
+    {
+        var first = (await ScorecardBuilder.BuildAsync()).ToMarkdown();
+        var second = (await ScorecardBuilder.BuildAsync()).ToMarkdown();
+        Assert.Equal(first, second);
+
+        // StateUpdating (the FAMA guard) must pass — it is the StateUpdating capability line.
+        Assert.True(await FamaForgetTests.StateUpdatingPasses());
+    }
+
+    private static void AssertUnit(double value)
+    {
+        Assert.False(double.IsNaN(value), "metric was NaN");
+        Assert.False(double.IsInfinity(value), "metric was Infinity");
+        Assert.InRange(value, 0.0, 1.0);
+    }
+}

--- a/tests/Eidet.Benchmark.Tests/Eidet.Benchmark.Tests.csproj
+++ b/tests/Eidet.Benchmark.Tests/Eidet.Benchmark.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="10.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Eidet.Core\Eidet.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Eidet.Benchmark.Tests/FamaForgetTests.cs
+++ b/tests/Eidet.Benchmark.Tests/FamaForgetTests.cs
@@ -1,0 +1,131 @@
+using Eidet.Core.Domain;
+using Eidet.Core.Services;
+
+namespace Eidet.Benchmark.Tests;
+
+/// <summary>
+/// FAMA (forget-and-modify-aware) behavioral guard for the AMA-Bench <c>StateUpdating</c>
+/// capability: once a memory is superseded or forgotten, the stale version must never resurface in
+/// recall or wake-up context — including across a cross-repo fan-out — while a live sibling still
+/// does. Driven through the real <see cref="MemoryService"/> over <see cref="BenchInMemoryStore"/>.
+/// The boolean outcome feeds the scorecard's StateUpdating row (see <see cref="StateUpdatingPasses"/>).
+/// </summary>
+public class FamaForgetTests
+{
+    private const string RepoA = "fama-repo-a";
+    private const string RepoB = "fama-repo-b";
+
+    private static (MemoryService Svc, BenchInMemoryStore Store) NewService()
+    {
+        var store = new BenchInMemoryStore();
+        var layers = new LayerService(store);
+        return (new MemoryService(store, layers), store);
+    }
+
+    /// <summary>Asserts the store succeeded and returns its (now non-null) id.</summary>
+    private static string Id(StoreResult result)
+    {
+        Assert.True(result.Success, result.Reason);
+        Assert.NotNull(result.Id);
+        return result.Id;
+    }
+
+    [Fact]
+    public async Task Supersede_RecallAndContext_ReturnTheLiveVersionNeverTheStale()
+    {
+        var (svc, _) = NewService();
+
+        var originalId = Id(await svc.StoreAsync(
+            RepoA, "Recall fuses lexical and vector arms with min-max normalization", MemoryType.Insight));
+
+        // Supersede via a content edit — the EditAsync path flips IsLatest=false on the original
+        // and stores a fresh live entry.
+        var edited = await svc.UpdateMemoryAsync(
+            originalId, content: "Recall fuses lexical and vector arms plus a UCB exploration bonus");
+        Assert.True(edited);
+
+        var recalled = await svc.RecallAsync(RepoA, "recall fuses arms");
+        Assert.DoesNotContain(recalled, r => r.Id == originalId);          // stale original gone
+        Assert.Contains(recalled, r => r.Content.Contains("UCB"));         // live version present
+
+        var context = await svc.GetContextAsync(RepoA);
+        Assert.DoesNotContain(originalId, context);
+    }
+
+    [Fact]
+    public async Task Forget_WithReason_NeverSurfaces_WhileLiveSiblingStillDoes()
+    {
+        var (svc, _) = NewService();
+
+        var doomedId = Id(await svc.StoreAsync(
+            RepoA, "Embedded RavenDB is the zero-setup default storage mode", MemoryType.Insight));
+        var siblingId = Id(await svc.StoreAsync(
+            RepoA, "External RavenDB mode targets an existing cluster install", MemoryType.Insight));
+
+        var forgotten = await svc.ForgetAsync(doomedId, reason: "Storage mode was consolidated");
+        Assert.True(forgotten);
+
+        var recalled = await svc.RecallAsync(RepoA, "ravendb storage mode");
+        Assert.DoesNotContain(recalled, r => r.Id == doomedId);
+        Assert.Contains(recalled, r => r.Id == siblingId);
+
+        var context = await svc.GetContextAsync(RepoA);
+        Assert.DoesNotContain(doomedId, context);
+    }
+
+    [Fact]
+    public async Task CrossRepo_StaleSuppression_HoldsAcrossTheMountedLayerUnion()
+    {
+        var (svc, store) = NewService();
+
+        // Mount a shared layer so a recall in RepoA fans out to RepoB.
+        await store.StoreMountedLayerAsync(new MemoryLayer
+        {
+            Id = "layers/shared/fama",
+            Name = "fama-shared",
+            Type = LayerType.Shared,
+            ApplicableRepos = [RepoA],
+            ApplicablePackages = [],
+        });
+        // The layer also resolves when querying RepoA's mounted layers; it adds RepoB to the union.
+        var layer = await store.GetLayerAsync("layers/shared/fama");
+        layer!.ApplicableRepos = [RepoA, RepoB];
+        await store.StoreMountedLayerAsync(layer);
+
+        var inBId = Id(await svc.StoreAsync(
+            RepoB, "Cross-repo recall fans out across mounted shared layers", MemoryType.Insight));
+
+        // Sanity: the cross-repo recall reaches RepoB's entry from RepoA.
+        var before = await svc.RecallAsync(RepoA, new RecallOptions("cross-repo recall fans out") { CrossRepo = true });
+        Assert.Contains(before, r => r.Id == inBId);
+
+        // Forget it; the cross-repo recall must no longer surface it.
+        Assert.True(await svc.ForgetAsync(inBId, reason: "No longer relevant cross-repo"));
+        var after = await svc.RecallAsync(RepoA, new RecallOptions("cross-repo recall fans out") { CrossRepo = true });
+        Assert.DoesNotContain(after, r => r.Id == inBId);
+    }
+
+    /// <summary>
+    /// The StateUpdating pass-rate the scorecard reports: runs the three guards and returns true only
+    /// if every one holds. Kept as a static so the scorecard build (<see cref="BenchmarkScorecardTests"/>)
+    /// can fold it into the StateUpdating capability line without duplicating the scenarios.
+    /// </summary>
+    public static async Task<bool> StateUpdatingPasses()
+    {
+        var t = new FamaForgetTests();
+        try
+        {
+            await t.Supersede_RecallAndContext_ReturnTheLiveVersionNeverTheStale();
+            await t.Forget_WithReason_NeverSurfaces_WhileLiveSiblingStillDoes();
+            await t.CrossRepo_StaleSuppression_HoldsAcrossTheMountedLayerUnion();
+            return true;
+        }
+        catch (Xunit.Sdk.XunitException)
+        {
+            // Only assertion failures map to "capability does not hold" → false. A non-assertion
+            // exception (NRE, store fault) is a genuine bug and is deliberately left to propagate
+            // and fail the build, rather than being silently scored as a clean fail.
+            return false;
+        }
+    }
+}

--- a/tests/Eidet.Benchmark.Tests/GoldDataset.cs
+++ b/tests/Eidet.Benchmark.Tests/GoldDataset.cs
@@ -1,0 +1,273 @@
+using Eidet.Core.Benchmark;
+using Eidet.Core.Domain;
+using Eidet.Core.Storage;
+
+namespace Eidet.Benchmark.Tests;
+
+/// <summary>
+/// Curated, adversarial in-repo gold dataset for the <see cref="AmaCapability.Recall"/> heading.
+///
+/// The win cases model the failure mode issue #33 fixed: the gold memory has <b>combined</b> relevance
+/// — present in both arms, strong in one — so its min-max-normalized fused score strictly exceeds any
+/// single-arm distractor (no ties, robust to sort order), while the flat baseline, which discards the
+/// arm scores and keeps lexical hits in backend order ahead of the vector-only tail, truncates the
+/// vector-strong-but-lexically-late gold at the budget boundary. On several cases the baseline still
+/// keeps gold (it lands inside k) but ranks it far lower, so the lift there is on MRR/nDCG, not recall.
+///
+/// The set deliberately includes cases the v2 ranker does <b>not</b> ace — gold genuinely weak in both
+/// arms (case 10), a type budget that caps survival for every ranker (case 11), and a distractor that
+/// is simply more relevant than gold (case 12) — plus a both-arms-strong sanity anchor (case 9) the
+/// baseline also wins. So the scorecard reports a real, non-perfect number, not a self-drawn curve.
+///
+/// All entries share a fixed <see cref="Now"/> creation time, so recency is a constant 1.0 and the
+/// fused ranking is driven purely by the normalized lexical+vector blend. Memory types are varied so
+/// the type-budget pass genuinely engages.
+/// </summary>
+public static class GoldDataset
+{
+    /// <summary>Fixed clock — every entry is "just created" so recency is identical and constant.</summary>
+    public static readonly DateTime Now = new(2026, 6, 20, 0, 0, 0, DateTimeKind.Utc);
+
+    private static MemoryEntry Entry(string id, MemoryType type) => new()
+    {
+        Id = id,
+        RepoId = "bench-repo",
+        Type = type,
+        Content = id,
+        CreatedAt = Now,
+        LastAccessedAt = null,
+        IsLatest = true,
+        Validity = new Validity { ValidFrom = Now },
+        Importance = 0.5f,
+    };
+
+    private static ScoredHit Hit(string id, MemoryType type, double score) => new(Entry(id, type), score);
+
+    private static IReadOnlySet<string> Gold(params string[] ids) =>
+        ids.ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+    public static IReadOnlyList<BenchmarkCase> Cases => _cases;
+
+    private static readonly IReadOnlyList<BenchmarkCase> _cases =
+    [
+        // ── 1. Vector-strong gold buried late in a lexical flood (k=2) ──
+        // Gold is lexically near the bottom (normLex 0.25) but tops the vector arm. Fusion lifts it to
+        // #1; the flat baseline keeps gold in the 1.0 lexical tier but behind two higher-relevance
+        // lexical distractors, so a k=2 budget drops it.
+        new("recall-vec-strong-gold-buried-in-lex-flood", AmaCapability.Recall,
+            Lex:
+            [
+                Hit("d1", MemoryType.Insight, 10.0),
+                Hit("d2", MemoryType.Insight, 8.0),
+                Hit("gold", MemoryType.Insight, 4.0),
+                Hit("d3", MemoryType.Observation, 2.0),
+            ],
+            Vec:
+            [
+                Hit("gold", MemoryType.Insight, 10.0),
+                Hit("v1", MemoryType.Insight, 2.0),
+            ],
+            GoldIds: Gold("gold"), K: 2),
+
+        // ── 2. Combined gold: mid lexical, top vector (k=2) ──
+        // Gold is 2nd in the lexical arm, so the baseline still keeps it at k=2 — but ranks it #2 while
+        // fusion ranks it #1. Lift here is on MRR/nDCG, not recall: fusion improves ordering even when
+        // the baseline doesn't lose the gold outright.
+        new("recall-combined-gold-mid-lex-top-vec", AmaCapability.Recall,
+            Lex:
+            [
+                Hit("lexOnly1", MemoryType.Insight, 10.0),
+                Hit("gold", MemoryType.Procedure, 7.5),
+                Hit("lexOnly2", MemoryType.Observation, 5.0),
+            ],
+            Vec:
+            [
+                Hit("gold", MemoryType.Procedure, 10.0),
+                Hit("vecOnly1", MemoryType.Insight, 5.0),
+                Hit("vecOnly2", MemoryType.Insight, 1.0),
+            ],
+            GoldIds: Gold("gold"), K: 2),
+
+        // ── 3. Heuristic gold, tiny lexical signal, top vector, lexically last (k=2) ──
+        // A different type (Heuristic) and a deep lexical arm: gold has the smallest lexical score but
+        // tops vector. Fusion #1; baseline truncates it (4th in the lexical tier).
+        new("recall-heuristic-gold-vec-led", AmaCapability.Recall,
+            Lex:
+            [
+                Hit("a1", MemoryType.Observation, 10.0),
+                Hit("a2", MemoryType.Observation, 8.0),
+                Hit("a3", MemoryType.Insight, 6.0),
+                Hit("gold", MemoryType.Heuristic, 3.0),
+                Hit("a4", MemoryType.Insight, 2.0),
+            ],
+            Vec:
+            [
+                Hit("gold", MemoryType.Heuristic, 10.0),
+                Hit("b1", MemoryType.Insight, 3.0),
+            ],
+            GoldIds: Gold("gold"), K: 2),
+
+        // ── 4. Two combined golds, both vector-led, behind a lexical noise wall (k=3) ──
+        // Fusion ranks both golds top-2; the baseline keeps only one (the other is 4th in the lexical
+        // tier) → recall and survival lift of 0.5.
+        new("recall-two-combined-golds", AmaCapability.Recall,
+            Lex:
+            [
+                Hit("lexNoise1", MemoryType.Insight, 10.0),
+                Hit("lexNoise2", MemoryType.Insight, 9.0),
+                Hit("goldA", MemoryType.Insight, 6.0),
+                Hit("goldB", MemoryType.Procedure, 4.0),
+                Hit("lexlow", MemoryType.Observation, 2.0),
+            ],
+            Vec:
+            [
+                Hit("goldA", MemoryType.Insight, 9.0),
+                Hit("goldB", MemoryType.Procedure, 10.0),
+                Hit("vecNoise", MemoryType.Observation, 7.0),
+            ],
+            GoldIds: Gold("goldA", "goldB"), K: 3),
+
+        // ── 5. Type-budget heuristic gold, generous k=4 ──
+        // k=4 is generous enough that the baseline keeps gold (3rd in lexical), but ranks it low; fusion
+        // ranks it #1. MRR/nDCG lift.
+        new("recall-type-budget-heuristic-gold", AmaCapability.Recall,
+            Lex:
+            [
+                Hit("i1", MemoryType.Insight, 10.0),
+                Hit("i2", MemoryType.Insight, 9.0),
+                Hit("gold", MemoryType.Heuristic, 6.0),
+                Hit("i5", MemoryType.Insight, 3.0),
+            ],
+            Vec:
+            [
+                Hit("gold", MemoryType.Heuristic, 10.0),
+                Hit("i3", MemoryType.Insight, 4.0),
+            ],
+            GoldIds: Gold("gold"), K: 4),
+
+        // ── 6. Narrow vector margin: lexically tied, separated only by the vector arm (k=1) ──
+        // Gold and the distractor tie lexically (both normalize to 1.0); only gold appears in vector.
+        // Fusion's combined score (2.0) strictly beats the distractor (1.0); the baseline, blind to the
+        // arm scores, keeps the distractor first by merge order and truncates gold at k=1.
+        new("recall-narrow-vec-margin", AmaCapability.Recall,
+            Lex:
+            [
+                Hit("distractor", MemoryType.Insight, 7.0),
+                Hit("gold", MemoryType.Insight, 7.0),
+            ],
+            Vec:
+            [
+                Hit("gold", MemoryType.Insight, 9.0),
+            ],
+            GoldIds: Gold("gold"), K: 1),
+
+        // ── 7. Deep pool, single vector-led combined gold (k=2) ──
+        new("recall-deep-pool-single-gold", AmaCapability.Recall,
+            Lex:
+            [
+                Hit("L1", MemoryType.Insight, 10.0),
+                Hit("L2", MemoryType.Observation, 9.0),
+                Hit("gold", MemoryType.Procedure, 7.0),
+                Hit("L3", MemoryType.Insight, 6.0),
+                Hit("L4", MemoryType.Observation, 5.0),
+            ],
+            Vec:
+            [
+                Hit("gold", MemoryType.Procedure, 10.0),
+                Hit("V1", MemoryType.Insight, 8.0),
+                Hit("V2", MemoryType.Insight, 6.0),
+            ],
+            GoldIds: Gold("gold"), K: 2),
+
+        // ── 8. Procedure gold behind an observation-heavy lexical arm (k=2) ──
+        // The baseline drops gold from the top-k ranking, but the type budget happens to reserve a
+        // procedure slot that pulls gold back into the survival set — so recall lifts while survival does
+        // not. A case where the two metrics diverge.
+        new("recall-procedure-gold-vs-observations", AmaCapability.Recall,
+            Lex:
+            [
+                Hit("o1", MemoryType.Observation, 10.0),
+                Hit("o2", MemoryType.Observation, 9.0),
+                Hit("gold", MemoryType.Procedure, 5.0),
+                Hit("o4", MemoryType.Observation, 2.0),
+            ],
+            Vec:
+            [
+                Hit("gold", MemoryType.Procedure, 10.0),
+                Hit("o3", MemoryType.Observation, 7.0),
+            ],
+            GoldIds: Gold("gold"), K: 2),
+
+        // ── 9. Sanity anchor: gold strong in BOTH arms — baseline wins too (no lift) ──
+        // Proves the benchmark isn't rigged pro-fusion: when gold is the obvious top lexical hit, the
+        // flat baseline recovers it just as well.
+        new("recall-gold-strong-both-arms-sanity", AmaCapability.Recall,
+            Lex:
+            [
+                Hit("gold", MemoryType.Insight, 10.0),
+                Hit("d1", MemoryType.Observation, 3.0),
+            ],
+            Vec:
+            [
+                Hit("gold", MemoryType.Insight, 10.0),
+                Hit("d2", MemoryType.Insight, 2.0),
+            ],
+            GoldIds: Gold("gold"), K: 1),
+
+        // ── 10. HARD: gold genuinely weak in both arms — fusion can't lift it (k=2) ──
+        // Gold is near the bottom of both arms; no fusion lifts a doubly-weak candidate above stronger
+        // single-arm hits. Fusion misses (recall 0, survival 0) — exactly as it should.
+        new("recall-hard-gold-weak-both-arms", AmaCapability.Recall,
+            Lex:
+            [
+                Hit("d1", MemoryType.Insight, 10.0),
+                Hit("d2", MemoryType.Insight, 8.0),
+                Hit("d3", MemoryType.Observation, 6.0),
+                Hit("gold", MemoryType.Procedure, 2.0),
+            ],
+            Vec:
+            [
+                Hit("e1", MemoryType.Insight, 10.0),
+                Hit("e2", MemoryType.Insight, 8.0),
+                Hit("gold", MemoryType.Procedure, 4.0),
+                Hit("e3", MemoryType.Observation, 2.0),
+            ],
+            GoldIds: Gold("gold"), K: 2),
+
+        // ── 11. HARD: two same-type golds, type budget admits only one (k=2) ──
+        // Both golds rank top-2 under fusion AND the baseline, but the Insight budget at k=2 is 1, so
+        // survival is capped at 0.5 for every ranker. A ranker-independent ceiling — the lift is 0 here.
+        new("recall-hard-budget-caps-survival", AmaCapability.Recall,
+            Lex:
+            [
+                Hit("goldA", MemoryType.Insight, 9.0),
+                Hit("goldB", MemoryType.Insight, 7.0),
+                Hit("d1", MemoryType.Observation, 2.0),
+            ],
+            Vec:
+            [
+                Hit("goldA", MemoryType.Insight, 8.0),
+                Hit("goldB", MemoryType.Insight, 10.0),
+                Hit("v1", MemoryType.Observation, 1.0),
+            ],
+            GoldIds: Gold("goldA", "goldB"), K: 2),
+
+        // ── 12. HARD: a distractor is simply more relevant than gold (k=1) ──
+        // The "dCombo" distractor is combined-strong in both arms and outranks gold on the merits.
+        // Fusion correctly ranks it #1, so gold misses at k=1 — fusion ranking by relevance, not bias.
+        new("recall-hard-superior-distractor", AmaCapability.Recall,
+            Lex:
+            [
+                Hit("dCombo", MemoryType.Insight, 9.0),
+                Hit("gold", MemoryType.Procedure, 6.0),
+                Hit("d2", MemoryType.Observation, 2.0),
+            ],
+            Vec:
+            [
+                Hit("dCombo", MemoryType.Insight, 10.0),
+                Hit("gold", MemoryType.Procedure, 7.0),
+                Hit("v1", MemoryType.Insight, 1.0),
+            ],
+            GoldIds: Gold("gold"), K: 1),
+    ];
+}

--- a/tests/Eidet.Benchmark.Tests/ScorecardBuilder.cs
+++ b/tests/Eidet.Benchmark.Tests/ScorecardBuilder.cs
@@ -1,0 +1,35 @@
+using Eidet.Core.Benchmark;
+
+namespace Eidet.Benchmark.Tests;
+
+/// <summary>
+/// Assembles the canonical <see cref="BenchmarkReport"/> the committed scorecard renders from: the
+/// Recall capability from <see cref="GoldDataset"/> run through <see cref="BenchmarkRunner"/>, plus a
+/// StateUpdating row carrying the FAMA forget/supersede pass-rate. StateUpdating correctness is
+/// ranker-independent (forget/supersede suppression is not a fusion feature), so its Fused and
+/// Baseline values are equal — the row reports the behavioral guarantee, not a fusion lift.
+/// </summary>
+public static class ScorecardBuilder
+{
+    /// <summary>Builds the report at <see cref="GoldDataset.Now"/>; deterministic given the dataset + FAMA result.</summary>
+    public static async Task<BenchmarkReport> BuildAsync()
+    {
+        var recall = BenchmarkRunner.Run(GoldDataset.Cases, GoldDataset.Now);
+        var famaPass = await FamaForgetTests.StateUpdatingPasses() ? 1.0 : 0.0;
+        var stateUpdating = StateUpdatingRow(famaPass);
+
+        return new BenchmarkReport(
+            Fused: Append(recall.Fused, stateUpdating),
+            Baseline: Append(recall.Baseline, stateUpdating));
+    }
+
+    private static CapabilityScore StateUpdatingRow(double passRate) =>
+        // One aggregate "case" — the combined FAMA guard. Every metric reflects the same pass-rate
+        // so the row reads as a clean pass/fail across all columns.
+        new(AmaCapability.StateUpdating, Cases: 1,
+            RecallAtK: passRate, Mrr: passRate, NdcgAtK: passRate, GoldSurvival: passRate);
+
+    private static IReadOnlyList<CapabilityScore> Append(
+        IReadOnlyList<CapabilityScore> scores, CapabilityScore extra) =>
+        scores.Append(extra).OrderBy(s => s.Capability).ToList();
+}

--- a/tests/Eidet.Benchmark.Tests/ScorecardSyncTests.cs
+++ b/tests/Eidet.Benchmark.Tests/ScorecardSyncTests.cs
@@ -1,0 +1,52 @@
+using Eidet.Core.Benchmark;
+
+namespace Eidet.Benchmark.Tests;
+
+/// <summary>
+/// Guards that the committed <c>docs/benchmark.md</c> is the truthful, current output of
+/// <see cref="BenchmarkReport.ToMarkdown"/>. Set <c>EIDET_BENCH_WRITE=1</c> to regenerate the file
+/// instead of asserting (the dev escape hatch). Skips silently when the repo root can't be located
+/// (e.g. a packaged run), so the guard never produces a false failure off a developer checkout.
+/// </summary>
+public class ScorecardSyncTests
+{
+    [Fact]
+    public async Task CommittedScorecard_MatchesRenderedMarkdown()
+    {
+        var repoRoot = FindRepoRoot();
+        if (repoRoot is null) return; // not a source checkout — nothing to guard
+
+        var path = Path.Combine(repoRoot, "docs", "benchmark.md");
+        var report = await ScorecardBuilder.BuildAsync();
+        var rendered = report.ToMarkdown();
+
+        if (Environment.GetEnvironmentVariable("EIDET_BENCH_WRITE") == "1")
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            File.WriteAllText(path, rendered);
+            return;
+        }
+
+        Assert.True(File.Exists(path),
+            $"docs/benchmark.md is missing. Regenerate it with EIDET_BENCH_WRITE=1.");
+
+        var committed = File.ReadAllText(path);
+        Assert.Equal(Normalize(rendered), Normalize(committed));
+    }
+
+    /// <summary>Walks up from the test's base directory until it finds the dir containing Eidet.slnx.</summary>
+    private static string? FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "Eidet.slnx")))
+                return dir.FullName;
+            dir = dir.Parent;
+        }
+        return null;
+    }
+
+    /// <summary>Compare on content, not line-ending flavor, so the guard is cross-platform.</summary>
+    private static string Normalize(string s) => s.Replace("\r\n", "\n").Replace("\r", "\n");
+}


### PR DESCRIPTION
## Summary

Stand up a local, deterministic, CI-runnable retrieval benchmark (issue #36, the "local scorecard" scope) — closing *the one real hole: no published benchmark number*. It measures the part of recall Eidet **owns** (ranking, hybrid fusion, type-budget quality), **not** embedding quality (RavenDB owns that) and **not** the external SWE Context Bench leaderboard (a deferred epic — see below).

## What it does

- Each gold case scripts per-arm `(lex, vec)` scores → runs the **real** `RecallScoring.Fuse` + `ApplyTypeBudgets` → scored under two rankers on the same data: **v2 fusion vs a faithful pre-#33 flat baseline** (lex=1.0, vec-only=0.9, no normalization/UCB/recency, stable merge order).
- Metrics: **Recall@k, MRR, nDCG@k, gold-survives-truncation%**, under AMA-Bench's four capability headings.
- **Headline lift** (adversarial Recall set): Recall **+0.46**, nDCG **+0.55**, gold-survival **+0.38**. Fusion is strong but deliberately **not** perfect (0.833 recall) — the dataset includes cases it can't fully solve, so the number isn't a self-drawn curve.
- Causal Inference / State Abstraction → marked **N/A** (need an LLM in the loop), not fabricated.
- The **FAMA forget/supersede** behavioral test is the *State Updating* capability: after a forget/supersede, the stale version never resurfaces in recall, context, or cross-repo, while the live one does.
- `docs/benchmark.md` is committed and citable; a sync test keeps it truthful (byte-asserted in CI, `EIDET_BENCH_WRITE=1` to regenerate).

## Quality gates

Ran through the 4-agent pipeline (implement → test → review ∥ verify). The reviewer caught **two integrity issues**, both fixed before this PR:

1. the flat baseline used an artificial alphabetical id tiebreak that **inflated** the lift → now reproduces the real pre-#33 stable merge order (the reported lift is genuine, not a strawman);
2. gold tied distractors on the exact fused score under an unstable sort → the dataset now gives gold **strict combined-relevance margins** (present in both arms, strong in one), so outcomes are robust to sort order with no ties.

Verifier: conforms on all scope items.

## Test plan

- `dotnet build Eidet.slnx -c Release` — benchmark code adds **0 warnings**.
- **Core 526 + Benchmark 9** green.

## Heads-up (unrelated, separate follow-up)

A clean Core rebuild surfaces a pre-existing **`CS0618`** on `RavenLooseEndStore.cs:73` (`UseOptimisticConcurrency`, from the just-merged #46) — unrelated to this PR and not failing CI (warnings ≠ errors). Recommend a small focused follow-up to migrate it to `OptimisticConcurrencyMode`, with the #46 concurrency tests as the guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01LejT5wHAhq2pKSaYA4hZdf
