### PR TITLE
feat(recall): per-repo alpha-learning + graph-neighbor expansion (#33)

### DIFF
--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -16,18 +16,18 @@ that is a deferred epic. This is a deterministic, no-LLM, CI regression guard.
 
 | Capability | Cases | Metric | v2 Fusion | Flat Baseline | Delta |
 |---|---|---|---|---|---|
-| Recall | 12 | Recall@k | 0.833 | 0.375 | +0.458 |
-|  |  | MRR | 0.889 | 0.472 | +0.417 |
-|  |  | nDCG@k | 0.833 | 0.286 | +0.547 |
-|  |  | Gold survival | 0.792 | 0.417 | +0.375 |
+| Recall | 14 | Recall@k | 0.857 | 0.321 | +0.536 |
+|  |  | MRR | 0.833 | 0.405 | +0.429 |
+|  |  | nDCG@k | 0.804 | 0.246 | +0.559 |
+|  |  | Gold survival | 0.750 | 0.357 | +0.393 |
 | StateUpdating | 1 | Recall@k | 1.000 | 1.000 | +0.000 |
 |  |  | MRR | 1.000 | 1.000 | +0.000 |
 |  |  | nDCG@k | 1.000 | 1.000 | +0.000 |
 |  |  | Gold survival | 1.000 | 1.000 | +0.000 |
-| **Overall** | 13 | Recall@k | 0.846 | 0.423 | +0.423 |
-|  |  | MRR | 0.897 | 0.513 | +0.385 |
-|  |  | nDCG@k | 0.846 | 0.341 | +0.505 |
-|  |  | Gold survival | 0.808 | 0.462 | +0.346 |
+| **Overall** | 15 | Recall@k | 0.867 | 0.367 | +0.500 |
+|  |  | MRR | 0.844 | 0.444 | +0.400 |
+|  |  | nDCG@k | 0.817 | 0.296 | +0.522 |
+|  |  | Gold survival | 0.767 | 0.400 | +0.367 |
 
 ## Capabilities not evaluated
 

--- a/src/Eidet.Core/Benchmark/BenchmarkCase.cs
+++ b/src/Eidet.Core/Benchmark/BenchmarkCase.cs
@@ -1,3 +1,4 @@
+using Eidet.Core.Domain;
 using Eidet.Core.Storage;
 
 namespace Eidet.Core.Benchmark;
@@ -8,6 +9,10 @@ namespace Eidet.Core.Benchmark;
 /// The runner feeds <see cref="Lex"/>/<see cref="Vec"/> through the real ranking math and scores
 /// the result against <see cref="GoldIds"/>. A case is self-contained — no external data, no clock
 /// beyond the <c>now</c> the runner supplies — so every metric is reproducible.
+/// <para><see cref="Neighbors"/> are off-pool, link-reachable entries (in neither arm) the runner can
+/// resolve when a parent hit carries a <see cref="MemoryLink.TargetMemoryId"/> into them — exercising
+/// graph-neighbor expansion. Empty (the default) makes expansion a no-op, so a case without neighbors
+/// scores byte-identically with or without the expansion pass.</para>
 /// </summary>
 public sealed record BenchmarkCase(
     string Id,
@@ -15,4 +20,8 @@ public sealed record BenchmarkCase(
     IReadOnlyList<ScoredHit> Lex,
     IReadOnlyList<ScoredHit> Vec,
     IReadOnlySet<string> GoldIds,
-    int K);
+    int K)
+{
+    public IReadOnlyDictionary<string, MemoryEntry> Neighbors { get; init; } =
+        new Dictionary<string, MemoryEntry>();
+}

--- a/src/Eidet.Core/Benchmark/BenchmarkRunner.cs
+++ b/src/Eidet.Core/Benchmark/BenchmarkRunner.cs
@@ -35,13 +35,20 @@ public static class BenchmarkRunner
         return new BenchmarkReport(Aggregate(fused), Aggregate(baseline));
     }
 
-    /// <summary>v2 ranking: real min-max fusion + UCB + recency, then the type-budget truncation.</summary>
+    /// <summary>
+    /// v2 ranking: real min-max fusion + UCB + recency, then bounded graph-neighbor expansion (when the
+    /// case ships neighbors), then the type-budget truncation. With no neighbors the expansion pass is a
+    /// no-op, so the ranking is byte-identical to fusion-only — the baseline never expands, so a gold
+    /// reachable only as a link-neighbor is a clean, honest lift for fusion.
+    /// </summary>
     private static (IReadOnlyList<string> Ranked, IReadOnlyList<string> Budgeted) RankFused(
         BenchmarkCase c, DateTime now)
     {
         var weights = RecallWeights.Default with { TotalN = ComputeTotalN(c.Lex, c.Vec) };
         // Fuse once; derive both the full ranking and the post-budget projection from it.
         var fused = RecallScoring.Fuse(c.Lex, c.Vec, weights, now);
+        if (c.Neighbors.Count > 0)
+            fused = RecallScoring.ExpandNeighbors(fused, id => c.Neighbors.GetValueOrDefault(id), weights, now);
         var ranked = fused.Select(f => f.Entry.Id).ToList();
         var results = fused.Select(f => RecallScoring.ToSearchResult(f.Entry, (float)f.Fused)).ToList();
         var budgeted = RecallScoring.ApplyTypeBudgets(results, c.K).Select(r => r.Id).ToList();

--- a/src/Eidet.Core/Domain/MemoryEntry.cs
+++ b/src/Eidet.Core/Domain/MemoryEntry.cs
@@ -48,6 +48,13 @@ public class MemoryEntry
     public int AccessCount { get; set; }
     public DateTime? LastAccessedAt { get; set; }
 
+    /// <summary>
+    /// Lexical share — normLex/(normLex+normVec), 0.5 when both 0 — of this memory at its most recent
+    /// recall. Drives per-repo alpha learning: a later echo/fizzle attributes a free relevance label
+    /// for the lexical-vs-vector blend back to this share. Null = never recalled under the v2 pipeline.
+    /// </summary>
+    public double? LastLexShare { get; set; }
+
     // Echo/Fizzle feedback
     public int EchoCount { get; set; }
     public int FizzleCount { get; set; }

--- a/src/Eidet.Core/Domain/MemoryQuery.cs
+++ b/src/Eidet.Core/Domain/MemoryQuery.cs
@@ -8,6 +8,10 @@ public class MemoryQuery
     public int Limit { get; set; } = 10;
     public bool IncludeExpired { get; set; }
     public bool CrossRepo { get; set; }
+    public bool ExpandGraph { get; set; } = true;
+
+    /// <summary>Pins the lexical-vs-vector blend weight, bypassing the per-repo learned alpha. Null = learned/default.</summary>
+    public double? AlphaOverride { get; set; }
 }
 
 public class MemorySearchResult

--- a/src/Eidet.Core/Domain/RepoUsage.cs
+++ b/src/Eidet.Core/Domain/RepoUsage.cs
@@ -16,6 +16,15 @@ public class RepoUsage
     /// </summary>
     public string? OriginalPath { get; set; }
 
+    /// <summary>
+    /// Per-repo learned lexical-vs-vector blend weight (the recall <c>alpha</c>), EWMA-updated from
+    /// echo/fizzle feedback. Null = unlearned → callers fall back to <c>RecallWeights.Default.Alpha</c>.
+    /// </summary>
+    public double? AlphaLex { get; set; }
+
+    /// <summary>Count of EWMA alpha updates applied — diagnostics / warmup signal.</summary>
+    public long AlphaSamples { get; set; }
+
     public static string MakeId(string repoId) =>
         $"usage/{RepoIdNormalizer.Normalize(repoId).Replace('\\', '-').Replace('/', '-').Replace(':', '-')}";
 

--- a/src/Eidet.Core/Memory/RecallCache.cs
+++ b/src/Eidet.Core/Memory/RecallCache.cs
@@ -85,9 +85,9 @@ internal sealed class RecallCache
         foreach (var scope in scopes) Invalidate(scope);
     }
 
-    public static string ComputeKey(string repoId, MemoryQuery query)
+    public static string ComputeKey(string repoId, MemoryQuery query, double alphaBucket)
     {
-        var raw = $"{repoId}|{query.Text}|{query.Type}|{string.Join(",", query.Tags)}|{query.Limit}|{query.IncludeExpired}|{query.CrossRepo}";
+        var raw = $"{repoId}|{query.Text}|{query.Type}|{string.Join(",", query.Tags)}|{query.Limit}|{query.IncludeExpired}|{query.CrossRepo}|{alphaBucket}";
         var hash = SHA256.HashData(Encoding.UTF8.GetBytes(raw));
         return Convert.ToHexString(hash)[..16];
     }

--- a/src/Eidet.Core/Memory/RecallScoring.cs
+++ b/src/Eidet.Core/Memory/RecallScoring.cs
@@ -75,7 +75,7 @@ public static class RecallScoring
         {
             var l = normLex.GetValueOrDefault(id);
             var v = normVec.GetValueOrDefault(id);
-            var ucb = w.Kappa * Math.Sqrt(lnN / (entry.EchoCount + entry.FizzleCount + 1));
+            var ucb = Ucb(entry, w, lnN);
             var recency = FadeMemCurve.Recency(entry.CreatedAt, entry.LastAccessedAt, now, entry.Type);
             var score = w.Alpha * l + (1 - w.Alpha) * v + ucb + recency;
             fused.Add(new FusedCandidate(entry, l, v, recency, ucb, score));
@@ -83,6 +83,65 @@ public static class RecallScoring
 
         fused.Sort((a, b) => b.Fused.CompareTo(a.Fused));
         return fused;
+    }
+
+    /// <summary>UCB exploration bonus: <c>Kappa·sqrt(ln(TotalN+1)/(Echo+Fizzle+1))</c>, the single home of
+    /// the exploration math shared by <see cref="Fuse"/> and <see cref="ExpandNeighbors"/>.</summary>
+    private static double Ucb(MemoryEntry entry, RecallWeights w, double lnN) =>
+        w.Kappa * Math.Sqrt(lnN / (entry.EchoCount + entry.FizzleCount + 1));
+
+    /// <summary>
+    /// Expands the fused pool with link-reachable neighbors that compete via damped inheritance:
+    /// a neighbor not already in the pool inherits parentFused * <paramref name="neighborDecay"/> plus
+    /// its own recency+UCB, so related-but-unsurfaced memories get a real shot at the budget without
+    /// swamping direct hits. Bounded: only the top <paramref name="parentTopK"/> candidates spread, total
+    /// new neighbors capped at <paramref name="maxNeighbors"/>, one hop. <paramref name="resolve"/> returns
+    /// the neighbor entry for a link target id (null if out of scope / missing). Neighbors enter with
+    /// normalized Lex/Vec = 0 (they are in neither arm); their inherited association is carried in the
+    /// <see cref="FusedCandidate.Fused"/> total. Pure, deterministic, re-sorted by fused descending.
+    /// </summary>
+    public static List<FusedCandidate> ExpandNeighbors(
+        IReadOnlyList<FusedCandidate> fused, Func<string, MemoryEntry?> resolve,
+        RecallWeights w, DateTime now, int parentTopK = 10, int maxNeighbors = 5, double neighborDecay = 0.5)
+    {
+        var lnN = Math.Log(w.TotalN + 1);
+        var present = new HashSet<string>(fused.Select(c => c.Entry.Id), StringComparer.OrdinalIgnoreCase);
+        var added = new List<FusedCandidate>();
+
+        // Parents are already sorted by fused descending (Fuse re-sorts); take the strongest few so the
+        // spreading activation flows from the most-relevant hits, not from low-ranked noise.
+        foreach (var parent in fused.Take(parentTopK))
+        {
+            if (added.Count >= maxNeighbors) break;
+            foreach (var link in parent.Entry.Links)
+            {
+                if (added.Count >= maxNeighbors) break;
+                var targetId = link.TargetMemoryId;
+                if (string.IsNullOrEmpty(targetId) || present.Contains(targetId)) continue;
+
+                var neighbor = resolve(targetId);
+                if (neighbor is null) continue;
+
+                var ucb = Ucb(neighbor, w, lnN);
+                var recency = FadeMemCurve.Recency(neighbor.CreatedAt, neighbor.LastAccessedAt, now, neighbor.Type);
+                var score = parent.Fused * neighborDecay + ucb + recency;
+                added.Add(new FusedCandidate(neighbor, Lex: 0, Vec: 0, recency, ucb, score));
+                present.Add(targetId); // dedup neighbors against each other, not just against the pool
+            }
+        }
+
+        if (added.Count == 0)
+        {
+            var copy = new List<FusedCandidate>(fused);
+            copy.Sort((a, b) => b.Fused.CompareTo(a.Fused));
+            return copy;
+        }
+
+        var expanded = new List<FusedCandidate>(fused.Count + added.Count);
+        expanded.AddRange(fused);
+        expanded.AddRange(added);
+        expanded.Sort((a, b) => b.Fused.CompareTo(a.Fused));
+        return expanded;
     }
 
     /// <summary>Convenience projection: fuse, then map to <see cref="MemorySearchResult"/> carrying the fused score.</summary>

--- a/src/Eidet.Core/Services/MemoryService.cs
+++ b/src/Eidet.Core/Services/MemoryService.cs
@@ -26,6 +26,13 @@ public sealed class MemoryService
 {
     private const float DuplicateThreshold = 0.92f;
 
+    // Alpha learning (#33 item 6): the EWMA smoothing factor and the clamp band that keeps the learned
+    // lexical-vs-vector blend from ever collapsing to a single arm (the compensating control for shipping
+    // alpha-learning alongside UCB). Applied at both learn-time and read-time.
+    private const double EwmaLambda = 0.1;
+    private const double AlphaMin = 0.15;
+    private const double AlphaMax = 0.85;
+
     private readonly IEidetStore _store;
     private readonly IHookRunner _hooks;
     private readonly LayerService? _layers;
@@ -192,7 +199,7 @@ public sealed class MemoryService
         entry.LastAccessedAt = DateTime.UtcNow;
         entry.AccessCount++;
 
-        return await RunMutationAsync(
+        var written = await RunMutationAsync(
             scope: entry.RepoId,
             pre: null, preCtx: null,
             post: null, postCtxFactory: null,
@@ -203,6 +210,29 @@ public sealed class MemoryService
             },
             denied: _ => false,
             ct: ct);
+
+        // Per-repo alpha learning (#33 item 6): each echo/fizzle is a free relevance label for the
+        // lexical-vs-vector blend. We nudge the learned alpha toward the lexical share that produced
+        // this hit on an echo (the mix worked), and away from it on a fizzle (the mix misled). Runs
+        // OUTSIDE the entry-write mutation — it patches RepoUsage, not a MemoryEntry, and must not
+        // interfere with the entry-write cache invalidation. Best-effort; skips if this memory was
+        // never surfaced under v2 (no LastLexShare attribution yet).
+        if (written && entry.LastLexShare is { } lastLexShare)
+        {
+            try
+            {
+                // Echo nudges alpha toward the lexical share that surfaced this hit (the mix worked);
+                // fizzle nudges away. The EWMA fold itself is applied server-side from the live stored
+                // alpha (see UpdateRepoAlphaAsync) so concurrent feedback can't lose a step.
+                var target = wasUsed ? lastLexShare : 1 - lastLexShare;
+                await _store.UpdateRepoAlphaAsync(
+                    entry.RepoId,
+                    new AlphaEwmaUpdate(target, EwmaLambda, AlphaMin, AlphaMax, RecallWeights.Default.Alpha), ct);
+            }
+            catch { /* Non-critical — feedback already recorded; alpha tuning is an enhancement. */ }
+        }
+
+        return written;
     }
 
     public Task<bool> UpdateMemoryAsync(
@@ -356,7 +386,12 @@ public sealed class MemoryService
         }, ct);
         if (!preHook.Allowed) return [];
 
-        var cacheKey = RecallCache.ComputeKey(scope.PrimaryRepoId, query);
+        // The learned alpha is part of the cache key, so it must be resolved BEFORE TryGet — a learned
+        // shift then invalidates cleanly via the bucket. One tiny Raven-cached doc load (the RepoUsage
+        // anchor) on the recall path; cheap and bounded.
+        var effectiveAlpha = await ResolveAlphaAsync(query, scope.PrimaryRepoId, ct);
+
+        var cacheKey = RecallCache.ComputeKey(scope.PrimaryRepoId, query, Math.Round(effectiveAlpha, 1));
         if (_cache.TryGet(cacheKey, scope.RepoIds, out var observed, out var cached))
             return cached;
 
@@ -366,8 +401,16 @@ public sealed class MemoryService
         await Task.WhenAll(lexTask, vecTask);
 
         var now = DateTime.UtcNow;
-        var weights = RecallWeights.Default with { TotalN = ComputeTotalN(lexTask.Result, vecTask.Result) };
+        var weights = RecallWeights.Default with
+        {
+            TotalN = ComputeTotalN(lexTask.Result, vecTask.Result),
+            Alpha = effectiveAlpha,
+        };
         var fused = RecallScoring.Fuse(lexTask.Result, vecTask.Result, weights, now);
+
+        // Graph-neighbor expansion (#33 item 7) runs BEFORE trust gating / de-boost / budgeting so
+        // link-reachable neighbors flow through exactly the same downstream policy as direct arm hits.
+        fused = await ExpandNeighborsAsync(fused, scope, query, weights, now, ct);
 
         // Trust gating is a production-recall policy layered on top of Fuse, NOT folded into it:
         // the benchmark scorecard calls Fuse directly and would be unfairly penalized on its
@@ -375,6 +418,9 @@ public sealed class MemoryService
         // retrieval time alongside the non-local de-boost.
         var staleAfter = StalenessWarningDays;
         var merged = new List<MemorySearchResult>(fused.Count);
+        // The lexical share of each candidate's surfacing mix — stamped onto the budgeted local results
+        // so each future echo/fizzle becomes a free relevance label for alpha learning (#33 item 6).
+        var lexShares = new Dictionary<string, double>(fused.Count, StringComparer.OrdinalIgnoreCase);
         foreach (var candidate in fused)
         {
             var entry = candidate.Entry;
@@ -391,11 +437,17 @@ public sealed class MemoryService
             else if (result.AgeDays >= staleAfter)
                 result.StalenessWarning = $"[stale: {result.AgeDays}d ago — verify before acting]";
             merged.Add(result);
+
+            // Lexical share of the surfacing mix. 0.5 = deliberate no-arm-info prior — used when neither
+            // arm scored the candidate (a graph neighbor enters with Lex=Vec=0), so a later echo on it
+            // pulls alpha toward neutral rather than toward a phantom arm preference.
+            var lv = candidate.Lex + candidate.Vec;
+            lexShares[entry.Id] = lv > 0 ? candidate.Lex / lv : 0.5;
         }
 
         var budgeted = RecallScoring.ApplyTypeBudgets(merged, query.Limit);
 
-        _ = BumpAccessCountsAsync(budgeted, scope.PrimaryRepoId, ct);
+        _ = BumpAccessCountsAsync(budgeted, scope.PrimaryRepoId, lexShares, ct);
 
         _ = _hooks.RunPostHooksAsync(HookEvent.PostRecall, new HookContext
         {
@@ -411,10 +463,85 @@ public sealed class MemoryService
     }
 
     /// <summary>
-    /// Diagnostic recall: runs the SAME fuse pipeline as <see cref="RecallInternalAsync"/> (resolve
-    /// scope → two scored arms → <see cref="RecallScoring.Fuse"/>) and returns the per-candidate
-    /// component breakdown instead of budgeted results. Bypasses the recall cache and fires no hooks —
-    /// it must not perturb live recall state.
+    /// Effective lexical-vs-vector blend weight: an explicit <see cref="RecallOptions.AlphaOverride"/>
+    /// wins, else the per-repo EWMA-learned <c>RepoUsage.AlphaLex</c>, else the cold-start default.
+    /// Clamped to [<see cref="AlphaMin"/>, <see cref="AlphaMax"/>] so neither arm is ever fully muted.
+    /// </summary>
+    private async Task<double> ResolveAlphaAsync(MemoryQuery query, string primaryRepoId, CancellationToken ct)
+    {
+        var learned = query.AlphaOverride ?? await _store.GetRepoAlphaAsync(primaryRepoId, ct);
+        return Math.Clamp(learned ?? RecallWeights.Default.Alpha, AlphaMin, AlphaMax);
+    }
+
+    /// <summary>
+    /// Pulls link-reachable neighbors of the top fused candidates into the pool so they compete on the
+    /// (damped) fused score. Best-effort: a failed neighbor load can't fail the whole recall (mirrors
+    /// access tracking). Neighbor entries are loaded only if in scope and latest; the pure damped-
+    /// inheritance math lives in <see cref="RecallScoring.ExpandNeighbors"/>.
+    /// </summary>
+    private async Task<List<FusedCandidate>> ExpandNeighborsAsync(
+        List<FusedCandidate> fused, LayerScope scope, MemoryQuery query, RecallWeights weights, DateTime now, CancellationToken ct)
+    {
+        if (!query.ExpandGraph || fused.Count == 0) return fused;
+
+        try
+        {
+            const int parentTopK = 10;
+            const int maxNeighbors = 5;
+            var present = new HashSet<string>(fused.Select(c => c.Entry.Id), StringComparer.OrdinalIgnoreCase);
+
+            // In-scope = a repo this recall already searches (RepoIds always contains the primary, plus
+            // any mounted layers). The de-boost loop downstream still de-boosts non-primary hits.
+            bool InScope(string repoId) => scope.RepoIds.Contains(repoId, StringComparer.OrdinalIgnoreCase);
+
+            // Gather neighbor ids from the strongest parents, deduped against the pool. Bounded by
+            // maxNeighbors here too so we never over-fetch (the pure helper enforces the same cap).
+            var toLoad = new List<string>();
+            foreach (var parent in fused.Take(parentTopK))
+            {
+                if (toLoad.Count >= maxNeighbors) break;
+                foreach (var link in parent.Entry.Links)
+                {
+                    if (toLoad.Count >= maxNeighbors) break;
+                    var targetId = link.TargetMemoryId;
+                    if (string.IsNullOrEmpty(targetId) || !present.Add(targetId)) continue;
+                    // Cheap pre-filter on the link's declared target repo; the loaded entry's REAL repo
+                    // is re-checked below (a stale/wrong TargetRepoId must not pull in an out-of-scope memory).
+                    if (!InScope(link.TargetRepoId)) continue;
+                    toLoad.Add(targetId);
+                }
+            }
+
+            if (toLoad.Count == 0) return fused;
+
+            var resolved = new Dictionary<string, MemoryEntry>(StringComparer.OrdinalIgnoreCase);
+            foreach (var id in toLoad)
+            {
+                var entry = await _store.GetAsync(id, ct);
+                // Authoritative scope check on the entry's actual RepoId — the link's declared
+                // TargetRepoId is untrusted; never admit a memory from a repo this recall isn't searching.
+                if (entry is { IsLatest: true } && InScope(entry.RepoId))
+                    resolved[id] = entry;
+            }
+
+            return RecallScoring.ExpandNeighbors(
+                fused, id => resolved.GetValueOrDefault(id), weights, now, parentTopK, maxNeighbors);
+        }
+        catch
+        {
+            // Expansion is an enhancement, not a correctness requirement — never fail recall over it.
+            return fused;
+        }
+    }
+
+    /// <summary>
+    /// Diagnostic recall: runs the fuse pipeline (resolve scope → two scored arms →
+    /// <see cref="RecallScoring.Fuse"/>) and returns the per-candidate component breakdown instead of
+    /// budgeted results. Bypasses the recall cache and fires no hooks — it must not perturb live recall
+    /// state. Uses the effective learned/overridden alpha so <see cref="RecallExplanation.AlphaUsed"/>
+    /// reflects what production recall ranks with. NOTE: this is a PRE-EXPANSION view — graph-neighbor
+    /// expansion (<see cref="ExpandNeighborsAsync"/>) is intentionally not run here, so link-reachable
+    /// candidates that production recall would surface do not appear; the rows show the arm-fusion math only.
     /// </summary>
     public async Task<RecallExplanation> ExplainRecallAsync(
         string repoId, RecallOptions opts, CancellationToken ct = default)
@@ -422,12 +549,17 @@ public sealed class MemoryService
         var query = ToMemoryQuery(opts);
         var scope = await ResolveScopeAsync(repoId, opts.CrossRepo, ct);
         var repoIds = scope.RepoIds.ToList();
+        var effectiveAlpha = await ResolveAlphaAsync(query, scope.PrimaryRepoId, ct);
 
         var lexTask = _store.SearchScoredAsync(SearchArm.Lexical, repoIds, query, ct);
         var vecTask = _store.SearchScoredAsync(SearchArm.Vector, repoIds, query, ct);
         await Task.WhenAll(lexTask, vecTask);
 
-        var weights = RecallWeights.Default with { TotalN = ComputeTotalN(lexTask.Result, vecTask.Result) };
+        var weights = RecallWeights.Default with
+        {
+            TotalN = ComputeTotalN(lexTask.Result, vecTask.Result),
+            Alpha = effectiveAlpha,
+        };
         var fused = RecallScoring.Fuse(lexTask.Result, vecTask.Result, weights, DateTime.UtcNow);
 
         var rows = fused
@@ -558,12 +690,15 @@ public sealed class MemoryService
         return sb.ToString();
     }
 
-    private async Task BumpAccessCountsAsync(List<MemorySearchResult> results, string repoId, CancellationToken ct)
+    private async Task BumpAccessCountsAsync(
+        List<MemorySearchResult> results, string repoId, IReadOnlyDictionary<string, double> lexShares, CancellationToken ct)
     {
         // Access tracking is a justified exemption from cache invalidation: AccessCount /
         // LastAccessedAt are not in the recall cache key. LastAccessedAt does feed dual-clock
         // recency (#33), so a cached recall can be marginally stale on recency — bounded and
         // acceptable within the cache's short TTL; invalidating on every recall would defeat it.
+        // We also stamp LastLexShare here (the surfacing mix that produced this hit) so a later
+        // echo/fizzle on this memory can attribute a free relevance label to alpha learning (#33 item 6).
         // The dedicated patch-only ctx prevents this path from accidentally writing other fields.
         var ctx = new AccessTrackingCtx(_store);
         try
@@ -572,7 +707,7 @@ public sealed class MemoryService
             {
                 if (!string.Equals(result.RepoId, repoId, StringComparison.OrdinalIgnoreCase))
                     continue;
-                await ctx.BumpAsync(result.Id, ct);
+                await ctx.BumpAsync(result.Id, lexShares.TryGetValue(result.Id, out var s) ? s : null, ct);
             }
         }
         catch { /* Non-critical — don't fail recall for access tracking */ }
@@ -743,6 +878,8 @@ public sealed class MemoryService
         Limit = opts.Limit,
         IncludeExpired = opts.IncludeExpired,
         CrossRepo = opts.CrossRepo,
+        ExpandGraph = opts.ExpandGraph,
+        AlphaOverride = opts.AlphaOverride,
     };
 
     private async Task<T> RunMutationAsync<T>(
@@ -874,10 +1011,11 @@ public readonly struct BulkMutationCtx
 
 /// <summary>
 /// Access-tracking gate. Exposes only the patch-only <c>BumpAsync</c> method — the API
-/// itself cannot be tricked into writing fields other than <c>AccessCount</c> and
-/// <c>LastAccessedAt</c>. Used by the recall path's access-count side-effect, which is a
-/// justified exemption from cache invalidation (the patched fields are not in the recall cache
-/// key; the recency staleness LastAccessedAt can introduce is bounded by the short cache TTL).
+/// itself cannot be tricked into writing fields other than <c>AccessCount</c>,
+/// <c>LastAccessedAt</c>, and <c>LastLexShare</c>. Used by the recall path's access-count
+/// side-effect, which is a justified exemption from cache invalidation (the patched fields are
+/// not in the recall cache key; the recency staleness LastAccessedAt can introduce is bounded by
+/// the short cache TTL).
 /// </summary>
 internal readonly struct AccessTrackingCtx
 {
@@ -885,6 +1023,6 @@ internal readonly struct AccessTrackingCtx
 
     internal AccessTrackingCtx(IEidetStore store) => _store = store;
 
-    public Task BumpAsync(string entryId, CancellationToken ct) =>
-        _store.PatchAccessAsync(entryId, DateTime.UtcNow, ct);
+    public Task BumpAsync(string entryId, double? lexShare, CancellationToken ct) =>
+        _store.PatchAccessAsync(entryId, DateTime.UtcNow, lexShare, ct);
 }

--- a/src/Eidet.Core/Services/MemoryServiceOptions.cs
+++ b/src/Eidet.Core/Services/MemoryServiceOptions.cs
@@ -21,6 +21,12 @@ public sealed record RecallOptions(string Query)
     public IReadOnlyList<string>? Tags { get; init; }
     public bool IncludeExpired { get; init; }
     public bool CrossRepo { get; init; } = true;
+
+    /// <summary>Bounded graph-neighbor expansion of the candidate pool (default on; opt out for raw fusion).</summary>
+    public bool ExpandGraph { get; init; } = true;
+
+    /// <summary>Pins the lexical-vs-vector blend weight, bypassing the per-repo learned alpha. Null = use learned/default.</summary>
+    public double? AlphaOverride { get; init; }
 }
 
 /// <summary>20% surface for <see cref="MemoryService.EditAsync(string, EditOptions, CancellationToken)"/>.</summary>

--- a/src/Eidet.Core/Storage/IEidetStore.cs
+++ b/src/Eidet.Core/Storage/IEidetStore.cs
@@ -8,6 +8,15 @@ public readonly record struct ScoredHit(MemoryEntry Entry, double Score);
 /// <summary>The two arms of hybrid search — lexical (full-text) and semantic (vector).</summary>
 public enum SearchArm { Lexical, Vector }
 
+/// <summary>
+/// One EWMA step for a repo's learned lexical-vs-vector alpha. The new value is computed
+/// <i>server-side</i> from the document's current alpha so concurrent feedback can't lose an update:
+/// <c>next = clamp((1-Lambda)·(current ?? Fallback) + Lambda·Target, Min, Max)</c>. The caller supplies
+/// only the relevance label (<see cref="Target"/>) and the recall-domain constants; the store owns the
+/// atomic apply.
+/// </summary>
+public readonly record struct AlphaEwmaUpdate(double Target, double Lambda, double Min, double Max, double Fallback);
+
 public interface IEidetStore
 {
     Task<MemoryEntry?> GetAsync(string id, CancellationToken ct = default);
@@ -16,14 +25,30 @@ public interface IEidetStore
     Task<bool> ForgetAsync(string id, CancellationToken ct = default);
 
     /// <summary>
-    /// Patch the access-tracking fields (<c>AccessCount</c>, <c>LastAccessedAt</c>) without
-    /// touching any other field. These fields are not in the recall cache key, so writes through
-    /// this path do not invalidate the recall cache; <c>LastAccessedAt</c> does feed dual-clock
-    /// recency, so a cached recall may be marginally stale on recency — bounded by the short cache
-    /// TTL. The default implementation is a no-op so test fakes don't have to opt in unless they
-    /// care about access tracking.
+    /// Patch the access-tracking fields (<c>AccessCount</c>, <c>LastAccessedAt</c>, and — when
+    /// <paramref name="lexShare"/> is supplied — <c>LastLexShare</c>) without touching any other field.
+    /// These fields are not in the recall cache key, so writes through this path do not invalidate the
+    /// recall cache; <c>LastAccessedAt</c> does feed dual-clock recency, so a cached recall may be
+    /// marginally stale on recency — bounded by the short cache TTL. The default implementation is a
+    /// no-op so test fakes don't have to opt in unless they care about access tracking.
     /// </summary>
-    Task PatchAccessAsync(string entryId, DateTime lastAccessedAt, CancellationToken ct = default) =>
+    Task PatchAccessAsync(string entryId, DateTime lastAccessedAt, double? lexShare = null, CancellationToken ct = default) =>
+        Task.CompletedTask;
+
+    /// <summary>
+    /// The per-repo learned lexical-vs-vector blend weight (<c>RepoUsage.AlphaLex</c>), or null when
+    /// unlearned (caller falls back to <c>RecallWeights.Default.Alpha</c>). Default null so fakes need
+    /// not opt in.
+    /// </summary>
+    Task<double?> GetRepoAlphaAsync(string repoId, CancellationToken ct = default) =>
+        Task.FromResult<double?>(null);
+
+    /// <summary>
+    /// Apply one EWMA step to the per-repo alpha (and bump the sample count) on the repo's usage anchor,
+    /// computing the new value server-side from the stored alpha so concurrent feedback can't lose an
+    /// update. Never disturbs the anchor's usage time series or original-path mapping. Default no-op for fakes.
+    /// </summary>
+    Task UpdateRepoAlphaAsync(string repoId, AlphaEwmaUpdate update, CancellationToken ct = default) =>
         Task.CompletedTask;
     Task<List<MemoryEntry>> FullTextSearchAsync(IReadOnlyList<string> repoIds, MemoryQuery query, CancellationToken ct = default);
     Task<List<MemoryEntry>> VectorSearchAsync(IReadOnlyList<string> repoIds, MemoryQuery query, CancellationToken ct = default);

--- a/src/Eidet.Core/Storage/RavenEidetStore.cs
+++ b/src/Eidet.Core/Storage/RavenEidetStore.cs
@@ -54,20 +54,71 @@ public class RavenEidetStore : IEidetStore
         return true;
     }
 
-    public async Task PatchAccessAsync(string entryId, DateTime lastAccessedAt, CancellationToken ct = default)
+    public async Task PatchAccessAsync(string entryId, DateTime lastAccessedAt, double? lexShare = null, CancellationToken ct = default)
     {
-        // Patch only AccessCount + LastAccessedAt — never load or replace the full entry.
-        // Keeps this path narrow so it cannot accidentally clobber other fields on a race.
+        // Patch only AccessCount + LastAccessedAt (+ LastLexShare when provided) — never load or replace
+        // the full entry. Keeps this path narrow so it cannot accidentally clobber other fields on a race.
+        // LastLexShare is set only when a share is supplied so a non-attributed bump leaves it untouched.
         var patchOp = new Raven.Client.Documents.Operations.PatchOperation(
             entryId,
             changeVector: null,
             new Raven.Client.Documents.Operations.PatchRequest
             {
-                Script = "this.AccessCount = (this.AccessCount || 0) + 1; this.LastAccessedAt = args.At;",
-                Values = { { "At", lastAccessedAt } },
+                Script = "this.AccessCount = (this.AccessCount || 0) + 1; this.LastAccessedAt = args.At;"
+                    + " if (args.LexShare !== null) this.LastLexShare = args.LexShare;",
+                Values = { { "At", lastAccessedAt }, { "LexShare", lexShare } },
             });
         try { await _store.Operations.SendAsync(patchOp, token: ct); }
         catch { /* Non-critical — access tracking is best-effort */ }
+    }
+
+    public async Task<double?> GetRepoAlphaAsync(string repoId, CancellationToken ct = default)
+    {
+        using var session = _store.OpenAsyncSession();
+        var usage = await session.LoadAsync<RepoUsage>(RepoUsage.MakeId(repoId), ct);
+        return usage?.AlphaLex;
+    }
+
+    public async Task UpdateRepoAlphaAsync(string repoId, AlphaEwmaUpdate update, CancellationToken ct = default)
+    {
+        // Patch ONLY AlphaLex + AlphaSamples on the usage anchor so we never clobber UsageTracker's
+        // time series or OriginalPath. The EWMA is computed SERVER-SIDE from the document's current
+        // AlphaLex (the patch reads this.AlphaLex at apply time), so two concurrent feedbacks each fold
+        // into the latest value — no read-compute-write race that a C#-side computed value would have.
+        // patchIfMissing upserts the doc (folding from Fallback) the first time alpha is learned for a
+        // repo with no usage anchor yet. Surfaces failures (no swallow) — the caller treats alpha tuning
+        // as best-effort, but a silent storage fault here would hide a real regression in learning.
+        var normalized = RepoIdNormalizer.Normalize(repoId);
+        var docId = RepoUsage.MakeId(repoId);
+        const string ewma =
+            "var cur = (this.AlphaLex === null || this.AlphaLex === undefined) ? args.Fallback : this.AlphaLex;"
+            + " var next = (1 - args.Lambda) * cur + args.Lambda * args.Target;"
+            + " if (next < args.Min) next = args.Min; if (next > args.Max) next = args.Max;"
+            + " this.AlphaLex = next;";
+        var patchOp = new Raven.Client.Documents.Operations.PatchOperation(
+            docId,
+            changeVector: null,
+            patch: new Raven.Client.Documents.Operations.PatchRequest
+            {
+                Script = ewma + " this.AlphaSamples = (this.AlphaSamples || 0) + 1;",
+                Values =
+                {
+                    { "Target", update.Target }, { "Lambda", update.Lambda },
+                    { "Min", update.Min }, { "Max", update.Max }, { "Fallback", update.Fallback },
+                },
+            },
+            patchIfMissing: new Raven.Client.Documents.Operations.PatchRequest
+            {
+                Script = "this.Id = args.Id; this.RepoId = args.RepoId; this.CreatedAt = args.Now;"
+                    + " " + ewma + " this.AlphaSamples = 1;",
+                Values =
+                {
+                    { "Id", docId }, { "RepoId", normalized }, { "Now", DateTime.UtcNow },
+                    { "Target", update.Target }, { "Lambda", update.Lambda },
+                    { "Min", update.Min }, { "Max", update.Max }, { "Fallback", update.Fallback },
+                },
+            });
+        await _store.Operations.SendAsync(patchOp, token: ct);
     }
 
     public async Task<List<MemoryEntry>> FullTextSearchAsync(

--- a/tests/Eidet.Benchmark.Tests/BenchmarkScorecardTests.cs
+++ b/tests/Eidet.Benchmark.Tests/BenchmarkScorecardTests.cs
@@ -40,7 +40,7 @@ public class BenchmarkScorecardTests
         var fused = Recall(RunRecall().Fused);
 
         // Conservative floors below the current Fused numbers — a guard against ranking regressions,
-        // not a tight pin. (Current: recall 0.833, survival 0.792, MRR 0.889, nDCG 0.833.)
+        // not a tight pin. (Current: recall 0.857, survival 0.750, MRR 0.833, nDCG 0.804.)
         Assert.True(fused.RecallAtK >= 0.75, $"fused recall@k was {fused.RecallAtK}");
         Assert.True(fused.GoldSurvival >= 0.70, $"fused gold survival was {fused.GoldSurvival}");
         Assert.True(fused.Mrr >= 0.80, $"fused MRR was {fused.Mrr}");

--- a/tests/Eidet.Benchmark.Tests/GoldDataset.cs
+++ b/tests/Eidet.Benchmark.Tests/GoldDataset.cs
@@ -19,9 +19,13 @@ namespace Eidet.Benchmark.Tests;
 /// is simply more relevant than gold (case 12) — plus a both-arms-strong sanity anchor (case 9) the
 /// baseline also wins. So the scorecard reports a real, non-perfect number, not a self-drawn curve.
 ///
+/// Cases 13-14 exercise graph-neighbor expansion (#33 item 7): the gold is in <b>neither</b> arm, reachable
+/// only as a link-neighbor of a top-ranked parent. Fusion-with-expansion rescues it via damped inheritance;
+/// the baseline never expands and scores recall 0 — an honest lift attributable purely to the graph signal.
+///
 /// All entries share a fixed <see cref="Now"/> creation time, so recency is a constant 1.0 and the
-/// fused ranking is driven purely by the normalized lexical+vector blend. Memory types are varied so
-/// the type-budget pass genuinely engages.
+/// fused ranking is driven purely by the normalized lexical+vector blend (plus the damped link
+/// inheritance on cases 13-14). Memory types are varied so the type-budget pass genuinely engages.
 /// </summary>
 public static class GoldDataset
 {
@@ -42,6 +46,19 @@ public static class GoldDataset
     };
 
     private static ScoredHit Hit(string id, MemoryType type, double score) => new(Entry(id, type), score);
+
+    /// <summary>A scored hit whose entry carries an outbound link to <paramref name="linkTo"/> — the
+    /// parent that lets graph expansion reach an off-pool gold.</summary>
+    private static ScoredHit HitLinkedTo(string id, MemoryType type, double score, string linkTo)
+    {
+        var entry = Entry(id, type);
+        entry.Links.Add(new MemoryLink { TargetRepoId = "bench-repo", TargetMemoryId = linkTo, Relation = "refines" });
+        return new ScoredHit(entry, score);
+    }
+
+    /// <summary>Off-pool neighbors keyed by id, for a case's <see cref="BenchmarkCase.Neighbors"/> map.</summary>
+    private static IReadOnlyDictionary<string, MemoryEntry> Neighbors(params (string Id, MemoryType Type)[] entries) =>
+        entries.ToDictionary(e => e.Id, e => Entry(e.Id, e.Type), StringComparer.OrdinalIgnoreCase);
 
     private static IReadOnlySet<string> Gold(params string[] ids) =>
         ids.ToHashSet(StringComparer.OrdinalIgnoreCase);
@@ -269,5 +286,47 @@ public static class GoldDataset
                 Hit("v1", MemoryType.Insight, 1.0),
             ],
             GoldIds: Gold("gold"), K: 1),
+
+        // ── 13. GRAPH: gold reachable ONLY as a link-neighbor of a strong parent (k=2) ──
+        // Gold is in NEITHER arm — fusion alone never sees it. But the top both-arms parent links to it
+        // (refines), so graph expansion pulls it in with damped inheritance (parentFused·0.5 + recency),
+        // outranking the single-arm distractor and landing inside k=2. The baseline never expands, so it
+        // scores recall 0 on this case — a clean lift attributable purely to graph expansion.
+        new("recall-graph-neighbor-rescue", AmaCapability.Recall,
+            Lex:
+            [
+                HitLinkedTo("parent", MemoryType.Insight, 10.0, linkTo: "gold"),
+                Hit("lexOnly", MemoryType.Insight, 4.0),
+            ],
+            Vec:
+            [
+                Hit("parent", MemoryType.Insight, 10.0),
+                Hit("vecOnly", MemoryType.Observation, 3.0),
+            ],
+            GoldIds: Gold("gold"), K: 2)
+        {
+            Neighbors = Neighbors(("gold", MemoryType.Insight)),
+        },
+
+        // ── 14. GRAPH: link-neighbor gold of a Procedure parent, deeper pool (k=3) ──
+        // A second graph rescue with a different parent type and a noisier pool: the gold sits behind a
+        // procedure parent that tops both arms. Expansion inherits the parent's strength and seats gold
+        // ahead of the lexical/vector noise tail; the baseline, blind to the link, misses it entirely.
+        new("recall-graph-neighbor-deeper-pool", AmaCapability.Recall,
+            Lex:
+            [
+                HitLinkedTo("proc", MemoryType.Procedure, 10.0, linkTo: "gold"),
+                Hit("n1", MemoryType.Insight, 6.0),
+                Hit("n2", MemoryType.Observation, 3.0),
+            ],
+            Vec:
+            [
+                Hit("proc", MemoryType.Procedure, 10.0),
+                Hit("n3", MemoryType.Insight, 5.0),
+            ],
+            GoldIds: Gold("gold"), K: 3)
+        {
+            Neighbors = Neighbors(("gold", MemoryType.Heuristic)),
+        },
     ];
 }

--- a/tests/Eidet.Core.Tests/Memory/AlphaLearningTests.cs
+++ b/tests/Eidet.Core.Tests/Memory/AlphaLearningTests.cs
@@ -1,0 +1,481 @@
+using Eidet.Core.Domain;
+using Eidet.Core.Memory;
+using Eidet.Core.Services;
+using Eidet.Core.Storage;
+
+namespace Eidet.Core.Tests.Memory;
+
+/// <summary>
+/// Behavioral tests for per-repo alpha learning (issue #33 item 6). Each echo/fizzle on a memory that
+/// was surfaced under the v2 recall pipeline (so it carries <see cref="MemoryEntry.LastLexShare"/>) is a
+/// free relevance label for the lexical-vs-vector blend weight. <see cref="MemoryService.FeedbackAsync"/>
+/// folds the label into a per-repo EWMA-learned alpha; <see cref="MemoryService.RecallAsync"/> then ranks
+/// with it (clamped, override-beatable).
+///
+/// The store applies the EWMA fold SERVER-SIDE from its own stored alpha (the post-review design): the
+/// service hands it an <see cref="AlphaEwmaUpdate"/> carrying only the relevance target + the recall-domain
+/// constants, and the store computes <c>next = clamp((1-λ)·(stored ?? Fallback) + λ·Target, Min, Max)</c>.
+/// <see cref="AlphaLearningStore"/> reproduces that fold against an in-memory per-repo dict so the whole
+/// feedback→learn→recall loop is exercisable without RavenDB.
+/// </summary>
+public class AlphaLearningTests
+{
+    private static readonly DateTime Now = new(2026, 6, 20, 0, 0, 0, DateTimeKind.Utc);
+
+    // Mirror of MemoryService's private alpha-learning constants so the tests can assert exact clamps.
+    private const double Default = 0.5;   // RecallWeights.Default.Alpha
+    private const double Min = 0.15;
+    private const double Max = 0.85;
+
+    private static MemoryEntry Entry(
+        string id, string repoId = "repo-a", double? lastLexShare = null, int echo = 0, int fizzle = 0) => new()
+    {
+        Id = id,
+        RepoId = repoId,
+        Type = MemoryType.Insight,
+        Content = id,
+        CreatedAt = Now,
+        Validity = new Validity { ValidFrom = Now },
+        IsLatest = true,
+        Importance = 0.5f,
+        EchoCount = echo,
+        FizzleCount = fizzle,
+        LastLexShare = lastLexShare,
+    };
+
+    // ════════════════════════════════════════════════════════════════════════
+    // Direction of the EWMA nudge
+    // ════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// A high-lexShare (lexically surfaced) memory that ECHOES (was useful) pushes the learned alpha UP
+    /// toward the lexical arm — the lexical mix worked, so weight it more.
+    /// </summary>
+    [Fact]
+    public async Task FeedbackAsync_EchoOnLexicalSurfacedMemory_MovesAlphaUp()
+    {
+        var store = new AlphaLearningStore();
+        store.Seed(Entry("m1", lastLexShare: 0.9));
+
+        var before = await store.GetRepoAlphaAsync("repo-a");
+        Assert.Null(before); // unlearned to start
+
+        var ok = await new MemoryService(store).FeedbackAsync("m1", wasUsed: true);
+        Assert.True(ok);
+
+        var after = await store.GetRepoAlphaAsync("repo-a");
+        Assert.NotNull(after);
+        // First fold from the 0.5 fallback toward target 0.9 ⇒ strictly above 0.5.
+        Assert.True(after > Default, $"alpha after lexical echo ({after}) should exceed default ({Default})");
+    }
+
+    /// <summary>
+    /// A high-lexShare memory that FIZZLES (misled) pushes the learned alpha DOWN — the lexical mix
+    /// misfired, so the fold targets (1 - lexShare), i.e. toward the vector arm.
+    /// </summary>
+    [Fact]
+    public async Task FeedbackAsync_FizzleOnLexicalSurfacedMemory_MovesAlphaDown()
+    {
+        var store = new AlphaLearningStore();
+        store.Seed(Entry("m1", lastLexShare: 0.9));
+
+        await new MemoryService(store).FeedbackAsync("m1", wasUsed: false);
+
+        var after = await store.GetRepoAlphaAsync("repo-a");
+        Assert.NotNull(after);
+        Assert.True(after < Default, $"alpha after lexical fizzle ({after}) should be below default ({Default})");
+    }
+
+    /// <summary>
+    /// A vector-surfaced memory (low lexShare) that ECHOES pushes alpha DOWN toward the vector arm —
+    /// echo targets the lexShare itself (0.1), which is below the 0.5 fallback.
+    /// </summary>
+    [Fact]
+    public async Task FeedbackAsync_EchoOnVectorSurfacedMemory_MovesAlphaDown()
+    {
+        var store = new AlphaLearningStore();
+        store.Seed(Entry("m1", lastLexShare: 0.1));
+
+        await new MemoryService(store).FeedbackAsync("m1", wasUsed: true);
+
+        var after = await store.GetRepoAlphaAsync("repo-a");
+        Assert.NotNull(after);
+        Assert.True(after < Default, $"alpha after vector-arm echo ({after}) should be below default ({Default})");
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // Clamp band — never collapses to a single arm
+    // ════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Many one-sided echoes on a purely-lexical memory (lexShare 1.0) drive alpha toward — but never
+    /// past — the 0.85 ceiling.
+    /// </summary>
+    [Fact]
+    public async Task FeedbackAsync_ManyLexicalEchoes_NeverExceedsAlphaMax()
+    {
+        var store = new AlphaLearningStore();
+        store.Seed(Entry("m1", lastLexShare: 1.0));
+        var svc = new MemoryService(store);
+
+        for (var i = 0; i < 50; i++)
+            await svc.FeedbackAsync("m1", wasUsed: true);
+
+        var after = await store.GetRepoAlphaAsync("repo-a");
+        Assert.NotNull(after);
+        Assert.True(after <= Max + 1e-9, $"alpha ({after}) must not exceed AlphaMax ({Max})");
+        // And it should have actually climbed up to (essentially) the ceiling.
+        Assert.True(after > 0.8, $"50 lexical echoes should drive alpha near the ceiling, got {after}");
+    }
+
+    /// <summary>
+    /// Many one-sided echoes on a purely-vector memory (lexShare 0.0) drive alpha toward — but never
+    /// below — the 0.15 floor.
+    /// </summary>
+    [Fact]
+    public async Task FeedbackAsync_ManyVectorEchoes_NeverDropsBelowAlphaMin()
+    {
+        var store = new AlphaLearningStore();
+        store.Seed(Entry("m1", lastLexShare: 0.0));
+        var svc = new MemoryService(store);
+
+        for (var i = 0; i < 50; i++)
+            await svc.FeedbackAsync("m1", wasUsed: true);
+
+        var after = await store.GetRepoAlphaAsync("repo-a");
+        Assert.NotNull(after);
+        Assert.True(after >= Min - 1e-9, $"alpha ({after}) must not drop below AlphaMin ({Min})");
+        Assert.True(after < 0.2, $"50 vector echoes should drive alpha near the floor, got {after}");
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // No-attribution → no-op
+    // ════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Feedback on a memory with no <see cref="MemoryEntry.LastLexShare"/> (never surfaced under v2)
+    /// records the echo but performs NO alpha update — there is no relevance label to attribute.
+    /// </summary>
+    [Fact]
+    public async Task FeedbackAsync_NoLexShareAttribution_DoesNotTouchAlpha()
+    {
+        var store = new AlphaLearningStore();
+        store.Seed(Entry("m1", lastLexShare: null, echo: 0));
+
+        var ok = await new MemoryService(store).FeedbackAsync("m1", wasUsed: true);
+
+        Assert.True(ok);                                  // feedback itself succeeds
+        Assert.Equal(1, store.GetEntry("m1")!.EchoCount); // echo was recorded
+        Assert.Equal(0, store.AlphaUpdateCalls);          // but no EWMA step ran
+        Assert.Null(await store.GetRepoAlphaAsync("repo-a"));
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // Fallback fold from the cold-start default, not 0
+    // ════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// The first-ever feedback for a repo with no stored alpha folds from the cold-start default (0.5),
+    /// not from 0. A neutral lexShare (0.5) echo therefore leaves alpha exactly at 0.5 — proving the
+    /// fold base is the fallback. (Folding from 0 would land at λ·0.5 = 0.05.)
+    /// </summary>
+    [Fact]
+    public async Task FeedbackAsync_FirstFeedback_FoldsFromDefaultNotZero()
+    {
+        var store = new AlphaLearningStore();
+        store.Seed(Entry("m1", lastLexShare: 0.5)); // neutral target == fallback
+
+        await new MemoryService(store).FeedbackAsync("m1", wasUsed: true);
+
+        var after = await store.GetRepoAlphaAsync("repo-a");
+        Assert.NotNull(after);
+        // next = (1-λ)·0.5 + λ·0.5 = 0.5 exactly — only true if the base was the 0.5 fallback.
+        Assert.Equal(0.5, after!.Value, precision: 9);
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // Recall applies the learned alpha
+    // ════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// With a learned alpha of 0.8 (lexical-leaning), a lexically-strong candidate out-ranks a
+    /// vector-strong one; flip the learned alpha to 0.2 (vector-leaning) and the ordering reverses.
+    /// Drives the whole RecallAsync path so the learned weight visibly changes results.
+    /// </summary>
+    [Fact]
+    public async Task RecallAsync_OrderingFollowsLearnedAlpha_FlipsWithTheWeight()
+    {
+        // lexHero is the lexical-arm leader; vecHero is the vector-arm leader. Equal-but-opposite.
+        async Task<List<MemorySearchResult>> RecallWithAlpha(double alpha)
+        {
+            var store = new AlphaLearningStore();
+            store.SetAlpha("repo-a", alpha);
+            store.SetArm(SearchArm.Lexical, ("lexHero", 10.0), ("vecHero", 5.0));
+            store.SetArm(SearchArm.Vector, ("vecHero", 10.0), ("lexHero", 5.0));
+            store.Seed(Entry("lexHero"), Entry("vecHero"));
+            // ExpandGraph off so neighbor expansion can't perturb the pure-fusion ordering.
+            return await new MemoryService(store).RecallAsync(
+                "repo-a", new RecallOptions("q") { ExpandGraph = false });
+        }
+
+        var lexLeaning = await RecallWithAlpha(0.8);
+        var vecLeaning = await RecallWithAlpha(0.2);
+
+        Assert.Equal("lexHero", lexLeaning[0].Id);  // alpha 0.8 favors the lexical arm
+        Assert.Equal("vecHero", vecLeaning[0].Id);  // alpha 0.2 favors the vector arm
+    }
+
+    /// <summary>
+    /// <see cref="ExplainRecallAsync"/> reflects the learned alpha (0.7) in <c>AlphaUsed</c>, clamped
+    /// into the band — proving recall resolves and ranks with the per-repo learned weight.
+    /// </summary>
+    [Fact]
+    public async Task ExplainRecall_AlphaUsed_ReflectsLearnedValue()
+    {
+        var store = new AlphaLearningStore();
+        store.SetAlpha("repo-a", 0.7);
+        store.SetArm(SearchArm.Lexical, ("a", 5.0));
+        store.SetArm(SearchArm.Vector, ("a", 5.0));
+        store.Seed(Entry("a"));
+
+        var explanation = await new MemoryService(store).ExplainRecallAsync("repo-a", new RecallOptions("q"));
+
+        Assert.Equal(0.7, explanation.AlphaUsed, precision: 9);
+    }
+
+    /// <summary>
+    /// A learned alpha that sits OUTSIDE the [0.15, 0.85] band is clamped at read-time. A stored 0.95 is
+    /// reported by ExplainRecall as 0.85 (the ceiling).
+    /// </summary>
+    [Fact]
+    public async Task ExplainRecall_AlphaUsed_ClampsOutOfBandLearnedValue()
+    {
+        var store = new AlphaLearningStore();
+        store.SetAlpha("repo-a", 0.95); // above the ceiling
+        store.SetArm(SearchArm.Lexical, ("a", 5.0));
+        store.SetArm(SearchArm.Vector, ("a", 5.0));
+        store.Seed(Entry("a"));
+
+        var explanation = await new MemoryService(store).ExplainRecallAsync("repo-a", new RecallOptions("q"));
+
+        Assert.Equal(Max, explanation.AlphaUsed, precision: 9);
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // AlphaOverride beats the learned alpha
+    // ════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// An explicit <see cref="RecallOptions.AlphaOverride"/> wins over the per-repo learned alpha
+    /// (still clamped into band). The store has learned 0.8 but the override pins 0.3.
+    /// </summary>
+    [Fact]
+    public async Task ExplainRecall_AlphaOverride_BeatsLearnedAlpha()
+    {
+        var store = new AlphaLearningStore();
+        store.SetAlpha("repo-a", 0.8);
+        store.SetArm(SearchArm.Lexical, ("a", 5.0));
+        store.SetArm(SearchArm.Vector, ("a", 5.0));
+        store.Seed(Entry("a"));
+
+        var explanation = await new MemoryService(store).ExplainRecallAsync(
+            "repo-a", new RecallOptions("q") { AlphaOverride = 0.3 });
+
+        Assert.Equal(0.3, explanation.AlphaUsed, precision: 9);
+    }
+
+    /// <summary>An out-of-band override is clamped too: AlphaOverride=0.05 → 0.15 (the floor).</summary>
+    [Fact]
+    public async Task ExplainRecall_AlphaOverride_IsClampedIntoBand()
+    {
+        var store = new AlphaLearningStore();
+        store.SetArm(SearchArm.Lexical, ("a", 5.0));
+        store.SetArm(SearchArm.Vector, ("a", 5.0));
+        store.Seed(Entry("a"));
+
+        var explanation = await new MemoryService(store).ExplainRecallAsync(
+            "repo-a", new RecallOptions("q") { AlphaOverride = 0.05 });
+
+        Assert.Equal(Min, explanation.AlphaUsed, precision: 9);
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // End-to-end loop: recall stamps lexShare → feedback learns from it
+    // ════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// The strongest test — the whole attribution loop wired through the real service. A recall surfaces
+    /// a purely-lexical local hit, which stamps <c>LastLexShare</c> ≈ 1.0 via the access-tracking patch.
+    /// A subsequent echo on that id then folds the learned alpha UP toward lexical — proving the recall
+    /// side stamps the share AND the feedback side reads it. No hand-set lexShare anywhere.
+    /// </summary>
+    [Fact]
+    public async Task RecallThenEcho_StampsLexShareAndLearnsFromIt()
+    {
+        var store = new AlphaLearningStore();
+        // Purely lexical surfacing: present in the lexical arm only ⇒ lexShare stamps to ~1.0.
+        store.SetArm(SearchArm.Lexical, ("m1", 7.0));
+        store.SetArm(SearchArm.Vector); // empty vector arm
+        store.Seed(Entry("m1", lastLexShare: null));
+        var svc = new MemoryService(store);
+
+        // 1) Recall surfaces m1 and (via PatchAccessAsync) stamps its LastLexShare.
+        var results = await svc.RecallAsync("repo-a", "q");
+        Assert.Contains(results, r => r.Id == "m1");
+
+        // The recall side-effect runs fire-and-forget; give it a moment to land the patch.
+        await WaitUntilAsync(() => store.GetEntry("m1")!.LastLexShare is not null);
+        var stamped = store.GetEntry("m1")!.LastLexShare;
+        Assert.NotNull(stamped);
+        Assert.True(stamped > 0.9, $"lex-only surfacing should stamp lexShare near 1.0, got {stamped}");
+
+        // 2) An echo on the now-attributed memory learns alpha UP toward lexical.
+        Assert.Null(await store.GetRepoAlphaAsync("repo-a"));
+        await svc.FeedbackAsync("m1", wasUsed: true);
+
+        var learned = await store.GetRepoAlphaAsync("repo-a");
+        Assert.NotNull(learned);
+        Assert.True(learned > Default, $"echo on a lex-surfaced hit should lift alpha above default, got {learned}");
+    }
+
+    /// <summary>
+    /// lexShare prior: a candidate scored by NEITHER arm (it rode in via graph expansion) is stamped with
+    /// the deliberate no-arm-info prior 0.5, not 0 or 1. We surface a linked neighbor that is in neither
+    /// arm, then assert the stamped LastLexShare is exactly 0.5.
+    /// </summary>
+    [Fact]
+    public async Task Recall_NoArmCandidate_StampsLexSharePriorOfHalf()
+    {
+        var store = new AlphaLearningStore();
+        // parent is the only arm hit; neighbor is in NO arm but is link-reachable from parent.
+        var parent = Entry("parent", lastLexShare: null);
+        parent.Links.Add(new MemoryLink { TargetRepoId = "repo-a", TargetMemoryId = "neighbor", Relation = "supports" });
+        var neighbor = Entry("neighbor", lastLexShare: null);
+
+        store.SetArm(SearchArm.Lexical, ("parent", 7.0));
+        store.SetArm(SearchArm.Vector, ("parent", 7.0));
+        store.Seed(parent, neighbor);
+        var svc = new MemoryService(store);
+
+        var results = await svc.RecallAsync("repo-a", "q"); // ExpandGraph default on
+        Assert.Contains(results, r => r.Id == "neighbor");
+
+        await WaitUntilAsync(() => store.GetEntry("neighbor")!.LastLexShare is not null);
+        Assert.Equal(0.5, store.GetEntry("neighbor")!.LastLexShare!.Value, precision: 9);
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> condition, int timeoutMs = 2000)
+    {
+        var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+        while (!condition() && DateTime.UtcNow < deadline)
+            await Task.Delay(10);
+    }
+}
+
+/// <summary>
+/// Test double that faithfully models the SERVER-SIDE EWMA fold and the lexShare-stamping access patch.
+/// Scripted per-arm scores drive fusion (like <c>InMemoryScoredStore</c>); on top of that it keeps a
+/// per-repo alpha dict and applies the <see cref="AlphaEwmaUpdate"/> fold inside
+/// <see cref="UpdateRepoAlphaAsync"/> exactly as the real Raven patch would, and records lexShare onto
+/// the in-memory entry in <see cref="PatchAccessAsync"/> so the feedback loop is end-to-end testable.
+/// </summary>
+internal sealed class AlphaLearningStore : IEidetStore
+{
+    private readonly Dictionary<SearchArm, List<(string Id, double Score)>> _arms = new()
+    {
+        [SearchArm.Lexical] = [],
+        [SearchArm.Vector] = [],
+    };
+    private readonly Dictionary<string, MemoryEntry> _entries = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, double> _alpha = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>How many times the server-side fold was invoked — lets a test assert the no-op contract.</summary>
+    public int AlphaUpdateCalls { get; private set; }
+
+    public void SetArm(SearchArm arm, params (string Id, double Score)[] hits) => _arms[arm] = hits.ToList();
+
+    public void Seed(params MemoryEntry[] entries)
+    {
+        foreach (var e in entries) _entries[e.Id] = e;
+    }
+
+    public void SetAlpha(string repoId, double alpha) => _alpha[repoId] = alpha;
+
+    public MemoryEntry? GetEntry(string id) => _entries.GetValueOrDefault(id);
+
+    public Task<IReadOnlyList<ScoredHit>> SearchScoredAsync(
+        SearchArm arm, IReadOnlyList<string> repoIds, MemoryQuery query, CancellationToken ct = default)
+    {
+        var hits = _arms[arm]
+            .Where(h => _entries.ContainsKey(h.Id) && repoIds.Contains(_entries[h.Id].RepoId, StringComparer.OrdinalIgnoreCase))
+            .Select(h => new ScoredHit(_entries[h.Id], h.Score))
+            .ToList();
+        return Task.FromResult<IReadOnlyList<ScoredHit>>(hits);
+    }
+
+    public Task<MemoryEntry?> GetAsync(string id, CancellationToken ct = default) =>
+        Task.FromResult(_entries.GetValueOrDefault(id));
+
+    public Task<string> StoreAsync(MemoryEntry entry, CancellationToken ct = default)
+    {
+        _entries[entry.Id] = entry;
+        return Task.FromResult(entry.Id);
+    }
+
+    public Task UpdateAsync(MemoryEntry entry, CancellationToken ct = default)
+    {
+        _entries[entry.Id] = entry;
+        return Task.CompletedTask;
+    }
+
+    public Task<double?> GetRepoAlphaAsync(string repoId, CancellationToken ct = default) =>
+        Task.FromResult(_alpha.TryGetValue(repoId, out var a) ? a : (double?)null);
+
+    /// <summary>Applies the fold server-side from the stored value (or the supplied fallback when unlearned).</summary>
+    public Task UpdateRepoAlphaAsync(string repoId, AlphaEwmaUpdate u, CancellationToken ct = default)
+    {
+        AlphaUpdateCalls++;
+        var current = _alpha.TryGetValue(repoId, out var a) ? a : u.Fallback;
+        var next = Math.Clamp((1 - u.Lambda) * current + u.Lambda * u.Target, u.Min, u.Max);
+        _alpha[repoId] = next;
+        return Task.CompletedTask;
+    }
+
+    /// <summary>Records the surfacing lexShare (and access fields) onto the in-memory entry.</summary>
+    public Task PatchAccessAsync(string entryId, DateTime lastAccessedAt, double? lexShare = null, CancellationToken ct = default)
+    {
+        if (_entries.TryGetValue(entryId, out var e))
+        {
+            e.AccessCount++;
+            e.LastAccessedAt = lastAccessedAt;
+            if (lexShare is { } s) e.LastLexShare = s;
+        }
+        return Task.CompletedTask;
+    }
+
+    // ── Unused interface surface (recall/feedback never reach these here) ──
+    public Task<List<MemoryEntry>> FullTextSearchAsync(IReadOnlyList<string> repoIds, MemoryQuery query, CancellationToken ct = default) =>
+        Task.FromResult(new List<MemoryEntry>());
+    public Task<List<MemoryEntry>> VectorSearchAsync(IReadOnlyList<string> repoIds, MemoryQuery query, CancellationToken ct = default) =>
+        Task.FromResult(new List<MemoryEntry>());
+    public Task<bool> ForgetAsync(string id, CancellationToken ct = default) => Task.FromResult(false);
+    public Task<MemoryEntry?> FindDuplicateAsync(string repoId, string content, float threshold, CancellationToken ct = default) =>
+        Task.FromResult<MemoryEntry?>(null);
+    public Task<Dictionary<MemoryType, int>> GetCountsByTypeAsync(string repoId, CancellationToken ct = default) =>
+        Task.FromResult(new Dictionary<MemoryType, int>());
+    public Task<List<MemoryEntry>> GetTopScoredAsync(string repoId, MemoryType[] types, int limit, CancellationToken ct = default) =>
+        Task.FromResult(new List<MemoryEntry>());
+    public Task<bool> TestConnectionAsync(CancellationToken ct = default) => Task.FromResult(true);
+    public Task<DatabaseInfo?> GetDatabaseInfoAsync(CancellationToken ct = default) => Task.FromResult<DatabaseInfo?>(null);
+    public Task EnsureIndexesAsync(CancellationToken ct = default) => Task.CompletedTask;
+    public Task<List<string>> GetDistinctRepoIdsAsync(CancellationToken ct = default) =>
+        Task.FromResult(_entries.Values.Select(e => e.RepoId).Distinct().ToList());
+    public Task<List<MemoryEntry>> BrowseAsync(string repoId, int skip, int take, MemoryType? type = null, CancellationToken ct = default) =>
+        Task.FromResult(new List<MemoryEntry>());
+    public Task<string> StoreMountedLayerAsync(MemoryLayer layer, CancellationToken ct = default) => Task.FromResult(layer.Id);
+    public Task<bool> UnmountLayerAsync(string layerId, CancellationToken ct = default) => Task.FromResult(false);
+    public Task<List<MemoryLayer>> GetMountedLayersAsync(string repoId, CancellationToken ct = default) => Task.FromResult(new List<MemoryLayer>());
+    public Task<MemoryLayer?> GetLayerAsync(string layerId, CancellationToken ct = default) => Task.FromResult<MemoryLayer?>(null);
+    public Task<List<MemoryEntry>> GetByLayerIdAsync(string layerId, CancellationToken ct = default) => Task.FromResult(new List<MemoryEntry>());
+    public Task<bool> HardDeleteAsync(string id, CancellationToken ct = default) => Task.FromResult(_entries.Remove(id));
+}

--- a/tests/Eidet.Core.Tests/Memory/GraphExpansionTests.cs
+++ b/tests/Eidet.Core.Tests/Memory/GraphExpansionTests.cs
@@ -1,0 +1,420 @@
+using Eidet.Core.Domain;
+using Eidet.Core.Maintenance;
+using Eidet.Core.Memory;
+using Eidet.Core.Services;
+using Eidet.Core.Storage;
+
+namespace Eidet.Core.Tests.Memory;
+
+/// <summary>
+/// Tests for graph-neighbor expansion (issue #33 item 7). Two surfaces:
+///
+/// Section A — the pure <see cref="RecallScoring.ExpandNeighbors"/> spreading-activation math: a fused
+/// candidate's links pull off-pool neighbors into the pool via damped inheritance
+/// (<c>parentFused·decay + neighborOwn(ucb+recency)</c>), bounded to one hop and a max-neighbor cap,
+/// deduped, re-sorted.
+///
+/// Section B — the <see cref="MemoryService.ExpandNeighborsAsync"/> I/O wrapper through RecallAsync:
+/// a gold memory in NEITHER arm but linked from a top hit surfaces when ExpandGraph is on and is absent
+/// when off; the loaded entry's REAL RepoId (not the link's declared TargetRepoId) gates scope; and a
+/// failing/missing/non-latest neighbor load never fails recall.
+/// </summary>
+public class GraphExpansionTests
+{
+    private static readonly DateTime Now = new(2026, 6, 20, 0, 0, 0, DateTimeKind.Utc);
+
+    private static MemoryEntry Entry(
+        string id, string repoId = "repo-a", bool isLatest = true,
+        params (string repo, string target)[] links)
+    {
+        var e = new MemoryEntry
+        {
+            Id = id,
+            RepoId = repoId,
+            Type = MemoryType.Insight,
+            Content = id,
+            CreatedAt = Now,
+            Validity = new Validity { ValidFrom = Now },
+            IsLatest = isLatest,
+            Importance = 0.5f,
+        };
+        foreach (var (repo, target) in links)
+            e.Links.Add(new MemoryLink { TargetRepoId = repo, TargetMemoryId = target, Relation = "supports" });
+        return e;
+    }
+
+    private static FusedCandidate Candidate(MemoryEntry entry, double fused, double lex = 0, double vec = 0) =>
+        new(entry, lex, vec, Recency: 0, Ucb: 0, Fused: fused);
+
+    // ════════════════════════════════════════════════════════════════════════
+    // Section A — pure ExpandNeighbors math
+    // ════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// A1 — a parent linking an off-pool neighbor yields that neighbor with Fused ≈
+    /// parentFused·0.5 + neighbor(ucb+recency), Lex==0, Vec==0; output re-sorted descending.
+    /// </summary>
+    [Fact]
+    public void ExpandNeighbors_LinkedNeighbor_InheritsDampedParentScore()
+    {
+        var parent = Entry("parent", links: ("repo-a", "neighbor"));
+        var neighbor = Entry("neighbor");
+        var fused = new List<FusedCandidate> { Candidate(parent, fused: 0.8) };
+
+        var resolved = new Dictionary<string, MemoryEntry> { ["neighbor"] = neighbor };
+        var expanded = RecallScoring.ExpandNeighbors(
+            fused, id => resolved.GetValueOrDefault(id), RecallWeights.Default, Now);
+
+        var n = expanded.Single(c => c.Entry.Id == "neighbor");
+        Assert.Equal(0.0, n.Lex);
+        Assert.Equal(0.0, n.Vec);
+
+        // The neighbor's own recency+ucb computed the same way the helper does, plus the damped parent.
+        var ucb = 0.0; // TotalN=0 ⇒ ln(1)=0 ⇒ ucb term 0
+        var recency = FadeMemCurve.Recency(neighbor.CreatedAt, neighbor.LastAccessedAt, Now, neighbor.Type);
+        Assert.Equal(0.8 * 0.5 + ucb + recency, n.Fused, precision: 9);
+
+        // Output is re-sorted by fused descending (the neighbor's own fresh recency happens to lift it
+        // above the parent's bare 0.8 here — the contract under test is the ordering, not which id wins).
+        Assert.Equal(2, expanded.Count);
+        for (var i = 1; i < expanded.Count; i++)
+            Assert.True(expanded[i - 1].Fused >= expanded[i].Fused,
+                $"expanded must be sorted descending: [{i - 1}]={expanded[i - 1].Fused} < [{i}]={expanded[i].Fused}");
+    }
+
+    /// <summary>A2 — a link target already in the fused pool is NOT duplicated.</summary>
+    [Fact]
+    public void ExpandNeighbors_LinkTargetAlreadyInPool_NotDuplicated()
+    {
+        var parent = Entry("parent", links: ("repo-a", "alsoInPool"));
+        var alsoInPool = Entry("alsoInPool");
+        var fused = new List<FusedCandidate>
+        {
+            Candidate(parent, fused: 0.9),
+            Candidate(alsoInPool, fused: 0.4),
+        };
+
+        var resolved = new Dictionary<string, MemoryEntry> { ["alsoInPool"] = alsoInPool };
+        var expanded = RecallScoring.ExpandNeighbors(
+            fused, id => resolved.GetValueOrDefault(id), RecallWeights.Default, Now);
+
+        Assert.Equal(2, expanded.Count);
+        Assert.Single(expanded, c => c.Entry.Id == "alsoInPool");
+        // The pre-existing pool entry keeps its own fused score (not the damped-inherited one).
+        Assert.Equal(0.4, expanded.Single(c => c.Entry.Id == "alsoInPool").Fused, precision: 9);
+    }
+
+    /// <summary>A2b — two parents linking the SAME off-pool neighbor add it exactly once.</summary>
+    [Fact]
+    public void ExpandNeighbors_TwoParentsSameNeighbor_AddedOnce()
+    {
+        var p1 = Entry("p1", links: ("repo-a", "shared"));
+        var p2 = Entry("p2", links: ("repo-a", "shared"));
+        var shared = Entry("shared");
+        var fused = new List<FusedCandidate> { Candidate(p1, 0.9), Candidate(p2, 0.7) };
+
+        var resolved = new Dictionary<string, MemoryEntry> { ["shared"] = shared };
+        var expanded = RecallScoring.ExpandNeighbors(
+            fused, id => resolved.GetValueOrDefault(id), RecallWeights.Default, Now);
+
+        Assert.Single(expanded, c => c.Entry.Id == "shared");
+        // Inherits from the FIRST (strongest) parent it was reached through (0.9), not p2.
+        var recency = FadeMemCurve.Recency(shared.CreatedAt, shared.LastAccessedAt, Now, shared.Type);
+        Assert.Equal(0.9 * 0.5 + recency, expanded.Single(c => c.Entry.Id == "shared").Fused, precision: 9);
+    }
+
+    /// <summary>A3 — with more than 5 distinct linkable neighbors, at most 5 are added.</summary>
+    [Fact]
+    public void ExpandNeighbors_MoreThanCap_AddsAtMostFive()
+    {
+        var links = Enumerable.Range(0, 8).Select(i => ("repo-a", $"n{i}")).ToArray();
+        var parent = Entry("parent", links: links);
+        var fused = new List<FusedCandidate> { Candidate(parent, 0.9) };
+
+        var resolved = Enumerable.Range(0, 8).ToDictionary(i => $"n{i}", i => Entry($"n{i}"));
+        var expanded = RecallScoring.ExpandNeighbors(
+            fused, id => resolved.GetValueOrDefault(id), RecallWeights.Default, Now);
+
+        var added = expanded.Count(c => c.Entry.Id.StartsWith('n'));
+        Assert.Equal(5, added);
+        Assert.Equal(6, expanded.Count); // parent + 5
+    }
+
+    /// <summary>
+    /// A4 — one hop only: a neighbor's OWN links are never expanded, so a neighbor-of-neighbor
+    /// never appears even though it is resolvable.
+    /// </summary>
+    [Fact]
+    public void ExpandNeighbors_OneHopOnly_NeighborOfNeighborNeverAppears()
+    {
+        var parent = Entry("parent", links: ("repo-a", "neighbor"));
+        var neighbor = Entry("neighbor", links: ("repo-a", "grandchild"));
+        var grandchild = Entry("grandchild");
+        var fused = new List<FusedCandidate> { Candidate(parent, 0.9) };
+
+        // resolve can reach the grandchild too, but expansion must not follow the neighbor's link.
+        var resolved = new Dictionary<string, MemoryEntry>
+        {
+            ["neighbor"] = neighbor,
+            ["grandchild"] = grandchild,
+        };
+        var expanded = RecallScoring.ExpandNeighbors(
+            fused, id => resolved.GetValueOrDefault(id), RecallWeights.Default, Now);
+
+        Assert.Contains(expanded, c => c.Entry.Id == "neighbor");
+        Assert.DoesNotContain(expanded, c => c.Entry.Id == "grandchild");
+    }
+
+    /// <summary>
+    /// A5 — a link whose target the resolver can't produce (null) is silently skipped; the pool is
+    /// returned re-sorted and otherwise untouched.
+    /// </summary>
+    [Fact]
+    public void ExpandNeighbors_UnresolvableTarget_SkippedNoThrow()
+    {
+        var parent = Entry("parent", links: ("repo-a", "missing"));
+        var fused = new List<FusedCandidate> { Candidate(parent, 0.9) };
+
+        var expanded = RecallScoring.ExpandNeighbors(
+            fused, _ => null, RecallWeights.Default, Now);
+
+        Assert.Single(expanded);
+        Assert.Equal("parent", expanded[0].Entry.Id);
+    }
+
+    /// <summary>
+    /// A6 — only the top <c>parentTopK</c> candidates spread. A link hanging off a candidate ranked
+    /// below the cut is not followed.
+    /// </summary>
+    [Fact]
+    public void ExpandNeighbors_OnlyTopKParentsSpread()
+    {
+        var rich = Entry("rich", links: ("repo-a", "fromRich"));
+        var poor = Entry("poor", links: ("repo-a", "fromPoor"));
+        var fused = new List<FusedCandidate> { Candidate(rich, 0.9), Candidate(poor, 0.1) };
+
+        var resolved = new Dictionary<string, MemoryEntry>
+        {
+            ["fromRich"] = Entry("fromRich"),
+            ["fromPoor"] = Entry("fromPoor"),
+        };
+        // parentTopK = 1 ⇒ only the strongest parent (rich) spreads.
+        var expanded = RecallScoring.ExpandNeighbors(
+            fused, id => resolved.GetValueOrDefault(id), RecallWeights.Default, Now, parentTopK: 1);
+
+        Assert.Contains(expanded, c => c.Entry.Id == "fromRich");
+        Assert.DoesNotContain(expanded, c => c.Entry.Id == "fromPoor");
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // Section B — behavioral through MemoryService.RecallAsync
+    // ════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// B1 — a gold memory in NEITHER arm but linked from a top arm-hit SURFACES when ExpandGraph is on
+    /// (the default) and is ABSENT when ExpandGraph=false.
+    /// </summary>
+    [Fact]
+    public async Task RecallAsync_LinkedGold_SurfacesWithExpansion_AbsentWithout()
+    {
+        GraphStore Build()
+        {
+            var store = new GraphStore();
+            var parent = Entry("parent", links: ("repo-a", "gold"));
+            var gold = Entry("gold"); // in NO arm
+            store.SetArm(SearchArm.Lexical, ("parent", 7.0));
+            store.SetArm(SearchArm.Vector, ("parent", 7.0));
+            store.Seed(parent, gold);
+            return store;
+        }
+
+        var withExpansion = await new MemoryService(Build()).RecallAsync(
+            "repo-a", new RecallOptions("q")); // ExpandGraph default true
+        var withoutExpansion = await new MemoryService(Build()).RecallAsync(
+            "repo-a", new RecallOptions("q") { ExpandGraph = false });
+
+        Assert.Contains(withExpansion, r => r.Id == "gold");
+        Assert.DoesNotContain(withoutExpansion, r => r.Id == "gold");
+    }
+
+    /// <summary>
+    /// B2 — the SCOPE-LEAK fix. A parent links a neighbor whose declared TargetRepoId LOOKS in-scope
+    /// ("repo-a") but whose LOADED entry actually belongs to an out-of-scope repo ("repo-b"). The
+    /// authoritative re-check on the loaded entry's real RepoId must reject it.
+    /// </summary>
+    [Fact]
+    public async Task RecallAsync_NeighborRealRepoOutOfScope_NotAdmitted_DespiteInScopeLinkRepo()
+    {
+        var store = new GraphStore();
+        // Link DECLARES repo-a (in scope) ...
+        var parent = Entry("parent", links: ("repo-a", "leak"));
+        // ... but the resolved entry's REAL RepoId is repo-b (NOT searched by this recall).
+        var leak = Entry("leak", repoId: "repo-b");
+        store.SetArm(SearchArm.Lexical, ("parent", 7.0));
+        store.SetArm(SearchArm.Vector, ("parent", 7.0));
+        store.Seed(parent, leak);
+
+        var results = await new MemoryService(store).RecallAsync("repo-a", new RecallOptions("q"));
+
+        Assert.Contains(results, r => r.Id == "parent");
+        Assert.DoesNotContain(results, r => r.Id == "leak");
+    }
+
+    /// <summary>
+    /// B2b — the cheap pre-filter also rejects a link whose DECLARED TargetRepoId is out of scope, even
+    /// when the loaded entry would have been in scope. (Guards the pre-filter branch; the link names
+    /// repo-b so the neighbor is never even loaded.)
+    /// </summary>
+    [Fact]
+    public async Task RecallAsync_NeighborDeclaredRepoOutOfScope_NotAdmitted()
+    {
+        var store = new GraphStore();
+        var parent = Entry("parent", links: ("repo-b", "neighbor")); // declared out of scope
+        var neighbor = Entry("neighbor", repoId: "repo-a");          // would be in scope if reached
+        store.SetArm(SearchArm.Lexical, ("parent", 7.0));
+        store.SetArm(SearchArm.Vector, ("parent", 7.0));
+        store.Seed(parent, neighbor);
+
+        var results = await new MemoryService(store).RecallAsync("repo-a", new RecallOptions("q"));
+
+        Assert.DoesNotContain(results, r => r.Id == "neighbor");
+    }
+
+    /// <summary>
+    /// B3 — best-effort: a neighbor load that THROWS doesn't fail recall — the direct arm hits still return.
+    /// </summary>
+    [Fact]
+    public async Task RecallAsync_NeighborLoadThrows_DirectHitsStillReturn()
+    {
+        var store = new GraphStore { ThrowOnGet = "boom" };
+        var parent = Entry("parent", links: ("repo-a", "boom"));
+        store.SetArm(SearchArm.Lexical, ("parent", 7.0));
+        store.SetArm(SearchArm.Vector, ("parent", 7.0));
+        store.Seed(parent, Entry("boom"));
+
+        var results = await new MemoryService(store).RecallAsync("repo-a", new RecallOptions("q"));
+
+        Assert.Contains(results, r => r.Id == "parent");
+        Assert.DoesNotContain(results, r => r.Id == "boom");
+    }
+
+    /// <summary>
+    /// B3b — a neighbor that resolves to a NON-LATEST (superseded) entry is rejected; recall still
+    /// returns the direct hit.
+    /// </summary>
+    [Fact]
+    public async Task RecallAsync_NeighborNotLatest_NotAdmitted()
+    {
+        var store = new GraphStore();
+        var parent = Entry("parent", links: ("repo-a", "stale"));
+        var stale = Entry("stale", isLatest: false);
+        store.SetArm(SearchArm.Lexical, ("parent", 7.0));
+        store.SetArm(SearchArm.Vector, ("parent", 7.0));
+        store.Seed(parent, stale);
+
+        var results = await new MemoryService(store).RecallAsync("repo-a", new RecallOptions("q"));
+
+        Assert.Contains(results, r => r.Id == "parent");
+        Assert.DoesNotContain(results, r => r.Id == "stale");
+    }
+
+    /// <summary>
+    /// B3c — a neighbor whose GetAsync returns null (missing) is skipped; recall still returns the hit.
+    /// </summary>
+    [Fact]
+    public async Task RecallAsync_NeighborMissing_NotAdmitted()
+    {
+        var store = new GraphStore();
+        var parent = Entry("parent", links: ("repo-a", "ghost")); // ghost never seeded
+        store.SetArm(SearchArm.Lexical, ("parent", 7.0));
+        store.SetArm(SearchArm.Vector, ("parent", 7.0));
+        store.Seed(parent);
+
+        var results = await new MemoryService(store).RecallAsync("repo-a", new RecallOptions("q"));
+
+        Assert.Contains(results, r => r.Id == "parent");
+        Assert.DoesNotContain(results, r => r.Id == "ghost");
+    }
+}
+
+/// <summary>
+/// Scripted-arm store for the behavioral expansion tests. Like <c>InMemoryScoredStore</c> but with two
+/// extra knobs the wrapper needs exercised: <see cref="GetAsync"/> returns seeded entries (so neighbor
+/// loads resolve) filtered by no scope (the SERVICE enforces scope, which is exactly what B2 tests), and
+/// <see cref="ThrowOnGet"/> makes a specific neighbor load throw to prove best-effort recovery.
+/// </summary>
+internal sealed class GraphStore : IEidetStore
+{
+    private readonly Dictionary<SearchArm, List<(string Id, double Score)>> _arms = new()
+    {
+        [SearchArm.Lexical] = [],
+        [SearchArm.Vector] = [],
+    };
+    private readonly Dictionary<string, MemoryEntry> _entries = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Id whose GetAsync throws — models a transient backend failure during neighbor load.</summary>
+    public string? ThrowOnGet { get; init; }
+
+    public void SetArm(SearchArm arm, params (string Id, double Score)[] hits) => _arms[arm] = hits.ToList();
+
+    public void Seed(params MemoryEntry[] entries)
+    {
+        foreach (var e in entries) _entries[e.Id] = e;
+    }
+
+    public Task<IReadOnlyList<ScoredHit>> SearchScoredAsync(
+        SearchArm arm, IReadOnlyList<string> repoIds, MemoryQuery query, CancellationToken ct = default)
+    {
+        // Arm hits are scoped by the repos this recall searches — exactly like the real backend.
+        var hits = _arms[arm]
+            .Where(h => _entries.ContainsKey(h.Id) && repoIds.Contains(_entries[h.Id].RepoId, StringComparer.OrdinalIgnoreCase))
+            .Select(h => new ScoredHit(_entries[h.Id], h.Score))
+            .ToList();
+        return Task.FromResult<IReadOnlyList<ScoredHit>>(hits);
+    }
+
+    public Task<MemoryEntry?> GetAsync(string id, CancellationToken ct = default)
+    {
+        if (ThrowOnGet is not null && string.Equals(id, ThrowOnGet, StringComparison.OrdinalIgnoreCase))
+            throw new InvalidOperationException("simulated backend failure");
+        return Task.FromResult(_entries.GetValueOrDefault(id));
+    }
+
+    public Task<string> StoreAsync(MemoryEntry entry, CancellationToken ct = default)
+    {
+        _entries[entry.Id] = entry;
+        return Task.FromResult(entry.Id);
+    }
+
+    public Task UpdateAsync(MemoryEntry entry, CancellationToken ct = default)
+    {
+        _entries[entry.Id] = entry;
+        return Task.CompletedTask;
+    }
+
+    // ── Unused interface surface ──
+    public Task<List<MemoryEntry>> FullTextSearchAsync(IReadOnlyList<string> repoIds, MemoryQuery query, CancellationToken ct = default) =>
+        Task.FromResult(new List<MemoryEntry>());
+    public Task<List<MemoryEntry>> VectorSearchAsync(IReadOnlyList<string> repoIds, MemoryQuery query, CancellationToken ct = default) =>
+        Task.FromResult(new List<MemoryEntry>());
+    public Task<bool> ForgetAsync(string id, CancellationToken ct = default) => Task.FromResult(false);
+    public Task<MemoryEntry?> FindDuplicateAsync(string repoId, string content, float threshold, CancellationToken ct = default) =>
+        Task.FromResult<MemoryEntry?>(null);
+    public Task<Dictionary<MemoryType, int>> GetCountsByTypeAsync(string repoId, CancellationToken ct = default) =>
+        Task.FromResult(new Dictionary<MemoryType, int>());
+    public Task<List<MemoryEntry>> GetTopScoredAsync(string repoId, MemoryType[] types, int limit, CancellationToken ct = default) =>
+        Task.FromResult(new List<MemoryEntry>());
+    public Task<bool> TestConnectionAsync(CancellationToken ct = default) => Task.FromResult(true);
+    public Task<DatabaseInfo?> GetDatabaseInfoAsync(CancellationToken ct = default) => Task.FromResult<DatabaseInfo?>(null);
+    public Task EnsureIndexesAsync(CancellationToken ct = default) => Task.CompletedTask;
+    public Task<List<string>> GetDistinctRepoIdsAsync(CancellationToken ct = default) =>
+        Task.FromResult(_entries.Values.Select(e => e.RepoId).Distinct().ToList());
+    public Task<List<MemoryEntry>> BrowseAsync(string repoId, int skip, int take, MemoryType? type = null, CancellationToken ct = default) =>
+        Task.FromResult(new List<MemoryEntry>());
+    public Task<string> StoreMountedLayerAsync(MemoryLayer layer, CancellationToken ct = default) => Task.FromResult(layer.Id);
+    public Task<bool> UnmountLayerAsync(string layerId, CancellationToken ct = default) => Task.FromResult(false);
+    public Task<List<MemoryLayer>> GetMountedLayersAsync(string repoId, CancellationToken ct = default) => Task.FromResult(new List<MemoryLayer>());
+    public Task<MemoryLayer?> GetLayerAsync(string layerId, CancellationToken ct = default) => Task.FromResult<MemoryLayer?>(null);
+    public Task<List<MemoryEntry>> GetByLayerIdAsync(string layerId, CancellationToken ct = default) => Task.FromResult(new List<MemoryEntry>());
+    public Task<bool> HardDeleteAsync(string id, CancellationToken ct = default) => Task.FromResult(_entries.Remove(id));
+}

--- a/tests/Eidet.Core.Tests/Portal/PortalRendererTests.cs
+++ b/tests/Eidet.Core.Tests/Portal/PortalRendererTests.cs
@@ -188,7 +188,7 @@ public class PortalRendererTests
         public Task<string> StoreAsync(MemoryEntry entry, CancellationToken ct = default) => Task.FromResult(entry.Id);
         public Task UpdateAsync(MemoryEntry entry, CancellationToken ct = default) => Task.CompletedTask;
         public Task<bool> ForgetAsync(string id, CancellationToken ct = default) => Task.FromResult(false);
-        public Task PatchAccessAsync(string entryId, DateTime lastAccessedAt, CancellationToken ct = default) => Task.CompletedTask;
+        public Task PatchAccessAsync(string entryId, DateTime lastAccessedAt, double? lexShare = null, CancellationToken ct = default) => Task.CompletedTask;
         public Task<List<MemoryEntry>> FullTextSearchAsync(IReadOnlyList<string> repoIds, MemoryQuery query, CancellationToken ct = default) => Task.FromResult(new List<MemoryEntry>());
         public Task<List<MemoryEntry>> VectorSearchAsync(IReadOnlyList<string> repoIds, MemoryQuery query, CancellationToken ct = default) => Task.FromResult(new List<MemoryEntry>());
         public Task<MemoryEntry?> FindDuplicateAsync(string repoId, string content, float threshold, CancellationToken ct = default) => Task.FromResult<MemoryEntry?>(null);


### PR DESCRIPTION
Completes **recall pipeline v2** (issue #33 items 6 & 7). The spine — items 1–5 (scored-search port, `RecallScoring.Fuse`, UCB, dual-clock recency, `ExplainRecallAsync` + oracle test) — shipped earlier; this PR closes the issue.

Built through the 4-agent pipeline (implement → test → review ∥ verify → synthesize); review/verify findings applied before commit.

## Item 6 — per-repo alpha-learning (EWMA)
- `RepoUsage.AlphaLex` is EWMA-tuned from each echo/fizzle — feedback is a free lexical-vs-vector relevance label.
- Per-memory arm attribution persisted on `MemoryEntry.LastLexShare`, stamped via the recall access-patch and read at feedback.
- The EWMA fold is computed **server-side** inside `UpdateRepoAlphaAsync` (`clamp((1-λ)·(stored ?? 0.5) + λ·target)`, λ=0.1) so concurrent feedback can't lose a step.
- Alpha is read once per recall and folded into the cache key (bucketed to 0.1) so tuning shifts invalidate cleanly. `RecallOptions.AlphaOverride` bypasses learning.
- **Safety:** the `[0.15, 0.85]` clamp keeps the blend from ever collapsing to a single arm — the compensating control for shipping alpha-learning alongside UCB ahead of the spec's real-repo oracle gate (sequencing step 3, intentionally bypassed with maintainer sign-off).

## Item 7 — graph-neighbor expansion
- Private `ExpandNeighborsAsync` runs between fuse and budget, pulling `eidet_link` neighbors of the top-K fused candidates (1 hop, cap 5) into the pool.
- Neighbors compete via **damped inheritance** (`parentFused·0.5 + own UCB+recency`) and flow through trust gating, de-boost, and type budgets like direct hits. Default-on; opt out via `RecallOptions.ExpandGraph`.
- The loaded entry's real `RepoId` is re-validated against scope (the link's declared `TargetRepoId` is untrusted).
- Fusion + expansion math lives in pure `RecallScoring` helpers (one home, shared with the benchmark).

## Benchmark
- `BenchmarkRunner` now models expansion — a no-op when a case declares no neighbors, so the existing 12 cases stay **byte-identical**.
- 2 new cases prove link-only gold is rescued by expansion and missed by the flat baseline.
- Scorecard regenerated (`docs/benchmark.md`); all invariants hold: fused beats baseline on every metric, clears conservative floors, recall < 1.0, deterministic. (Recall MRR dips 0.889→0.833 — rescued neighbors rank #2/#3 by design — still well above the 0.80 floor.)

## Tests
27 new (`AlphaLearningTests` 15, `GraphExpansionTests` 12): EWMA direction/clamp/fallback/end-to-end loop; expansion dedup/cap/1-hop/scope-revalidation/opt-out. **Core 599/0, Service 208/0, build 0 warnings.**

Closes #33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01LejT5wHAhq2pKSaYA4hZdf