### PR TITLE
feat(security): memory provenance/trust tier + consolidation carry-through (#34)

### DIFF
--- a/STRIDE.md
+++ b/STRIDE.md
@@ -1,6 +1,6 @@
 # Eidet - STRIDE Threat Model
 
-**Version:** 1.0
+**Version:** 1.1
 **Created:** 2026-04-12
 **Author:** Steve Hansen
 **Next Review:** 2027-04-12
@@ -113,10 +113,14 @@ Eidet is a local-first long-term memory service for AI coding agents. It provide
 | T-4 | Backup tampering | Attacker modifies .eidetbackup manifest or contents | 1 | 3 | 3 | SHA256 checksum verified on restore (BackupService.cs:115). Tampering both data and manifest checksum in a consistent way requires understanding the format. |
 | T-5 | Environment variable injection | Attacker sets `EIDET_RAVEN_URL` to redirect database traffic to attacker-controlled server | 1 | 4 | 4 | Requires process-level env var access. No URL validation on config load. |
 | T-6 | Memory content manipulation via API | Authenticated attacker stores misleading memories to poison agent knowledge | 2 | 2 | 4 | Write gate blocks secrets and low-signal content. Scope model limits write access. Quality dashboard detects anomalies. |
+| T-7 | Single-shot memory poisoning via pack import | Attacker crafts one Pack/Intake memory — especially a Procedure or Heuristic — that an agent recalls and acts on without it ever being echoed (MemoryGraft, trigger-free, single-shot — arXiv:2512.16962) | 2 | 4 | **8** | **Provenance/trust tier** (`MemoryTrust`) — derived, never-stored trust factor gates retrieval weight. Pack/Intake float at 0.5, Procedure/Heuristic at 0.7 (floors combine as `min`); only earned echoes lift a memory toward 1.0. A freshly-injected, never-echoed pack Procedure is held at 0.5 in recall scoring, below trusted first-party memories. Import hardening: a pack's self-declared `provenance=` cannot escalate trust above the Pack floor — `MarkdownPackFormat` clamps any trust-raising declaration back to `Pack`, so an attacker controlling the pack bytes cannot self-assign first-party trust. |
+| T-8 | Provenance laundering via consolidation | Attacker injects a poisoned Pack/Intake observation, then relies on consolidation to fold it into a high-trust Insight (`Provenance=Consolidation`), erasing the low-trust origin (compression-amplified toxin) | 2 | 3 | 6 | **Consolidation carry-through** — a new insight derived from any untrusted source inherits the *least-trusted* contributor's provenance (not `Consolidation`), so the trust tier keeps demoting it. The boost path admits only trusted sources: untrusted matches can neither raise a trusted insight's importance nor contaminate its lineage. |
 
 **Countermeasures in place:**
 - Write gate with SecretScanner (13 patterns) and SignalGate (WriteGate.cs)
 - Pack imports isolated to read-only layers with de-boost scoring
+- Provenance/trust tier (`MemoryTrust`, MemoryTrust.cs) — derived per-recall trust factor gating retrieval weight; deterministic, local, always-on; no stored field to forge
+- Consolidation provenance carry-through (ConsolidationEngine.cs) — prevents laundering a poisoned source into a trusted insight
 - Backup SHA256 checksum verification
 - API key scopes restrict write access
 - Quality dashboard detects low-confidence and conflicting memories
@@ -186,6 +190,23 @@ Eidet is a local-first long-term memory service for AI coding agents. It provide
 - RavenDB access via strongly-typed LINQ API (no injection)
 - System.Text.Json for serialization (no type-based deserialization attacks)
 
+### 2.7 Memory-Lifecycle Security Taxonomy
+
+The STRIDE tables above are categorized by attacker action. Because Eidet's core asset is a *memory* that flows through a lifecycle, this taxonomy cross-cuts that view: the 6-phase × 4-objective grid from the Mnemonic Sovereignty survey (arXiv:2604.16548) maps where each security objective is enforced as a memory moves from ingestion to sharing. It exists to surface gaps — a blank cell is an unguarded phase/objective pair.
+
+Objectives: **Confidentiality** (who may read it), **Integrity** (it is not tampered with), **Availability** (it survives and is retrievable), **Provenance** (its origin and trust are known and honest).
+
+| Phase | Confidentiality | Integrity | Availability | Provenance |
+|-------|-----------------|-----------|--------------|------------|
+| **Ingest** | SecretScanner blocks credential storage; API scopes gate writes | SignalGate rejects low-signal content; strongly-typed deserialization | — | `MemoryProvenance` stamped on every write; pack/intake tagged at the import surface |
+| **Store** | OS file permissions on RavenDB data dir; localhost-only binding | Append-only model with validity intervals | Maintenance TTL + retention; backups | Provenance + `Source` + `DerivedFrom` persisted; never mutated in place |
+| **Retrieve** | API key scopes on read endpoints | Non-local de-boost (0.8×) on mounted layers | Hybrid lexical+vector recall; type budgets | **Trust tier (`MemoryTrust`) gates retrieval weight** — pack/intake & procedure/heuristic held provisional until echoed |
+| **Consolidate** | Runs in-process, no new exposure | Dedup + supersession chains | Importance boost keeps salient insights alive | **Provenance carry-through** — untrusted sources cannot launder into a trusted insight; boost admits trusted sources only |
+| **Forget** | Soft-delete hides content from recall | Forget audit observation with reason + `DerivedFrom` | Soft-delete preserves history (recoverable) | Audit trail records who/why; version chain via `eidet_history` |
+| **Share** | Packs are read-only layers; no auto-share | No pack signature verification *(residual — T-1)* | Pack export/import portability | Provenance survives export (markdown frontmatter); imported packs stay provisional via trust tier |
+
+Known gaps (tracked above): no pack signature verification (T-1, T-7 attack surface), no per-request read audit (R-1), no encryption at rest for backups (I-4).
+
 ---
 
 ## 3. Risk Summary
@@ -198,6 +219,7 @@ Eidet is a local-first long-term memory service for AI coding agents. It provide
 | T-2 | Config file modification (add hooks, change RavenDB URL, disable auth) | 8 | Accepted — attacker with config write access already has equivalent system access. Improve startup logging to show configured hooks and connection targets. |
 | T-3 | Unverified binary update from GitHub | 8 | Accepted — immutable releases enabled on GitHub, HTTPS transport, public repo/actions. Improve update command to show full download URI. |
 | I-1 | Exception message leakage in API 500 responses | 9 | To fix — return generic error messages instead of raw exception details. |
+| T-7 | Single-shot memory poisoning via pack import | 8 | Mitigated — provenance/trust tier holds never-echoed pack/procedure memories below trusted first-party recall weight. Residual: no pack signature verification (T-1). |
 | E-1 | Arbitrary command execution via hook config | 8 | Accepted — same trust boundary as T-2. Hooks run at same privilege as user. Log configured hooks at startup. |
 
 ### 3.2 Residual Risks
@@ -220,6 +242,7 @@ Eidet is a local-first long-term memory service for AI coding agents. It provide
 | **Secret Prevention** | SecretScanner with 13 regex patterns (AWS, GitHub, JWT, private keys, etc.), runs before all writes |
 | **Input Validation** | SignalGate rejects low-signal content, entity extraction length/format validation, System.Text.Json strongly-typed deserialization |
 | **Data Integrity** | Append-only model with validity intervals, backup SHA256 checksums, soft-delete with audit trail |
+| **Provenance & Trust** | `MemoryProvenance` stamped on every write; derived `MemoryTrust` factor gates retrieval weight (pack/intake & procedure/heuristic provisional until echoed); consolidation carry-through blocks provenance laundering — deterministic, local, always-on |
 | **XSS Prevention** | escHtml() in Web UI for all user content, path traversal protection for embedded file serving |
 | **Process Isolation** | Hook execution with UseShellExecute=false, configurable timeout, process tree kill |
 | **Quality Monitoring** | QualityService with 8 checks (stale, high-fizzle, conflicts, orphans, tag concentration, type imbalance, low-confidence, missing entities) |
@@ -232,6 +255,7 @@ Eidet is a local-first long-term memory service for AI coding agents. It provide
 | Version | Date | Author | Changes |
 |---------|------|--------|---------|
 | 1.0 | 2026-04-12 | Steve Hansen | Initial STRIDE analysis covering all 10 implementation phases |
+| 1.1 | 2026-06-22 | Steve Hansen | Added provenance/trust tier (T-7 single-shot poisoning, T-8 consolidation laundering) and the 6-phase × 4-objective memory-lifecycle security taxonomy (§2.7) |
 
 ---
 
@@ -241,3 +265,5 @@ Eidet is a local-first long-term memory service for AI coding agents. It provide
 - [OWASP Top 10](https://owasp.org/www-project-top-ten/) — Web Application Security Risks
 - [RavenDB Security](https://ravendb.net/docs/article-page/7.0/csharp/server/security/overview) — RavenDB Documentation
 - [MCP Specification](https://modelcontextprotocol.io/) — Model Context Protocol
+- [MemoryGraft: Trigger-Free Single-Shot Memory Poisoning](https://arxiv.org/abs/2512.16962) — arXiv:2512.16962
+- [Mnemonic Sovereignty: A Memory-Lifecycle Security Survey](https://arxiv.org/abs/2604.16548) — arXiv:2604.16548

--- a/src/Eidet.Core/Domain/MemoryQuery.cs
+++ b/src/Eidet.Core/Domain/MemoryQuery.cs
@@ -23,6 +23,7 @@ public class MemorySearchResult
     public string? OneLiner { get; set; }
     public DateTime CreatedAt { get; set; }
     public float Score { get; set; }
+    public float TrustFactor { get; set; } = 1.0f;
     public string? LayerSource { get; set; }
     public int AgeDays { get; set; }
     public string? StalenessWarning { get; set; }

--- a/src/Eidet.Core/Maintenance/ConsolidationEngine.cs
+++ b/src/Eidet.Core/Maintenance/ConsolidationEngine.cs
@@ -1,5 +1,6 @@
 using Eidet.Core.Domain;
 using Eidet.Core.Enrichment;
+using Eidet.Core.Memory;
 using Eidet.Core.Services;
 using Eidet.Core.Storage;
 
@@ -74,9 +75,16 @@ public sealed class ConsolidationEngine
             var existingInsight = await _store.FindDuplicateAsync(repoId, representative.Content, 0.85f, ct);
             if (existingInsight is not null && existingInsight.Type == MemoryType.Insight)
             {
-                existingInsight.Importance = Math.Min(1.0f, existingInsight.Importance + 0.05f * group.Count);
+                // Anti-laundering (boost path): only trusted sources may lift a trusted insight. An
+                // attacker must not be able to raise a good insight's importance — or contaminate its
+                // lineage — by injecting low-trust (Pack/Intake) observations that happen to match it.
+                // No trusted contributors → skip the boost entirely (a "compression-amplified toxin").
+                var trusted = group.Where(IsTrustedSource).ToList();
+                if (trusted.Count == 0) continue;
+
+                existingInsight.Importance = Math.Min(1.0f, existingInsight.Importance + 0.05f * trusted.Count);
                 existingInsight.DerivedFrom = existingInsight.DerivedFrom
-                    .Concat(candidate.ObservationIds)
+                    .Concat(trusted.Select(o => o.Id))
                     .Distinct()
                     .ToList();
                 await ctx.WriteAsync(existingInsight, ct);
@@ -93,6 +101,16 @@ public sealed class ConsolidationEngine
                         mergedContent = merged;
                 }
 
+                // Anti-laundering (create path): if ANY contributing observation is untrusted
+                // (Pack/Intake), stamp the new insight with the least-trusted contributor's
+                // provenance instead of Consolidation, so MemoryTrust.Factor keeps demoting it at
+                // recall. This stops an attacker laundering a poisoned observation into a fully
+                // trusted insight ("compression-amplified toxin"). The audit trail — Source and
+                // DerivedFrom — is preserved untouched.
+                var provenance = group.Any(o => !IsTrustedSource(o))
+                    ? group.OrderBy(o => MemoryTrust.ProvenanceTrust(o.Provenance)).First().Provenance
+                    : MemoryProvenance.Consolidation;
+
                 var now = DateTime.UtcNow;
                 var insight = new MemoryEntry
                 {
@@ -103,7 +121,7 @@ public sealed class ConsolidationEngine
                     Tags = unionTags,
                     Importance = proposedImportance,
                     Source = "consolidation",
-                    Provenance = MemoryProvenance.Consolidation,
+                    Provenance = provenance,
                     Confidence = 0.7f,
                     CreatedAt = now,
                     Validity = new Validity { ValidFrom = now },
@@ -117,6 +135,11 @@ public sealed class ConsolidationEngine
         }
         return 0;
     }
+
+    /// <summary>An observation counts as a trusted source unless its origin is a known poisoning
+    /// surface (Pack/Intake), i.e. its provenance trust floor is the full 1.0.</summary>
+    private static bool IsTrustedSource(MemoryEntry obs) =>
+        MemoryTrust.ProvenanceTrust(obs.Provenance) >= 1.0;
 
     public async Task<int> ApplyImportanceDecayAsync(
         string repoId, bool isRepoActive = true, CancellationToken ct = default, BulkMutationCtx? write = null)

--- a/src/Eidet.Core/Memory/MemoryTrust.cs
+++ b/src/Eidet.Core/Memory/MemoryTrust.cs
@@ -1,0 +1,64 @@
+using Eidet.Core.Domain;
+
+namespace Eidet.Core.Memory;
+
+/// <summary>
+/// Derived, never-stored trust factor for a memory — the deterministic anti-poisoning gate.
+/// A memory's trust is recomputed on every recall from its provenance, type, and earned feedback;
+/// there is no stored trust field to forge, lie about, or let drift out of sync with the evidence.
+///
+/// The gate exists because the most dangerous memories are the cheapest to inject: a single
+/// imported pack entry (MemoryGraft-style single-shot poisoning) or a wrongly-recalled
+/// Procedure/Heuristic is net-negative even before it is echoed. So both the import surface
+/// (Intake/Pack) and the action-shaped types (Procedure/Heuristic) start PROVISIONAL — their
+/// retrieval weight is held below full trust — and only earned echoes (minus fizzles) lift them
+/// back toward 1.0. Untainted first-party knowledge (UserStated/AgentInferred/ToolOutput/System
+/// observations and insights) is fully trusted from the start, so this never penalizes the
+/// honest path.
+/// </summary>
+public static class MemoryTrust
+{
+    /// <summary>Smoothing constant for the echo-lift term — keeps a memory provisional until it has
+    /// accumulated several echoes, so a single feedback event cannot flip it to full trust.</summary>
+    private const double EchoSmoothing = 3.0;
+
+    /// <summary>Trust floor for the import / poisoning surface (Intake, Pack); 1.0 for everything else.</summary>
+    private const double ImportTrust = 0.5;
+
+    /// <summary>Trust floor for action-shaped types (Procedure, Heuristic); 1.0 for Insight/Observation.</summary>
+    private const double ActionTypeTrust = 0.7;
+
+    /// <summary>
+    /// Trust factor in (0, 1.0], where 1.0 means full trust (no retrieval penalty). Starts at the
+    /// lower of the provenance and type floors, then lets earned echoes lift it toward 1.0:
+    /// <c>trust = base + (1 - base) · echo/(echo + fizzle + K)</c>.
+    /// </summary>
+    public static double Factor(MemoryEntry entry)
+    {
+        var floor = Math.Min(ProvenanceTrust(entry.Provenance), TypeTrust(entry.Type));
+        var lift = entry.EchoCount / (double)(entry.EchoCount + entry.FizzleCount + EchoSmoothing);
+        return floor + (1 - floor) * lift;
+    }
+
+    /// <summary>
+    /// Provenance trust floor. Intake and Pack are the import / poisoning surface and stay
+    /// provisional (0.5); first-party origins (UserStated, AgentInferred, ToolOutput, Consolidation,
+    /// System) are fully trusted. Public so consolidation can identify untrusted contributing sources.
+    /// </summary>
+    public static double ProvenanceTrust(MemoryProvenance provenance) => provenance switch
+    {
+        MemoryProvenance.Intake or MemoryProvenance.Pack => ImportTrust,
+        _ => 1.0,
+    };
+
+    /// <summary>
+    /// Type trust floor. Procedure and Heuristic are action-shaped — a wrongly-recalled one is
+    /// net-negative (SWE-Skills-Bench) — so they stay provisional (0.7) until echoed; Insight and
+    /// Observation are fully trusted.
+    /// </summary>
+    private static double TypeTrust(MemoryType type) => type switch
+    {
+        MemoryType.Procedure or MemoryType.Heuristic => ActionTypeTrust,
+        _ => 1.0,
+    };
+}

--- a/src/Eidet.Core/Memory/RecallExplanation.cs
+++ b/src/Eidet.Core/Memory/RecallExplanation.cs
@@ -7,5 +7,10 @@ namespace Eidet.Core.Memory;
 /// </summary>
 public sealed record RecallExplanation(IReadOnlyList<RecallExplanationRow> Rows, double AlphaUsed, int CandidatePool);
 
-/// <summary>One candidate's fusion components: normalized arm scores plus recency + UCB contributions and the total.</summary>
-public sealed record RecallExplanationRow(string Id, double Lex, double Vec, double Recency, double Ucb, double Fused);
+/// <summary>
+/// One candidate's fusion components: normalized arm scores plus recency + UCB contributions and the
+/// total. <see cref="Trust"/> is the derived trust factor and <see cref="Gated"/> = Fused·Trust is the
+/// production-recall score after trust gating, so the diagnostic mirrors what live recall actually ranks.
+/// </summary>
+public sealed record RecallExplanationRow(
+    string Id, double Lex, double Vec, double Recency, double Ucb, double Fused, double Trust, double Gated);

--- a/src/Eidet.Core/Services/MarkdownPackFormat.cs
+++ b/src/Eidet.Core/Services/MarkdownPackFormat.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using System.Text;
 using System.Text.RegularExpressions;
 using Eidet.Core.Domain;
+using Eidet.Core.Memory;
 
 namespace Eidet.Core.Services;
 
@@ -340,6 +341,14 @@ public static partial class MarkdownPackFormat
                 // Parse metadata from HTML comments
                 foreach (var comment in metaComments)
                     ApplyMetadataComment(entry, comment);
+
+                // Imported pack content is untrusted-until-echoed regardless of what the pack DECLARES.
+                // A poisoned pack (MemoryGraft, #34 / STRIDE T-7) controls its own bytes and could write
+                // `provenance=userStated` to self-assign full trust and dodge the Pack floor. Clamp any
+                // declared provenance that would raise the trust floor above Pack's back down to Pack;
+                // lower- or equal-trust origins (e.g. Intake) are left as declared.
+                if (MemoryTrust.ProvenanceTrust(entry.Provenance) > MemoryTrust.ProvenanceTrust(MemoryProvenance.Pack))
+                    entry.Provenance = MemoryProvenance.Pack;
 
                 // Generate deterministic ID
                 entry.RepoId = packId;

--- a/src/Eidet.Core/Services/MemoryService.cs
+++ b/src/Eidet.Core/Services/MemoryService.cs
@@ -367,18 +367,30 @@ public sealed class MemoryService
 
         var now = DateTime.UtcNow;
         var weights = RecallWeights.Default with { TotalN = ComputeTotalN(lexTask.Result, vecTask.Result) };
-        var merged = RecallScoring.FuseAndScore(lexTask.Result, vecTask.Result, weights, now);
+        var fused = RecallScoring.Fuse(lexTask.Result, vecTask.Result, weights, now);
 
+        // Trust gating is a production-recall policy layered on top of Fuse, NOT folded into it:
+        // the benchmark scorecard calls Fuse directly and would be unfairly penalized on its
+        // Procedure/Heuristic gold cases. Here we hold poisoned/provisional memories down at
+        // retrieval time alongside the non-local de-boost.
         var staleAfter = StalenessWarningDays;
-        foreach (var result in merged)
+        var merged = new List<MemorySearchResult>(fused.Count);
+        foreach (var candidate in fused)
         {
-            if (!scope.IsLocalRepo(result.RepoId))
-                result.Score *= LayerScope.NonLocalDeBoost;
+            var entry = candidate.Entry;
+            var trust = MemoryTrust.Factor(entry);
+            var score = candidate.Fused * trust;
+            if (!scope.IsLocalRepo(entry.RepoId))
+                score *= LayerScope.NonLocalDeBoost;
+
+            var result = RecallScoring.ToSearchResult(entry, (float)score);
+            result.TrustFactor = (float)trust;
             result.AgeDays = (int)(now - result.CreatedAt).TotalDays;
             if (result.Drift is { Verdict: DriftVerdictKind.Stale or DriftVerdictKind.Contradicted } drift)
                 result.StalenessWarning = $"[drift: {drift.Reason ?? drift.Verdict.ToString().ToLowerInvariant()}]";
             else if (result.AgeDays >= staleAfter)
                 result.StalenessWarning = $"[stale: {result.AgeDays}d ago — verify before acting]";
+            merged.Add(result);
         }
 
         var budgeted = RecallScoring.ApplyTypeBudgets(merged, query.Limit);
@@ -419,7 +431,12 @@ public sealed class MemoryService
         var fused = RecallScoring.Fuse(lexTask.Result, vecTask.Result, weights, DateTime.UtcNow);
 
         var rows = fused
-            .Select(c => new RecallExplanationRow(c.Entry.Id, c.Lex, c.Vec, c.Recency, c.Ucb, c.Fused))
+            .Select(c =>
+            {
+                var trust = MemoryTrust.Factor(c.Entry);
+                return new RecallExplanationRow(
+                    c.Entry.Id, c.Lex, c.Vec, c.Recency, c.Ucb, c.Fused, trust, c.Fused * trust);
+            })
             .ToList();
         return new RecallExplanation(rows, weights.Alpha, rows.Count);
     }

--- a/tests/Eidet.Core.Tests/Maintenance/ConsolidationTrustTests.cs
+++ b/tests/Eidet.Core.Tests/Maintenance/ConsolidationTrustTests.cs
@@ -1,0 +1,251 @@
+using Eidet.Core.Domain;
+using Eidet.Core.Maintenance;
+using Eidet.Core.Memory;
+using Eidet.Core.Services;
+using Eidet.Core.Storage;
+using Eidet.Core.Tests.Services;
+
+namespace Eidet.Core.Tests.Maintenance;
+
+/// <summary>
+/// Anti-laundering carry-through tests for <see cref="ConsolidationEngine"/> (issue #34). The threat
+/// is a "compression-amplified toxin": an attacker launders an untrusted (Pack/Intake) observation
+/// into a fully-trusted Insight by getting consolidation to merge it.
+///
+/// CREATE path: a group containing ANY untrusted contributor stamps the new Insight with the
+/// least-trusted contributor's provenance (NOT Consolidation), so <see cref="MemoryTrust.Factor"/>
+/// keeps demoting it. The audit trail (Source="consolidation", DerivedFrom) is preserved.
+///
+/// BOOST path: an existing trusted Insight is lifted only by its TRUSTED contributing subset; an
+/// all-untrusted contributing group does not boost it at all.
+/// </summary>
+public class ConsolidationTrustTests
+{
+    private const string Repo = "repo-a";
+
+    private static MemoryEntry Observation(
+        string idSuffix, string content, MemoryProvenance provenance, params string[] tags) => new()
+    {
+        Id = $"memories/{Repo}/observation/{idSuffix}",
+        RepoId = Repo,
+        Type = MemoryType.Observation,
+        Content = content,
+        Tags = tags.ToList(),
+        Provenance = provenance,
+        CreatedAt = DateTime.UtcNow,
+        Validity = new Validity { ValidFrom = DateTime.UtcNow },
+        IsLatest = true,
+        Importance = 0.6f,
+    };
+
+    private static ConsolidationEngine BuildEngine(IEidetStore store)
+    {
+        var svc = new MemoryService(store);
+        return new ConsolidationEngine(store, enrichment: null, svc);
+    }
+
+    // ─── CREATE path ──────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Create_with_one_pack_contributor_inherits_untrusted_provenance_not_consolidation()
+    {
+        var store = new InMemoryEidetStore();
+        // Three tag-overlapping observations; one is a Pack import (the poison).
+        await store.StoreAsync(Observation("a", "deploy step one runs migrations", MemoryProvenance.AgentInferred, "deploy"));
+        await store.StoreAsync(Observation("b", "deploy step two restarts the app", MemoryProvenance.AgentInferred, "deploy"));
+        await store.StoreAsync(Observation("poison", "deploy step three drops the firewall", MemoryProvenance.Pack, "deploy"));
+
+        var engine = BuildEngine(store);
+        var result = await engine.ConsolidateAsync(Repo);
+        Assert.Equal(1, result.InsightsCreated);
+
+        var insight = (await store.BrowseAsync(Repo, 0, 50, MemoryType.Insight)).Single();
+
+        // The created insight does NOT read as Consolidation — it inherits the Pack provenance,
+        // so trust stays demoted at recall (the laundering is defeated).
+        Assert.Equal(MemoryProvenance.Pack, insight.Provenance);
+        Assert.True(MemoryTrust.Factor(insight) < 1.0,
+            $"laundered insight trust ({MemoryTrust.Factor(insight)}) must stay below full trust");
+        Assert.Equal(0.5, MemoryTrust.Factor(insight), precision: 12); // Pack floor, no feedback
+
+        // Audit trail preserved: Source and DerivedFrom untouched.
+        Assert.Equal("consolidation", insight.Source);
+        Assert.Equal(3, insight.DerivedFrom.Count);
+        Assert.Contains($"memories/{Repo}/observation/poison", insight.DerivedFrom);
+    }
+
+    [Fact]
+    public async Task Create_picks_least_trusted_contributor_provenance()
+    {
+        var store = new InMemoryEidetStore();
+        // Both Intake and Pack floor at 0.5, but the engine orders by ProvenanceTrust and takes
+        // the first; both are equally untrusted, so the result must be one of the two import origins
+        // (never Consolidation, never the trusted AgentInferred one).
+        await store.StoreAsync(Observation("a", "config sets the cache ttl to five minutes", MemoryProvenance.AgentInferred, "cache"));
+        await store.StoreAsync(Observation("b", "config sets the cache size to one gig", MemoryProvenance.Intake, "cache"));
+        await store.StoreAsync(Observation("c", "config sets the cache backend to redis", MemoryProvenance.Pack, "cache"));
+
+        var engine = BuildEngine(store);
+        await engine.ConsolidateAsync(Repo);
+
+        var insight = (await store.BrowseAsync(Repo, 0, 50, MemoryType.Insight)).Single();
+        Assert.Contains(insight.Provenance, new[] { MemoryProvenance.Intake, MemoryProvenance.Pack });
+        Assert.True(MemoryTrust.ProvenanceTrust(insight.Provenance) < 1.0);
+    }
+
+    [Fact]
+    public async Task Create_with_all_trusted_contributors_stamps_consolidation_full_trust()
+    {
+        var store = new InMemoryEidetStore();
+        await store.StoreAsync(Observation("a", "auth uses jwt rs256 keys", MemoryProvenance.AgentInferred, "auth"));
+        await store.StoreAsync(Observation("b", "auth tokens expire after ten minutes", MemoryProvenance.ToolOutput, "auth"));
+        await store.StoreAsync(Observation("c", "auth refresh is rotated on use", MemoryProvenance.UserStated, "auth"));
+
+        var engine = BuildEngine(store);
+        var result = await engine.ConsolidateAsync(Repo);
+        Assert.Equal(1, result.InsightsCreated);
+
+        var insight = (await store.BrowseAsync(Repo, 0, 50, MemoryType.Insight)).Single();
+        Assert.Equal(MemoryProvenance.Consolidation, insight.Provenance);
+        Assert.Equal(1.0, MemoryTrust.Factor(insight));
+    }
+
+    [Fact]
+    public async Task DryRun_does_not_write_any_insight()
+    {
+        var store = new InMemoryEidetStore();
+        await store.StoreAsync(Observation("a", "deploy step one runs migrations", MemoryProvenance.Pack, "deploy"));
+        await store.StoreAsync(Observation("b", "deploy step two restarts the app", MemoryProvenance.AgentInferred, "deploy"));
+        await store.StoreAsync(Observation("c", "deploy step three warms caches", MemoryProvenance.AgentInferred, "deploy"));
+
+        var engine = BuildEngine(store);
+        var result = await engine.ConsolidateAsync(Repo, dryRun: true);
+
+        Assert.Single(result.Candidates);
+        Assert.Equal(0, result.InsightsCreated);
+        Assert.Empty(await store.BrowseAsync(Repo, 0, 50, MemoryType.Insight));
+    }
+
+    // ─── BOOST path ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Boost_skips_entirely_when_all_contributors_are_untrusted()
+    {
+        // FindDuplicate returns a pre-existing trusted Insight, so the engine takes the BOOST path.
+        var existing = new MemoryEntry
+        {
+            Id = $"memories/{Repo}/insight/standing",
+            RepoId = Repo,
+            Type = MemoryType.Insight,
+            Content = "the deployment pipeline is well understood",
+            Tags = ["deploy"],
+            Provenance = MemoryProvenance.Consolidation,
+            Importance = 0.6f,
+            CreatedAt = DateTime.UtcNow,
+            Validity = new Validity { ValidFrom = DateTime.UtcNow },
+            IsLatest = true,
+        };
+        var store = new BoostStore(existing);
+
+        // An all-untrusted contributing group (every observation is Pack/Intake).
+        await store.StoreAsync(Observation("a", "the deployment pipeline is well understood now", MemoryProvenance.Pack, "deploy"));
+        await store.StoreAsync(Observation("b", "the deployment pipeline is well understood today", MemoryProvenance.Pack, "deploy"));
+        await store.StoreAsync(Observation("c", "the deployment pipeline is well understood here", MemoryProvenance.Intake, "deploy"));
+
+        var importanceBefore = existing.Importance;
+        var derivedBefore = existing.DerivedFrom.Count;
+
+        var engine = BuildEngine(store);
+        var result = await engine.ConsolidateAsync(Repo);
+
+        // No trusted contributor → boost is skipped: standing is NOT laundered upward.
+        Assert.Equal(0, result.InsightsBoosted);
+        Assert.Equal(importanceBefore, existing.Importance);
+        Assert.Equal(derivedBefore, existing.DerivedFrom.Count);
+    }
+
+    [Fact]
+    public async Task Boost_admits_only_the_trusted_subset()
+    {
+        var existing = new MemoryEntry
+        {
+            Id = $"memories/{Repo}/insight/standing",
+            RepoId = Repo,
+            Type = MemoryType.Insight,
+            Content = "the deployment pipeline is well understood",
+            Tags = ["deploy"],
+            Provenance = MemoryProvenance.Consolidation,
+            Importance = 0.6f,
+            CreatedAt = DateTime.UtcNow,
+            Validity = new Validity { ValidFrom = DateTime.UtcNow },
+            IsLatest = true,
+        };
+        var store = new BoostStore(existing);
+
+        // Mixed group: two trusted, one Pack. Only the two trusted contributors may lift it.
+        await store.StoreAsync(Observation("t1", "the deployment pipeline is well understood now", MemoryProvenance.AgentInferred, "deploy"));
+        await store.StoreAsync(Observation("t2", "the deployment pipeline is well understood today", MemoryProvenance.ToolOutput, "deploy"));
+        await store.StoreAsync(Observation("poison", "the deployment pipeline is well understood here", MemoryProvenance.Pack, "deploy"));
+
+        var importanceBefore = existing.Importance;
+
+        var engine = BuildEngine(store);
+        var result = await engine.ConsolidateAsync(Repo);
+
+        Assert.Equal(1, result.InsightsBoosted);
+        // Importance lifted by exactly 0.05 * (trusted count == 2) == 0.10, NOT 0.15 for all three.
+        Assert.Equal(importanceBefore + 0.10f, existing.Importance, precision: 5);
+        // Only the two trusted contributors entered the lineage; the Pack id did NOT.
+        Assert.Contains($"memories/{Repo}/observation/t1", existing.DerivedFrom);
+        Assert.Contains($"memories/{Repo}/observation/t2", existing.DerivedFrom);
+        Assert.DoesNotContain($"memories/{Repo}/observation/poison", existing.DerivedFrom);
+    }
+}
+
+/// <summary>
+/// In-memory store that drives the consolidation BOOST path: <see cref="FindDuplicateAsync"/>
+/// returns the single pre-seeded Insight (which the engine then boosts in place). Everything else
+/// delegates to a plain <see cref="InMemoryEidetStore"/> via composition.
+/// </summary>
+internal sealed class BoostStore : IEidetStore
+{
+    private readonly InMemoryEidetStore _inner = new();
+    private readonly MemoryEntry _duplicate;
+
+    public BoostStore(MemoryEntry duplicate)
+    {
+        _duplicate = duplicate;
+        _inner.StoreAsync(duplicate).GetAwaiter().GetResult();
+    }
+
+    // The boost trigger: any content lookup returns the standing Insight.
+    public Task<MemoryEntry?> FindDuplicateAsync(string repoId, string content, float threshold, CancellationToken ct = default) =>
+        Task.FromResult<MemoryEntry?>(_duplicate);
+
+    public Task<string> StoreAsync(MemoryEntry entry, CancellationToken ct = default) => _inner.StoreAsync(entry, ct);
+    public Task<MemoryEntry?> GetAsync(string id, CancellationToken ct = default) => _inner.GetAsync(id, ct);
+    public Task UpdateAsync(MemoryEntry entry, CancellationToken ct = default) => _inner.UpdateAsync(entry, ct);
+    public Task<bool> ForgetAsync(string id, CancellationToken ct = default) => _inner.ForgetAsync(id, ct);
+    public Task<List<MemoryEntry>> FullTextSearchAsync(IReadOnlyList<string> repoIds, MemoryQuery query, CancellationToken ct = default) =>
+        _inner.FullTextSearchAsync(repoIds, query, ct);
+    public Task<List<MemoryEntry>> VectorSearchAsync(IReadOnlyList<string> repoIds, MemoryQuery query, CancellationToken ct = default) =>
+        _inner.VectorSearchAsync(repoIds, query, ct);
+    public Task<IReadOnlyList<MemoryEntry>> FindNearDuplicatesAsync(string repoId, MemoryEntry entry, float minSimilarity, int max, CancellationToken ct = default) =>
+        _inner.FindNearDuplicatesAsync(repoId, entry, minSimilarity, max, ct);
+    public Task<Dictionary<MemoryType, int>> GetCountsByTypeAsync(string repoId, CancellationToken ct = default) =>
+        _inner.GetCountsByTypeAsync(repoId, ct);
+    public Task<List<MemoryEntry>> GetTopScoredAsync(string repoId, MemoryType[] types, int limit, CancellationToken ct = default) =>
+        _inner.GetTopScoredAsync(repoId, types, limit, ct);
+    public Task<bool> TestConnectionAsync(CancellationToken ct = default) => _inner.TestConnectionAsync(ct);
+    public Task<DatabaseInfo?> GetDatabaseInfoAsync(CancellationToken ct = default) => _inner.GetDatabaseInfoAsync(ct);
+    public Task EnsureIndexesAsync(CancellationToken ct = default) => _inner.EnsureIndexesAsync(ct);
+    public Task<List<string>> GetDistinctRepoIdsAsync(CancellationToken ct = default) => _inner.GetDistinctRepoIdsAsync(ct);
+    public Task<List<MemoryEntry>> BrowseAsync(string repoId, int skip, int take, MemoryType? type = null, CancellationToken ct = default) =>
+        _inner.BrowseAsync(repoId, skip, take, type, ct);
+    public Task<string> StoreMountedLayerAsync(MemoryLayer layer, CancellationToken ct = default) => _inner.StoreMountedLayerAsync(layer, ct);
+    public Task<bool> UnmountLayerAsync(string layerId, CancellationToken ct = default) => _inner.UnmountLayerAsync(layerId, ct);
+    public Task<List<MemoryLayer>> GetMountedLayersAsync(string repoId, CancellationToken ct = default) => _inner.GetMountedLayersAsync(repoId, ct);
+    public Task<MemoryLayer?> GetLayerAsync(string layerId, CancellationToken ct = default) => _inner.GetLayerAsync(layerId, ct);
+    public Task<List<MemoryEntry>> GetByLayerIdAsync(string layerId, CancellationToken ct = default) => _inner.GetByLayerIdAsync(layerId, ct);
+    public Task<bool> HardDeleteAsync(string id, CancellationToken ct = default) => _inner.HardDeleteAsync(id, ct);
+}

--- a/tests/Eidet.Core.Tests/Memory/MemoryTrustTests.cs
+++ b/tests/Eidet.Core.Tests/Memory/MemoryTrustTests.cs
@@ -1,0 +1,213 @@
+using Eidet.Core.Domain;
+using Eidet.Core.Memory;
+
+namespace Eidet.Core.Tests.Memory;
+
+/// <summary>
+/// Unit tests for <see cref="MemoryTrust"/> (issue #34) — the derived, never-stored anti-poisoning
+/// trust factor. The contract: trust ∈ (0, 1.0], starting at the LOWER of the provenance floor
+/// (Intake/Pack = 0.5, else 1.0) and the type floor (Procedure/Heuristic = 0.7, else 1.0), then
+/// lifted toward 1.0 by earned echoes: <c>trust = floor + (1 - floor) · echo/(echo + fizzle + K)</c>
+/// with K = 3.
+///
+/// Pure math, no clock, no store — feedback counts are the only input beyond provenance/type.
+///
+/// AS-BUILT floor combination is <c>Math.Min(provenanceFloor, typeFloor)</c> (MemoryTrust.cs:38),
+/// which matches the original spec's <c>min(...)</c>. (The pipeline brief flagged a suspected
+/// MULTIPLICATIVE combination — that is NOT what the code does; see PackProcedure_* below.)
+/// </summary>
+public class MemoryTrustTests
+{
+    private static MemoryEntry Entry(
+        MemoryProvenance provenance = MemoryProvenance.AgentInferred,
+        MemoryType type = MemoryType.Insight,
+        int echo = 0,
+        int fizzle = 0) => new()
+    {
+        Id = "memories/repo-a/insight/x",
+        RepoId = "repo-a",
+        Type = type,
+        Provenance = provenance,
+        Content = "x",
+        EchoCount = echo,
+        FizzleCount = fizzle,
+    };
+
+    // ─── Baseline: fully-trusted honest path is never penalized ───────────
+
+    [Fact]
+    public void Trusted_provenance_nonProcedural_type_zero_feedback_is_full_trust()
+    {
+        var trust = MemoryTrust.Factor(Entry(MemoryProvenance.AgentInferred, MemoryType.Insight));
+        Assert.Equal(1.0, trust);
+    }
+
+    // ─── Provenance floor (type held neutral at Insight) ──────────────────
+
+    [Theory]
+    [InlineData(MemoryProvenance.Intake)]
+    [InlineData(MemoryProvenance.Pack)]
+    public void Import_provenance_floors_trust_at_half_with_zero_feedback(MemoryProvenance provenance)
+    {
+        var trust = MemoryTrust.Factor(Entry(provenance, MemoryType.Insight));
+        Assert.Equal(0.5, trust);
+    }
+
+    [Theory]
+    [InlineData(MemoryProvenance.AgentInferred)]
+    [InlineData(MemoryProvenance.ToolOutput)]
+    [InlineData(MemoryProvenance.UserStated)]
+    [InlineData(MemoryProvenance.System)]
+    [InlineData(MemoryProvenance.Consolidation)]
+    public void FirstParty_provenance_is_fully_trusted_with_zero_feedback(MemoryProvenance provenance)
+    {
+        var trust = MemoryTrust.Factor(Entry(provenance, MemoryType.Insight));
+        Assert.Equal(1.0, trust);
+    }
+
+    [Theory]
+    [InlineData(MemoryProvenance.Intake, 0.5)]
+    [InlineData(MemoryProvenance.Pack, 0.5)]
+    [InlineData(MemoryProvenance.AgentInferred, 1.0)]
+    [InlineData(MemoryProvenance.ToolOutput, 1.0)]
+    [InlineData(MemoryProvenance.UserStated, 1.0)]
+    [InlineData(MemoryProvenance.System, 1.0)]
+    [InlineData(MemoryProvenance.Consolidation, 1.0)]
+    public void ProvenanceTrust_returns_expected_floor(MemoryProvenance provenance, double expected)
+    {
+        Assert.Equal(expected, MemoryTrust.ProvenanceTrust(provenance));
+    }
+
+    // ─── Type floor (provenance held neutral at AgentInferred) ────────────
+
+    [Theory]
+    [InlineData(MemoryType.Procedure)]
+    [InlineData(MemoryType.Heuristic)]
+    public void ActionShaped_types_floor_trust_at_0_7_with_zero_feedback(MemoryType type)
+    {
+        var trust = MemoryTrust.Factor(Entry(MemoryProvenance.AgentInferred, type));
+        Assert.Equal(0.7, trust);
+    }
+
+    [Theory]
+    [InlineData(MemoryType.Insight)]
+    [InlineData(MemoryType.Observation)]
+    public void Knowledge_types_are_fully_trusted_with_zero_feedback(MemoryType type)
+    {
+        var trust = MemoryTrust.Factor(Entry(MemoryProvenance.AgentInferred, type));
+        Assert.Equal(1.0, trust);
+    }
+
+    // ─── Floor combination rule: AS-BUILT is min(...), NOT the product ────
+
+    /// <summary>
+    /// Pins the floor-combination rule. A Pack Procedure combines provenance floor 0.5 and type
+    /// floor 0.7. The AS-BUILT code uses <c>Math.Min</c> ⇒ 0.5. A multiplicative rule would give
+    /// 0.5·0.7 = 0.35. This asserts the min result (0.5) and would fail loudly if the code were the
+    /// product (0.35) — the combination rule the pipeline brief flagged as under review.
+    /// </summary>
+    [Fact]
+    public void PackProcedure_floor_is_min_of_floors_not_product()
+    {
+        var trust = MemoryTrust.Factor(Entry(MemoryProvenance.Pack, MemoryType.Procedure, echo: 0, fizzle: 0));
+
+        Assert.Equal(0.5, trust);                  // min(0.5, 0.7) == 0.5  (AS-BUILT)
+        Assert.NotEqual(0.35, trust, precision: 6); // product 0.5 * 0.7 would be 0.35 (NOT the rule)
+    }
+
+    [Fact]
+    public void IntakeHeuristic_floor_is_min_of_floors()
+    {
+        // min(provenance 0.5, type 0.7) == 0.5.
+        var trust = MemoryTrust.Factor(Entry(MemoryProvenance.Intake, MemoryType.Heuristic));
+        Assert.Equal(0.5, trust);
+    }
+
+    // ─── Echo-lift formula: exact pinned values ───────────────────────────
+
+    /// <summary>
+    /// Exact formula values at known (echo, fizzle) points for a Pack Insight (floor 0.5):
+    ///   echo=3,fizzle=0 → 0.5 + 0.5·(3/6)   = 0.75
+    ///   echo=3,fizzle=3 → 0.5 + 0.5·(3/9)   ≈ 0.6667  (fizzles dampen the same echo count)
+    ///   echo=9,fizzle=0 → 0.5 + 0.5·(9/12)  = 0.875
+    /// </summary>
+    [Theory]
+    [InlineData(3, 0, 0.75)]
+    [InlineData(3, 3, 0.6666666666666666)]
+    [InlineData(9, 0, 0.875)]
+    [InlineData(0, 0, 0.5)]
+    public void EchoLift_exact_formula_for_pack_insight(int echo, int fizzle, double expected)
+    {
+        var trust = MemoryTrust.Factor(Entry(MemoryProvenance.Pack, MemoryType.Insight, echo, fizzle));
+        Assert.Equal(expected, trust, precision: 12);
+    }
+
+    /// <summary>
+    /// Exact formula value for a Procedure (type floor 0.7, AgentInferred provenance):
+    ///   echo=9,fizzle=0 → 0.7 + 0.3·(9/12) = 0.925.
+    /// </summary>
+    [Fact]
+    public void EchoLift_exact_formula_for_procedure_floor()
+    {
+        var trust = MemoryTrust.Factor(Entry(MemoryProvenance.AgentInferred, MemoryType.Procedure, echo: 9, fizzle: 0));
+        Assert.Equal(0.925, trust, precision: 12);
+    }
+
+    // ─── Monotonicity properties ──────────────────────────────────────────
+
+    [Fact]
+    public void EchoLift_raises_trust_monotonically_toward_one()
+    {
+        var prev = MemoryTrust.Factor(Entry(MemoryProvenance.Pack, MemoryType.Insight, echo: 0));
+        for (var echo = 1; echo <= 50; echo++)
+        {
+            var trust = MemoryTrust.Factor(Entry(MemoryProvenance.Pack, MemoryType.Insight, echo));
+            Assert.True(trust > prev, $"trust at echo={echo} ({trust}) should exceed echo={echo - 1} ({prev})");
+            Assert.True(trust <= 1.0);
+            prev = trust;
+        }
+
+        // Asymptotically approaches (never exceeds) 1.0 as echoes grow large.
+        var huge = MemoryTrust.Factor(Entry(MemoryProvenance.Pack, MemoryType.Insight, echo: 100_000));
+        Assert.True(huge > 0.99 && huge <= 1.0, $"trust at echo=100000 was {huge}");
+    }
+
+    [Fact]
+    public void Fizzles_dampen_the_lift_more_fizzle_lower_trust_at_equal_echoes()
+    {
+        const int echo = 10;
+        var noFizzle = MemoryTrust.Factor(Entry(MemoryProvenance.Pack, MemoryType.Insight, echo, fizzle: 0));
+        var someFizzle = MemoryTrust.Factor(Entry(MemoryProvenance.Pack, MemoryType.Insight, echo, fizzle: 5));
+        var moreFizzle = MemoryTrust.Factor(Entry(MemoryProvenance.Pack, MemoryType.Insight, echo, fizzle: 20));
+
+        Assert.True(noFizzle > someFizzle, $"0 fizzle ({noFizzle}) should beat 5 fizzle ({someFizzle})");
+        Assert.True(someFizzle > moreFizzle, $"5 fizzle ({someFizzle}) should beat 20 fizzle ({moreFizzle})");
+
+        // Even with heavy fizzle the floor still holds — trust never drops below the floor.
+        Assert.True(moreFizzle >= 0.5, $"trust ({moreFizzle}) must not fall below the floor 0.5");
+    }
+
+    // ─── Range + determinism ──────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(MemoryProvenance.Pack, MemoryType.Procedure, 0, 0)]
+    [InlineData(MemoryProvenance.Intake, MemoryType.Heuristic, 5, 100)]
+    [InlineData(MemoryProvenance.AgentInferred, MemoryType.Insight, 0, 0)]
+    [InlineData(MemoryProvenance.UserStated, MemoryType.Observation, 1000, 1000)]
+    [InlineData(MemoryProvenance.Pack, MemoryType.Insight, 0, 9999)]
+    public void Factor_is_always_in_open_unit_interval(MemoryProvenance prov, MemoryType type, int echo, int fizzle)
+    {
+        var trust = MemoryTrust.Factor(Entry(prov, type, echo, fizzle));
+        Assert.True(trust > 0.0, $"trust {trust} must be > 0");
+        Assert.True(trust <= 1.0, $"trust {trust} must be <= 1.0");
+    }
+
+    [Fact]
+    public void Factor_is_deterministic_across_repeated_calls()
+    {
+        var entry = Entry(MemoryProvenance.Pack, MemoryType.Procedure, echo: 7, fizzle: 4);
+        var first = MemoryTrust.Factor(entry);
+        for (var i = 0; i < 5; i++)
+            Assert.Equal(first, MemoryTrust.Factor(entry));
+    }
+}

--- a/tests/Eidet.Core.Tests/Memory/RecallTrustGatingTests.cs
+++ b/tests/Eidet.Core.Tests/Memory/RecallTrustGatingTests.cs
@@ -1,0 +1,152 @@
+using Eidet.Core.Domain;
+using Eidet.Core.Memory;
+using Eidet.Core.Services;
+using Eidet.Core.Storage;
+
+namespace Eidet.Core.Tests.Memory;
+
+/// <summary>
+/// Behavioral tests for trust gating in the recall pipeline (issue #34). At recall time
+/// <see cref="MemoryService.RecallInternalAsync"/> multiplies each candidate's fused score by
+/// <see cref="MemoryTrust.Factor"/> and stamps <see cref="MemorySearchResult.TrustFactor"/>. The
+/// contract: a provisional (Pack/Intake, or fresh Procedure/Heuristic) memory ranks BELOW a
+/// fully-trusted one of EQUAL relevance, and earned echoes close the gap.
+///
+/// Driven through the scripted-arm <see cref="InMemoryScoredStore"/> (from RecallFusionTests) so
+/// per-arm raw scores are identical for the two candidates — only the trust multiplier can move
+/// the ranking. <see cref="MemoryService.ExplainRecallAsync"/> exposes the same per-row Trust.
+/// </summary>
+public class RecallTrustGatingTests
+{
+    private static readonly DateTime Now = new(2026, 6, 20, 0, 0, 0, DateTimeKind.Utc);
+
+    private static MemoryEntry Entry(
+        string id,
+        MemoryType type = MemoryType.Insight,
+        MemoryProvenance provenance = MemoryProvenance.AgentInferred,
+        int echo = 0,
+        int fizzle = 0) => new()
+    {
+        Id = id,
+        RepoId = "repo-a",
+        Type = type,
+        Provenance = provenance,
+        Content = id,
+        CreatedAt = Now,
+        Validity = new Validity { ValidFrom = Now },
+        EchoCount = echo,
+        FizzleCount = fizzle,
+        IsLatest = true,
+        Importance = 0.5f,
+    };
+
+    [Fact]
+    public async Task PackMemory_ranks_below_equally_relevant_trusted_memory()
+    {
+        var store = new InMemoryScoredStore();
+        // Identical raw scores in BOTH arms — relevance is a tie; only trust can break it.
+        store.SetArm(SearchArm.Lexical, ("trusted", 7.0), ("packed", 7.0));
+        store.SetArm(SearchArm.Vector, ("trusted", 7.0), ("packed", 7.0));
+        store.Seed(
+            Entry("trusted", provenance: MemoryProvenance.AgentInferred),
+            Entry("packed", provenance: MemoryProvenance.Pack));
+
+        var svc = new MemoryService(store);
+        var results = await svc.RecallAsync("repo-a", "query");
+
+        Assert.Equal(2, results.Count);
+        Assert.Equal("trusted", results[0].Id);
+        Assert.Equal("packed", results[1].Id);
+        Assert.True(results[0].Score > results[1].Score,
+            $"trusted score ({results[0].Score}) should exceed packed score ({results[1].Score})");
+    }
+
+    [Fact]
+    public async Task FreshProcedure_ranks_below_equally_relevant_insight()
+    {
+        var store = new InMemoryScoredStore();
+        store.SetArm(SearchArm.Lexical, ("insight", 7.0), ("procedure", 7.0));
+        store.SetArm(SearchArm.Vector, ("insight", 7.0), ("procedure", 7.0));
+        store.Seed(
+            Entry("insight", type: MemoryType.Insight),
+            Entry("procedure", type: MemoryType.Procedure));
+
+        var svc = new MemoryService(store);
+        var results = await svc.RecallAsync("repo-a", "query");
+
+        Assert.Equal("insight", results[0].Id);
+        Assert.Equal("procedure", results[1].Id);
+    }
+
+    [Fact]
+    public async Task TrustFactor_is_populated_below_one_for_lowTrust_and_one_for_trusted()
+    {
+        var store = new InMemoryScoredStore();
+        store.SetArm(SearchArm.Lexical, ("trusted", 7.0), ("packed", 7.0), ("procedure", 7.0));
+        store.SetArm(SearchArm.Vector, ("trusted", 7.0), ("packed", 7.0), ("procedure", 7.0));
+        store.Seed(
+            Entry("trusted", provenance: MemoryProvenance.AgentInferred),
+            Entry("packed", provenance: MemoryProvenance.Pack),
+            Entry("procedure", type: MemoryType.Procedure));
+
+        var svc = new MemoryService(store);
+        var results = await svc.RecallAsync("repo-a", "query");
+
+        var trusted = results.Single(r => r.Id == "trusted");
+        var packed = results.Single(r => r.Id == "packed");
+        var procedure = results.Single(r => r.Id == "procedure");
+
+        Assert.Equal(1.0f, trusted.TrustFactor);
+        Assert.Equal(0.5f, packed.TrustFactor, precision: 5);       // Pack floor, no feedback
+        Assert.Equal(0.7f, procedure.TrustFactor, precision: 5);    // Procedure floor, no feedback
+    }
+
+    [Fact]
+    public async Task Enough_echoes_close_the_trust_gap_for_a_pack_memory()
+    {
+        // A fresh Pack memory is gated at the 0.5 floor; after many echoes its trust factor lifts
+        // toward 1.0, closing the gap with a trusted memory. We assert on TrustFactor directly —
+        // the trust gate is the contract under test. (The fused SCORE also carries the unrelated
+        // UCB exploration term, which independently favors the low-feedback memory, so a raw score
+        // comparison would not isolate the trust effect.)
+        var fresh = new InMemoryScoredStore();
+        fresh.SetArm(SearchArm.Lexical, ("packed", 7.0));
+        fresh.SetArm(SearchArm.Vector, ("packed", 7.0));
+        fresh.Seed(Entry("packed", provenance: MemoryProvenance.Pack, echo: 0));
+
+        var echoed = new InMemoryScoredStore();
+        echoed.SetArm(SearchArm.Lexical, ("packed", 7.0));
+        echoed.SetArm(SearchArm.Vector, ("packed", 7.0));
+        echoed.Seed(Entry("packed", provenance: MemoryProvenance.Pack, echo: 500));
+
+        var freshTrust = (await new MemoryService(fresh).RecallAsync("repo-a", "query")).Single().TrustFactor;
+        var echoedTrust = (await new MemoryService(echoed).RecallAsync("repo-a", "query")).Single().TrustFactor;
+
+        Assert.Equal(0.5f, freshTrust, precision: 5);              // gated at the floor when unproven
+        Assert.True(echoedTrust > freshTrust, $"echoed trust ({echoedTrust}) should exceed fresh ({freshTrust})");
+        Assert.True(echoedTrust > 0.99f, $"echoed pack trust ({echoedTrust}) should approach full trust");
+    }
+
+    [Fact]
+    public async Task ExplainRecall_emits_per_row_trust_and_gated_score()
+    {
+        var store = new InMemoryScoredStore();
+        store.SetArm(SearchArm.Lexical, ("trusted", 7.0), ("packed", 7.0));
+        store.SetArm(SearchArm.Vector, ("trusted", 7.0), ("packed", 7.0));
+        store.Seed(
+            Entry("trusted", provenance: MemoryProvenance.AgentInferred),
+            Entry("packed", provenance: MemoryProvenance.Pack));
+
+        var svc = new MemoryService(store);
+        var explanation = await svc.ExplainRecallAsync("repo-a", new RecallOptions("query"));
+
+        var trustedRow = explanation.Rows.Single(r => r.Id == "trusted");
+        var packedRow = explanation.Rows.Single(r => r.Id == "packed");
+
+        Assert.Equal(1.0, trustedRow.Trust);
+        Assert.Equal(0.5, packedRow.Trust, precision: 12);
+        // Gated == Fused · Trust — the production-recall score the diagnostic mirrors.
+        Assert.Equal(packedRow.Fused * packedRow.Trust, packedRow.Gated, precision: 12);
+        Assert.True(packedRow.Gated < trustedRow.Gated);
+    }
+}

--- a/tests/Eidet.Core.Tests/Services/MarkdownPackFormatTests.cs
+++ b/tests/Eidet.Core.Tests/Services/MarkdownPackFormatTests.cs
@@ -381,8 +381,12 @@ public class MarkdownPackFormatTests
     }
 
     [Fact]
-    public void Deserialize_HandlesCustomProvenance()
+    public void Deserialize_ClampsDeclaredProvenanceThatWouldEscalateTrust()
     {
+        // Security (#34 / STRIDE T-7): a poisoned pack controls its own bytes and could declare
+        // provenance=userstated to self-assign full trust and dodge the Pack floor. Import must clamp
+        // any provenance that would raise the trust floor above Pack back down to Pack. The free-form
+        // `source` label carries no trust weight, so it is still honored.
         var md = """
             ---
             title: Test
@@ -403,8 +407,36 @@ public class MarkdownPackFormatTests
             """;
 
         var pack = MarkdownPackFormat.Deserialize(md);
-        Assert.Equal(MemoryProvenance.UserStated, pack.Entries[0].Provenance);
+        Assert.Equal(MemoryProvenance.Pack, pack.Entries[0].Provenance);
         Assert.Equal("manual-curation", pack.Entries[0].Source);
+    }
+
+    [Fact]
+    public void Deserialize_PreservesDeclaredProvenanceThatDoesNotEscalateTrust()
+    {
+        // A declared provenance at or below Pack's trust floor (e.g. intake, also 0.5) is honored as-is
+        // — only trust-escalating declarations are clamped.
+        var md = """
+            ---
+            title: Test
+            eidet:
+              id: test
+              version: 1.0.0
+              author: test
+            ---
+
+            # Test
+
+            ## Insights
+
+            ### Intake insight
+            <!-- eidet: provenance=intake -->
+
+            Seeded from a project file.
+            """;
+
+        var pack = MarkdownPackFormat.Deserialize(md);
+        Assert.Equal(MemoryProvenance.Intake, pack.Entries[0].Provenance);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #34 (P0, security).

## What

A deterministic, local anti-poisoning defense. Adds a derived **trust tier** that gates retrieval weight by a memory's origin + type + earned feedback, and carries provenance through consolidation so a low-trust source can't be laundered into a trusted insight. Defends the MemoryGraft single-shot, trigger-free poisoning threat (arXiv:2512.16962) against the pack-import / Procedure-Heuristic surface.

## Design

- **`MemoryTrust.Factor(entry)` → (0,1]** — pure, derived from `Provenance + Type + Echo/Fizzle`. **No stored field, no migration** (single source of truth). Pack/Intake floor `0.5`, Procedure/Heuristic `0.7` (floors combine as `min`); earned echoes lift toward `1.0`.
- **Retrieval gating in the production path only** — `score *= trust` in `RecallInternalAsync`, alongside the existing non-local de-boost. `RecallScoring.Fuse` stays **pure and byte-unchanged**, so the #36 benchmark scorecard (`docs/benchmark.md`) is unaffected (verified empty diff).
- **Consolidation carry-through** — a new insight derived from any untrusted source inherits the *least-trusted* contributor's provenance (not `Consolidation`); the boost path admits only trusted sources. Audit lineage (`DerivedFrom`, `Source`) preserved.
- **Pack import hardening** — a pack's self-declared `provenance=` cannot escalate trust above the Pack floor (clamped in `MarkdownPackFormat`). Closes a bypass where a poisoned pack self-assigns first-party trust.
- **STRIDE.md** — T-7 (single-shot poisoning) + T-8 (consolidation laundering) rows + the 6-phase × 4-objective memory-lifecycle taxonomy.

Item 4 (per-source Bayesian trust score) deferred to a follow-up, as agreed.

## Pipeline

Implemented + tested + reviewed + spec-verified via the 4-agent pipeline. The review caught a **blocking** bypass (pack import honoring a self-declared trusted provenance) — fixed in this PR with regression tests.

## Verification

- Clean build: **0 warnings, 0 errors**
- **800 tests green** — Core 572, Benchmark 9, Service 208, Integration 11
- +48 new tests (trust factor, retrieval gating, consolidation anti-laundering, pack-import clamp)
- `RecallScoring.Fuse` + `docs/benchmark.md` byte-unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LejT5wHAhq2pKSaYA4hZdf