### PR TITLE
fix(storage): migrate to OptimisticConcurrencyMode (RavenDB 7.2 CS0618)

### DIFF
--- a/src/Eidet.Core/Storage/RavenLooseEndStore.cs
+++ b/src/Eidet.Core/Storage/RavenLooseEndStore.cs
@@ -70,7 +70,7 @@ public sealed class RavenLooseEndStore : ILooseEndStore
         // claims race on the change vector: exactly one SaveChanges wins Open→Resolving, the loser sees
         // ConcurrencyException and returns false — the atomic gate that stops a double-mint promote.
         using var session = _store.OpenAsyncSession();
-        session.Advanced.UseOptimisticConcurrency = true;
+        session.Advanced.OptimisticConcurrencyMode = Raven.Client.Documents.Session.OptimisticConcurrencyMode.Writes;
         var end = await session.LoadAsync<LooseEnd>(id, ct);
         if (end is null || end.State != LooseEndState.Open) return false;
         end.State = LooseEndState.Resolving;


### PR DESCRIPTION
## What

`session.Advanced.UseOptimisticConcurrency` is obsolete in RavenDB 7.2.4 (CS0618). Replace the single use in `RavenLooseEndStore.TryClaimForResolveAsync` with `OptimisticConcurrencyMode.Writes`.

This is the documented like-for-like: `UseOptimisticConcurrency = true` always meant write-time change-vector checks, which is exactly `OptimisticConcurrencyMode.Writes`. Behavior is unchanged — the atomic `Open→Resolving` claim gate still races on the change vector, exactly one `SaveChanges` wins, the loser sees `ConcurrencyException` and returns false.

Pre-existing warning introduced by #46; surfaced after the RavenDB 7.2.4 bump (#43).

## Verification

- Core clean rebuild (`--no-incremental`): **0 warnings, 0 errors**
- LooseEnd Core tests: **22/22**
- Integration tests (boot embedded RavenDB + construct `RavenLooseEndStore`): **11/11**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LejT5wHAhq2pKSaYA4hZdf