### PR TITLE
feat(memory): Procedure/Heuristic ROI tracking + auto-demote (#35)

### DIFF
--- a/STRIDE.md
+++ b/STRIDE.md
@@ -1,6 +1,6 @@
 # Eidet - STRIDE Threat Model
 
-**Version:** 1.1
+**Version:** 1.2
 **Created:** 2026-04-12
 **Author:** Steve Hansen
 **Next Review:** 2027-04-12
@@ -115,11 +115,13 @@ Eidet is a local-first long-term memory service for AI coding agents. It provide
 | T-6 | Memory content manipulation via API | Authenticated attacker stores misleading memories to poison agent knowledge | 2 | 2 | 4 | Write gate blocks secrets and low-signal content. Scope model limits write access. Quality dashboard detects anomalies. |
 | T-7 | Single-shot memory poisoning via pack import | Attacker crafts one Pack/Intake memory — especially a Procedure or Heuristic — that an agent recalls and acts on without it ever being echoed (MemoryGraft, trigger-free, single-shot — arXiv:2512.16962) | 2 | 4 | **8** | **Provenance/trust tier** (`MemoryTrust`) — derived, never-stored trust factor gates retrieval weight. Pack/Intake float at 0.5, Procedure/Heuristic at 0.7 (floors combine as `min`); only earned echoes lift a memory toward 1.0. A freshly-injected, never-echoed pack Procedure is held at 0.5 in recall scoring, below trusted first-party memories. Import hardening: a pack's self-declared `provenance=` cannot escalate trust above the Pack floor — `MarkdownPackFormat` clamps any trust-raising declaration back to `Pack`, so an attacker controlling the pack bytes cannot self-assign first-party trust. |
 | T-8 | Provenance laundering via consolidation | Attacker injects a poisoned Pack/Intake observation, then relies on consolidation to fold it into a high-trust Insight (`Provenance=Consolidation`), erasing the low-trust origin (compression-amplified toxin) | 2 | 3 | 6 | **Consolidation carry-through** — a new insight derived from any untrusted source inherits the *least-trusted* contributor's provenance (not `Consolidation`), so the trust tier keeps demoting it. The boost path admits only trusted sources: untrusted matches can neither raise a trusted insight's importance nor contaminate its lineage. |
+| T-9 | Feedback-driven memory suppression | Caller with feedback access (or any localhost caller when auth is off) repeatedly fizzles a *legitimate* Procedure/Heuristic — preferentially with `reason=incorrect`/`version_drift`, which triggers the steeper content-invalidating penalty (Importance −0.2 / Confidence −0.3 per fizzle) — to drive the ROI gate's recall de-boost and `RoiDecay` Importance demotion, suppressing a useful memory below recall threshold (the downward dual of T-7's poison-upward) | 2 | 2 | 4 | **Reversible by design** — `MemoryRoi` is derived (never stored), never forgets, and never mutates content; Importance floors at 0.05 (never zero) and `RoiDecay` only engages after `MinFeedback=3`, so suppression is gradual, not single-shot. A single echo back to parity restores full ROI and the next maintenance pass leaves the memory alone. Requires the same write/feedback trust boundary as T-6; append-only echo/fizzle counts feed the quality dashboard's high-fizzle check. |
 
 **Countermeasures in place:**
 - Write gate with SecretScanner (13 patterns) and SignalGate (WriteGate.cs)
 - Pack imports isolated to read-only layers with de-boost scoring
 - Provenance/trust tier (`MemoryTrust`, MemoryTrust.cs) — derived per-recall trust factor gating retrieval weight; deterministic, local, always-on; no stored field to forge
+- Realized-benefit ROI gate (`MemoryRoi`, MemoryRoi.cs) — reversible, derived recall de-boost + `RoiDecay` Importance demotion for proven net-negative action memories; never forgets, content untouched, recoverable by a single echo (bounds T-9)
 - Consolidation provenance carry-through (ConsolidationEngine.cs) — prevents laundering a poisoned source into a trusted insight
 - Backup SHA256 checksum verification
 - API key scopes restrict write access
@@ -200,7 +202,7 @@ Objectives: **Confidentiality** (who may read it), **Integrity** (it is not tamp
 |-------|-----------------|-----------|--------------|------------|
 | **Ingest** | SecretScanner blocks credential storage; API scopes gate writes | SignalGate rejects low-signal content; strongly-typed deserialization | — | `MemoryProvenance` stamped on every write; pack/intake tagged at the import surface |
 | **Store** | OS file permissions on RavenDB data dir; localhost-only binding | Append-only model with validity intervals | Maintenance TTL + retention; backups | Provenance + `Source` + `DerivedFrom` persisted; never mutated in place |
-| **Retrieve** | API key scopes on read endpoints | Non-local de-boost (0.8×) on mounted layers | Hybrid lexical+vector recall; type budgets | **Trust tier (`MemoryTrust`) gates retrieval weight** — pack/intake & procedure/heuristic held provisional until echoed |
+| **Retrieve** | API key scopes on read endpoints | Non-local de-boost (0.8×) on mounted layers; reversible ROI de-boost of proven net-negative action memories *(T-9)* | Hybrid lexical+vector recall; type budgets | **Trust tier (`MemoryTrust`) gates retrieval weight** — pack/intake & procedure/heuristic held provisional until echoed |
 | **Consolidate** | Runs in-process, no new exposure | Dedup + supersession chains | Importance boost keeps salient insights alive | **Provenance carry-through** — untrusted sources cannot launder into a trusted insight; boost admits trusted sources only |
 | **Forget** | Soft-delete hides content from recall | Forget audit observation with reason + `DerivedFrom` | Soft-delete preserves history (recoverable) | Audit trail records who/why; version chain via `eidet_history` |
 | **Share** | Packs are read-only layers; no auto-share | No pack signature verification *(residual — T-1)* | Pack export/import portability | Provenance survives export (markdown frontmatter); imported packs stay provisional via trust tier |
@@ -256,6 +258,7 @@ Known gaps (tracked above): no pack signature verification (T-1, T-7 attack surf
 |---------|------|--------|---------|
 | 1.0 | 2026-04-12 | Steve Hansen | Initial STRIDE analysis covering all 10 implementation phases |
 | 1.1 | 2026-06-22 | Steve Hansen | Added provenance/trust tier (T-7 single-shot poisoning, T-8 consolidation laundering) and the 6-phase × 4-objective memory-lifecycle security taxonomy (§2.7) |
+| 1.2 | 2026-06-24 | Steve Hansen | Added T-9 feedback-driven memory suppression (downward dual of T-7) for the #35 ROI gate + tiered fizzle penalty; reversibility bounds it |
 
 ---
 

--- a/UBIQUITOUS_LANGUAGE.md
+++ b/UBIQUITOUS_LANGUAGE.md
@@ -55,6 +55,8 @@ Every **Memory** has exactly one of the following types. Each type has its own r
 | **Echo**         | Positive feedback: a recalled **Memory** was useful; boosts future **Recall** score                  | Upvote, thumbs-up                      |
 | **Fizzle**       | Negative feedback: a recalled **Memory** was irrelevant; dampens future **Recall** score             | Downvote, reject                       |
 | **FadeMem**      | The decay model that reduces a **Memory**'s influence over time unless reinforced by **Echoes**      | Decay, aging                           |
+| **ROI**          | Realized net benefit of an action-shaped **Memory** (**Procedure**/**Heuristic**), derived from **Echoes** minus **Fizzles**; net-negative **ROI** demotes the **Memory** at **Recall** and via **FadeMem**. Reversible; distinct from **Forget** (no soft-delete) | Value, payoff, utility |
+| **Fizzle reason** | Optional taxonomy on a **Fizzle** (WrongContext / Incorrect / VersionDrift / Other); content-invalidating reasons (VersionDrift, Incorrect) penalize harder | Fizzle category, downvote reason |
 | **Access count** | Number of times a **Memory** has been surfaced by **Recall**                                         | Views, hits                            |
 
 ## Write path

--- a/sdk/dotnet/Eidet.Sdk/EidetClient.cs
+++ b/sdk/dotnet/Eidet.Sdk/EidetClient.cs
@@ -60,10 +60,10 @@ public sealed class EidetClient : IDisposable
         return data.Forgotten;
     }
 
-    public async Task<bool> FeedbackAsync(string memoryId, bool wasUsed, CancellationToken ct = default)
+    public async Task<bool> FeedbackAsync(string memoryId, bool wasUsed, string? reason = null, CancellationToken ct = default)
     {
         var res = await _http.PostAsJsonAsync("api/eidet/feedback",
-            new { memoryId, wasUsed }, JsonOptions, ct);
+            new { memoryId, wasUsed, reason }, JsonOptions, ct);
         var data = await ReadAsync<FeedbackResponse>(res, ct);
         return data.Applied;
     }

--- a/src/Eidet.Core/Domain/FizzleReason.cs
+++ b/src/Eidet.Core/Domain/FizzleReason.cs
@@ -1,0 +1,25 @@
+namespace Eidet.Core.Domain;
+
+/// <summary>
+/// Optional taxonomy on a Fizzle. Content-invalidating reasons (VersionDrift, Incorrect) signal the
+/// memory's substance is wrong — not merely mis-recalled — and so penalize harder than a plain fizzle.
+/// Plain enum (no converter), matching <see cref="MemoryType"/>: RavenDB persists it as a stable
+/// string by default, and System.Text.Json callers serialize it via their JsonStringEnumConverter.
+/// </summary>
+public enum FizzleReason
+{
+    WrongContext,
+    Incorrect,
+    VersionDrift,
+    Other,
+}
+
+/// <summary>Policy home for the fizzle-penalty tier — one place to ask "does this reason invalidate
+/// the memory's content?" so the steeper penalty stays in sync across the recall and feedback paths.</summary>
+public static class FizzleReasons
+{
+    /// <summary>VersionDrift/Incorrect mean the content itself is wrong (framework/version drift, a
+    /// factual error) — the first-class lever for the steeper content-invalidating penalty tier.</summary>
+    public static bool IsContentInvalidating(FizzleReason? r) =>
+        r is FizzleReason.VersionDrift or FizzleReason.Incorrect;
+}

--- a/src/Eidet.Core/Domain/MemoryEntry.cs
+++ b/src/Eidet.Core/Domain/MemoryEntry.cs
@@ -59,6 +59,11 @@ public class MemoryEntry
     public int EchoCount { get; set; }
     public int FizzleCount { get; set; }
 
+    /// Most-recent fizzle's reason; null = never fizzled with a reason. Drives the steeper
+    /// content-invalidating penalty tier at fizzle time. A later echo intentionally leaves this
+    /// untouched — it records the last <i>fizzle's</i> reason, not the last feedback event.
+    public FizzleReason? LastFizzleReason { get; set; }
+
     // Enrichment
     public string? ForesightHint { get; set; }
 

--- a/src/Eidet.Core/Domain/MemoryQuery.cs
+++ b/src/Eidet.Core/Domain/MemoryQuery.cs
@@ -28,6 +28,7 @@ public class MemorySearchResult
     public DateTime CreatedAt { get; set; }
     public float Score { get; set; }
     public float TrustFactor { get; set; } = 1.0f;
+    public float RoiFactor { get; set; } = 1.0f;
     public string? LayerSource { get; set; }
     public int AgeDays { get; set; }
     public string? StalenessWarning { get; set; }

--- a/src/Eidet.Core/Maintenance/MaintenanceOrchestrator.cs
+++ b/src/Eidet.Core/Maintenance/MaintenanceOrchestrator.cs
@@ -40,6 +40,7 @@ public sealed class MaintenanceOrchestrator : IMaintenanceRunner
         new ObservationRetentionStage(),
         new DedupSweepStage(),
         new ImportanceDecayStage(),
+        new RoiDecayStage(),
         new OrphanCleanupStage(),
         new EnrichmentCleanupStage(),
         new HeuristicEnrichmentBackfillStage(),

--- a/src/Eidet.Core/Maintenance/MaintenanceReport.cs
+++ b/src/Eidet.Core/Maintenance/MaintenanceReport.cs
@@ -1,7 +1,7 @@
 namespace Eidet.Core.Maintenance;
 
 /// <summary>
-/// The 10 maintenance stages, in pipeline order. Each value's name equals the matching
+/// The 11 maintenance stages, in pipeline order. Each value's name equals the matching
 /// stage's <c>StageName</c> const; the orchestrator maps enum ⇄ name at the selection boundary.
 /// </summary>
 public enum MaintenanceStep
@@ -10,6 +10,7 @@ public enum MaintenanceStep
     ObservationRetention,
     DedupSweep,
     ImportanceDecay,
+    RoiDecay,
     OrphanCleanup,
     EnrichmentCleanup,
     HeuristicEnrichmentBackfill,

--- a/src/Eidet.Core/Maintenance/Stages/RoiDecayStage.cs
+++ b/src/Eidet.Core/Maintenance/Stages/RoiDecayStage.cs
@@ -1,0 +1,55 @@
+using Eidet.Core.Domain;
+using Eidet.Core.Memory;
+
+namespace Eidet.Core.Maintenance.Stages;
+
+/// <summary>
+/// Reversible, Importance-only demotion of proven net-negative action memories — the FadeMem
+/// auto-demote of issue #35. For Procedure/Heuristic that have earned enough feedback and run
+/// net-negative (fizzles &gt; echoes), it scales Importance by <see cref="MemoryRoi.Factor"/>
+/// (the single source of the penalty). It never forgets and never touches content, so one echo
+/// back to parity restores full ROI and the next pass leaves the memory alone.
+///
+/// Ordered after ImportanceDecay and before Consolidation so a demoted procedure doesn't seed an
+/// insight. The two Importance stages compose <i>across</i> nightly runs, not within one: this stage
+/// re-reads candidates from the (eventually-consistent) search index, so within a single run it may
+/// load the pre-ImportanceDecay Importance and its write supersedes that run's age-decay for the same
+/// entry. Both writes are monotonic-downward and converge to the floor, so the ordering is safe.
+/// </summary>
+internal sealed class RoiDecayStage : IMaintenanceStage
+{
+    public const string StageName = "RoiDecay";
+    public string Name => StageName;
+
+    /// <summary>Minimum echo+fizzle evidence before a memory is eligible — keeps demotion conservative.</summary>
+    private const int MinFeedback = 3;
+
+    public async Task<StageOutcome> ExecuteAsync(MaintenanceContext ctx, CancellationToken ct)
+    {
+        if (!ctx.IsRepoActive) return new StageOutcome(Name, 0);
+
+        var demoted = 0;
+        foreach (var type in new[] { MemoryType.Procedure, MemoryType.Heuristic })
+        {
+            var entries = await ctx.Store.GetTopScoredAsync(ctx.RepoId, [type], 500, ct);
+            foreach (var entry in entries)
+            {
+                if (!(entry.IsLatest && entry.LayerId == null && entry.Validity.IsValidAt(ctx.Now)))
+                    continue;
+                if (entry.EchoCount + entry.FizzleCount < MinFeedback) continue;
+                if (entry.FizzleCount <= entry.EchoCount) continue; // not net-negative — leave it
+
+                var roi = MemoryRoi.Factor(entry);
+                var target = Math.Max(FadeMemCurve.Floor, (float)(entry.Importance * roi));
+                if (Math.Abs(target - entry.Importance) / Math.Max(entry.Importance, 0.01f) < 0.01f)
+                    continue;
+
+                entry.Importance = target;
+                await ctx.Write.WriteAsync(entry, ct);
+                demoted++;
+            }
+        }
+
+        return new StageOutcome(Name, demoted);
+    }
+}

--- a/src/Eidet.Core/Memory/MemoryRoi.cs
+++ b/src/Eidet.Core/Memory/MemoryRoi.cs
@@ -1,0 +1,36 @@
+using Eidet.Core.Domain;
+
+namespace Eidet.Core.Memory;
+
+/// <summary>
+/// Derived, never-stored ROI factor — the realized-benefit demotion gate, ORTHOGONAL to
+/// <see cref="MemoryTrust"/>. Trust is the anti-poisoning FLOOR (provenance/type) and never drops
+/// below its floor; ROI expresses PERFORMANCE and can push a proven net-negative action memory
+/// BELOW that trust floor. The two compose multiplicatively at recall.
+///
+/// Like trust, ROI is recomputed on every recall from the live echo/fizzle counts — there is no
+/// stored ROI field to forge or let drift. It only penalizes the action-shaped types
+/// (Procedure/Heuristic), and only once they have proven net-negative (fizzles &gt; echoes); the
+/// positive side is already handled by UCB and trust's echo-lift. Non-action types always return 1.0.
+/// </summary>
+public static class MemoryRoi
+{
+    /// <summary>Smoothing constant — softens thin evidence so a single fizzle is not decisive
+    /// (same rationale as <c>MemoryTrust.EchoSmoothing</c>). Reversible: one echo to parity restores 1.0.</summary>
+    private const double EchoSmoothing = 3.0;
+
+    /// <summary>
+    /// ROI factor in (0, 1.0]. Returns 1.0 (no penalty) except for net-negative Procedure/Heuristic
+    /// memories (<c>FizzleCount &gt; EchoCount</c>), where it is <c>(echo + K)/(fizzle + K)</c> with
+    /// <c>K = 3.0</c>: 0e/1f → 0.75, 0e/3f → 0.5, 0e/5f → 0.375. The smoothing IS the conservatism —
+    /// there is no separate min-evidence gate, because the recall de-boost is ephemeral and per-query.
+    /// </summary>
+    public static double Factor(MemoryEntry entry)
+    {
+        if (entry.Type is not (MemoryType.Procedure or MemoryType.Heuristic))
+            return 1.0;
+        if (entry.FizzleCount <= entry.EchoCount)
+            return 1.0;
+        return (entry.EchoCount + EchoSmoothing) / (entry.FizzleCount + EchoSmoothing);
+    }
+}

--- a/src/Eidet.Core/Services/MemoryService.cs
+++ b/src/Eidet.Core/Services/MemoryService.cs
@@ -176,10 +176,12 @@ public sealed class MemoryService
         return outcome;
     }
 
-    public Task<bool> ApplyFeedbackAsync(string memoryId, bool wasUsed, CancellationToken ct = default) =>
-        FeedbackAsync(memoryId, wasUsed, ct);
+    public Task<bool> ApplyFeedbackAsync(string memoryId, bool wasUsed, FizzleReason? reason = null, CancellationToken ct = default) =>
+        FeedbackAsync(memoryId, wasUsed, reason, ct);
 
-    public async Task<bool> FeedbackAsync(string memoryId, bool wasUsed, CancellationToken ct = default)
+    // A fizzle optionally carries a reason: content-invalidating reasons (VersionDrift/Incorrect) cut
+    // importance and confidence harder, since the memory's substance — not just its recall context — is wrong.
+    public async Task<bool> FeedbackAsync(string memoryId, bool wasUsed, FizzleReason? reason = null, CancellationToken ct = default)
     {
         var entry = await _store.GetAsync(memoryId, ct);
         if (entry is null) return false;
@@ -193,8 +195,17 @@ public sealed class MemoryService
         else
         {
             entry.FizzleCount++;
-            entry.Importance = Math.Max(0.05f, entry.Importance - 0.1f);
-            entry.Confidence = Math.Max(0.0f, entry.Confidence - 0.15f);
+            entry.LastFizzleReason = reason;
+            if (FizzleReasons.IsContentInvalidating(reason))
+            {
+                entry.Importance = Math.Max(0.05f, entry.Importance - 0.2f);
+                entry.Confidence = Math.Max(0.0f, entry.Confidence - 0.3f);
+            }
+            else
+            {
+                entry.Importance = Math.Max(0.05f, entry.Importance - 0.1f);
+                entry.Confidence = Math.Max(0.0f, entry.Confidence - 0.15f);
+            }
         }
         entry.LastAccessedAt = DateTime.UtcNow;
         entry.AccessCount++;
@@ -425,12 +436,16 @@ public sealed class MemoryService
         {
             var entry = candidate.Entry;
             var trust = MemoryTrust.Factor(entry);
-            var score = candidate.Fused * trust;
+            // ROI demotes proven net-negative Procedure/Heuristic memories below the trust floor —
+            // it's a performance gate orthogonal to trust's anti-poisoning floor (1.0 otherwise).
+            var roi = MemoryRoi.Factor(entry);
+            var score = candidate.Fused * trust * roi;
             if (!scope.IsLocalRepo(entry.RepoId))
                 score *= LayerScope.NonLocalDeBoost;
 
             var result = RecallScoring.ToSearchResult(entry, (float)score);
             result.TrustFactor = (float)trust;
+            result.RoiFactor = (float)roi;
             result.AgeDays = (int)(now - result.CreatedAt).TotalDays;
             if (result.Drift is { Verdict: DriftVerdictKind.Stale or DriftVerdictKind.Contradicted } drift)
                 result.StalenessWarning = $"[drift: {drift.Reason ?? drift.Verdict.ToString().ToLowerInvariant()}]";
@@ -641,9 +656,14 @@ public sealed class MemoryService
             .ToList();
 
         const int maxItems = 20;
-        var insightBudget = (int)Math.Ceiling(maxItems * 0.50);
-        var procedureBudget = (int)Math.Ceiling(maxItems * 0.30);
-        var heuristicBudget = maxItems - insightBudget - procedureBudget;
+        const int procedureWakeupCap = 3; // hard cap (SWE-Skills-Bench: a wrongly-recalled procedure is net-negative; bound procedure pollution in the wake-up regardless of the soft type budget)
+        var uncappedProcedureBudget = (int)Math.Ceiling(maxItems * 0.30);
+        var procedureBudget = Math.Min(uncappedProcedureBudget, procedureWakeupCap);
+        // The slots the cap frees from procedures backfill insights — fully trusted (floor 1.0) — rather
+        // than inflating heuristics, which are action-shaped and net-negative-if-wrong just like procedures.
+        // Heuristics keep their own uncapped share; total wake-up item count is unchanged (maxItems).
+        var heuristicBudget = maxItems - (int)Math.Ceiling(maxItems * 0.50) - uncappedProcedureBudget;
+        var insightBudget = maxItems - procedureBudget - heuristicBudget;
 
         var insightCount = 0;
         var procedureCount = 0;

--- a/src/Eidet.Core/Services/MemoryService.cs
+++ b/src/Eidet.Core/Services/MemoryService.cs
@@ -657,12 +657,13 @@ public sealed class MemoryService
 
         const int maxItems = 20;
         const int procedureWakeupCap = 3; // hard cap (SWE-Skills-Bench: a wrongly-recalled procedure is net-negative; bound procedure pollution in the wake-up regardless of the soft type budget)
+        var uncappedInsightBudget = (int)Math.Ceiling(maxItems * 0.50);
         var uncappedProcedureBudget = (int)Math.Ceiling(maxItems * 0.30);
+        var heuristicBudget = maxItems - uncappedInsightBudget - uncappedProcedureBudget;
         var procedureBudget = Math.Min(uncappedProcedureBudget, procedureWakeupCap);
         // The slots the cap frees from procedures backfill insights — fully trusted (floor 1.0) — rather
         // than inflating heuristics, which are action-shaped and net-negative-if-wrong just like procedures.
         // Heuristics keep their own uncapped share; total wake-up item count is unchanged (maxItems).
-        var heuristicBudget = maxItems - (int)Math.Ceiling(maxItems * 0.50) - uncappedProcedureBudget;
         var insightBudget = maxItems - procedureBudget - heuristicBudget;
 
         var insightCount = 0;

--- a/src/Eidet.Service/Api/ApiRequests.cs
+++ b/src/Eidet.Service/Api/ApiRequests.cs
@@ -18,6 +18,7 @@ public record FeedbackRequest
 {
     public string MemoryId { get; init; } = "";
     public bool WasUsed { get; init; }
+    public string? Reason { get; init; }
 }
 
 public record PackExportRequest

--- a/src/Eidet.Service/Api/Endpoints/MemoryWriteEndpoints.cs
+++ b/src/Eidet.Service/Api/Endpoints/MemoryWriteEndpoints.cs
@@ -72,6 +72,7 @@ internal sealed class MemoryWriteEndpoints
         {
             id = req.MemoryId,
             used = req.WasUsed,
+            reason = req.Reason,
         }, HttpJson.Options);
 
         var repo = ExtractRepoFromMemoryId(req.MemoryId) ?? "";

--- a/src/Eidet.Service/Tools/Handlers/FeedbackToolHandler.cs
+++ b/src/Eidet.Service/Tools/Handlers/FeedbackToolHandler.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Nodes;
+using Eidet.Core.Domain;
 using Eidet.Core.Services;
 using Eidet.Service.Mcp;
 
@@ -27,8 +28,10 @@ public sealed class FeedbackToolHandler : IToolHandler
     {
         var id = ToolArgs.RequireString(request.Arguments, "id");
         var used = ToolArgs.RequireBool(request.Arguments, "used");
+        // A fizzle reason only carries meaning on a fizzle; ignore it on an echo.
+        var reason = used ? null : ParseReason(ToolArgs.GetString(request.Arguments, "reason"));
 
-        var ok = await _svc.ApplyFeedbackAsync(id, used, request.Ct);
+        var ok = await _svc.ApplyFeedbackAsync(id, used, reason, request.Ct);
         if (!ok)
             return ToolResult.NotFound($"Memory not found: {id}");
 
@@ -54,7 +57,23 @@ public sealed class FeedbackToolHandler : IToolHandler
                 ["type"] = "boolean",
                 ["description"] = "true = echo (memory was useful), false = fizzle (memory was irrelevant).",
             },
+            ["reason"] = new JsonObject
+            {
+                ["type"] = "string",
+                ["description"] = "optional fizzle reason: wrong_context | incorrect | version_drift | other — version_drift/incorrect demote harder.",
+            },
         },
         ["required"] = new JsonArray { "id", "used" },
+    };
+
+    /// <summary>Maps the snake_case wire reason to <see cref="FizzleReason"/>; null stays null,
+    /// any unrecognized non-null value falls back to <see cref="FizzleReason.Other"/>.</summary>
+    private static FizzleReason? ParseReason(string? raw) => raw?.Trim().ToLowerInvariant() switch
+    {
+        null or "" => null,
+        "wrong_context" => FizzleReason.WrongContext,
+        "incorrect" => FizzleReason.Incorrect,
+        "version_drift" => FizzleReason.VersionDrift,
+        _ => FizzleReason.Other,
     };
 }

--- a/tests/Eidet.Core.Tests/Maintenance/MaintenanceOrchestratorTests.cs
+++ b/tests/Eidet.Core.Tests/Maintenance/MaintenanceOrchestratorTests.cs
@@ -140,7 +140,7 @@ public class MaintenanceOrchestratorTests
         var stageNames = MaintenanceOrchestrator.DefaultStages().Select(s => s.Name).ToHashSet();
         var enumNames = Enum.GetNames<MaintenanceStep>().ToHashSet();
 
-        Assert.Equal(10, stageNames.Count);
+        Assert.Equal(11, stageNames.Count);
         Assert.Equal(enumNames, stageNames);
     }
 

--- a/tests/Eidet.Core.Tests/Maintenance/RoiDecayStageTests.cs
+++ b/tests/Eidet.Core.Tests/Maintenance/RoiDecayStageTests.cs
@@ -1,0 +1,281 @@
+using Eidet.Core.Domain;
+using Eidet.Core.Enrichment;
+using Eidet.Core.Maintenance;
+using Eidet.Core.Maintenance.Stages;
+using Eidet.Core.Memory;
+using Eidet.Core.Services;
+using Eidet.Core.Tests.Services;
+
+namespace Eidet.Core.Tests.Maintenance;
+
+/// <summary>
+/// Per-stage isolation tests for <see cref="RoiDecayStage"/> (issue #35) — the reversible,
+/// Importance-only auto-demote of proven net-negative action memories. Driven directly via
+/// <see cref="MaintenanceContext.ForTest"/> inside a real bulk-write scope (mirroring
+/// <see cref="MaintenanceStageIsolationTests"/>). Eligibility: Procedure/Heuristic that are
+/// IsLatest + unlayered + valid, with ≥3 echo+fizzle feedback AND fizzles &gt; echoes; the new
+/// Importance is <c>max(Floor, Importance · MemoryRoi.Factor)</c>, skipped if the change is &lt;1%.
+/// It never sets ForgetAfter/Validity, so it is fully reversible.
+/// </summary>
+public class RoiDecayStageTests
+{
+    private const string Repo = "test-repo";
+
+    private static MemoryEntry Entry(
+        string id,
+        MemoryType type = MemoryType.Procedure,
+        float importance = 0.6f,
+        int echo = 0,
+        int fizzle = 0,
+        bool isLatest = true,
+        string? layerId = null,
+        DateTime? validUntil = null) => new()
+    {
+        Id = $"memories/{Repo}/{type.ToString().ToLowerInvariant()}/{id}",
+        RepoId = Repo,
+        Type = type,
+        Content = $"content for {id}",
+        CreatedAt = DateTime.UtcNow.AddDays(-30),
+        Validity = new Validity { ValidFrom = DateTime.UtcNow.AddDays(-30), ValidUntil = validUntil },
+        IsLatest = isLatest,
+        LayerId = layerId,
+        Importance = importance,
+        EchoCount = echo,
+        FizzleCount = fizzle,
+    };
+
+    private static async Task<StageOutcome> RunStageAsync(
+        InMemoryEidetStore store, bool isRepoActive = true)
+    {
+        var svc = new MemoryService(store);
+        return await svc.RunBulkAsync(async write =>
+        {
+            var ctx = isRepoActive
+                ? MaintenanceContext.ForTest(store, write, repoId: Repo)
+                : InactiveCtx(store, write);
+            return await new RoiDecayStage().ExecuteAsync(ctx, default);
+        });
+    }
+
+    private static MaintenanceContext InactiveCtx(InMemoryEidetStore store, BulkMutationCtx write)
+    {
+        var memory = new MemoryService(store);
+        var enrich = EnrichmentService.CreateNull();
+        return new MaintenanceContext
+        {
+            Store = store,
+            Write = write,
+            Enrichment = enrich,
+            Consolidation = new ConsolidationEngine(store, enrich, memory),
+            Dedup = new DedupEngine(store, memory, enrich),
+            RepoId = Repo,
+            IsRepoActive = false,
+        };
+    }
+
+    // ─── Happy path: net-negative action memory is demoted ────────────────────
+
+    [Fact]
+    public async Task NetNegative_procedure_with_enough_feedback_is_demoted_by_roi()
+    {
+        var store = new InMemoryEidetStore();
+        // 0 echo / 5 fizzle ⇒ roi = 3/8 = 0.375; importance 0.6 → 0.225.
+        var entry = Entry("bad", echo: 0, fizzle: 5, importance: 0.6f);
+        await store.StoreAsync(entry);
+
+        var outcome = await RunStageAsync(store);
+
+        Assert.Equal(1, outcome.Affected);
+        var expected = Math.Max(FadeMemCurve.Floor, 0.6f * (float)MemoryRoi.Factor(entry));
+        Assert.Equal(0.225f, entry.Importance, 0.0001f);
+        Assert.Equal(expected, entry.Importance, 0.0001f);
+    }
+
+    [Fact]
+    public async Task NetNegative_heuristic_is_also_demoted()
+    {
+        var store = new InMemoryEidetStore();
+        var entry = Entry("badh", MemoryType.Heuristic, echo: 1, fizzle: 4, importance: 0.7f);
+        await store.StoreAsync(entry);
+
+        var outcome = await RunStageAsync(store);
+
+        Assert.Equal(1, outcome.Affected);
+        // roi = (1+3)/(4+3) = 4/7; 0.7 * 4/7 = 0.4.
+        Assert.Equal(0.4f, entry.Importance, 0.0001f);
+    }
+
+    [Fact]
+    public async Task Demoted_importance_is_floored_at_fademem_floor()
+    {
+        var store = new InMemoryEidetStore();
+        // Heavy fizzle on an already-low importance: roi*importance would dip below the floor.
+        var entry = Entry("floored", echo: 0, fizzle: 50, importance: 0.07f);
+        await store.StoreAsync(entry);
+
+        await RunStageAsync(store);
+
+        Assert.Equal(FadeMemCurve.Floor, entry.Importance);
+    }
+
+    // ─── Eligibility gates ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Below_min_feedback_is_untouched()
+    {
+        var store = new InMemoryEidetStore();
+        // Net-negative but only 2 total feedback (< MinFeedback 3).
+        var entry = Entry("thin", echo: 0, fizzle: 2, importance: 0.6f);
+        await store.StoreAsync(entry);
+
+        var outcome = await RunStageAsync(store);
+
+        Assert.Equal(0, outcome.Affected);
+        Assert.Equal(0.6f, entry.Importance, 0.0001f);
+    }
+
+    [Fact]
+    public async Task NetNonnegative_action_memory_is_untouched()
+    {
+        var store = new InMemoryEidetStore();
+        // 5 echo / 4 fizzle: enough feedback but NOT net-negative.
+        var entry = Entry("good", echo: 5, fizzle: 4, importance: 0.6f);
+        await store.StoreAsync(entry);
+
+        var outcome = await RunStageAsync(store);
+
+        Assert.Equal(0, outcome.Affected);
+        Assert.Equal(0.6f, entry.Importance, 0.0001f);
+    }
+
+    [Theory]
+    [InlineData(MemoryType.Insight)]
+    [InlineData(MemoryType.Observation)]
+    public async Task Knowledge_types_are_untouched_even_when_net_negative(MemoryType type)
+    {
+        var store = new InMemoryEidetStore();
+        var entry = Entry("knowledge", type, echo: 0, fizzle: 10, importance: 0.6f);
+        await store.StoreAsync(entry);
+
+        var outcome = await RunStageAsync(store);
+
+        Assert.Equal(0, outcome.Affected);
+        Assert.Equal(0.6f, entry.Importance, 0.0001f);
+    }
+
+    [Fact]
+    public async Task Layered_memory_is_untouched()
+    {
+        var store = new InMemoryEidetStore();
+        // A read-only layer entry: net-negative but LayerId != null → the stage skips it.
+        var entry = Entry("layered", echo: 0, fizzle: 5, importance: 0.6f, layerId: "layers/base");
+        await store.StoreAsync(entry);
+
+        var outcome = await RunStageAsync(store);
+
+        Assert.Equal(0, outcome.Affected);
+        Assert.Equal(0.6f, entry.Importance, 0.0001f);
+    }
+
+    [Fact]
+    public async Task NonLatest_and_invalid_entries_are_untouched()
+    {
+        var store = new InMemoryEidetStore();
+        var superseded = Entry("old", echo: 0, fizzle: 5, importance: 0.6f, isLatest: false);
+        var expired = Entry("expired", echo: 0, fizzle: 5, importance: 0.6f,
+            validUntil: DateTime.UtcNow.AddDays(-1));
+        await store.StoreAsync(superseded);
+        await store.StoreAsync(expired);
+
+        var outcome = await RunStageAsync(store);
+
+        Assert.Equal(0, outcome.Affected);
+        Assert.Equal(0.6f, superseded.Importance, 0.0001f);
+        Assert.Equal(0.6f, expired.Importance, 0.0001f);
+    }
+
+    [Fact]
+    public async Task SubOnePercent_change_is_skipped_without_a_write()
+    {
+        var store = new CountingStore();
+        // roi ≈ 0.9999 (echo just under fizzle with large counts) → change < 1% → skip.
+        // (echo+K)/(fizzle+K) with echo=996, fizzle=997 = 999/1000 = 0.999 → 0.1% change → skipped.
+        var entry = Entry("tiny", echo: 996, fizzle: 997, importance: 0.6f);
+        await store.StoreAsync(entry);
+
+        var outcome = await RunStageAsync(store);
+
+        Assert.Equal(0, outcome.Affected);
+        Assert.Equal(0.6f, entry.Importance, 0.0001f);
+        Assert.Equal(0, store.UpdateCount);
+    }
+
+    // ─── Reversibility ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Demotion_never_sets_forgetafter_or_validity()
+    {
+        var store = new InMemoryEidetStore();
+        var entry = Entry("rev", echo: 0, fizzle: 5, importance: 0.6f);
+        await store.StoreAsync(entry);
+
+        await RunStageAsync(store);
+
+        Assert.Null(entry.ForgetAfter);
+        Assert.Null(entry.Validity.ValidUntil);
+        Assert.True(entry.IsLatest);
+    }
+
+    // ─── Convergence / idempotency ──────────────────────────────────────────────
+
+    [Fact]
+    public async Task Repeated_runs_converge_toward_but_never_below_the_floor_and_never_throw()
+    {
+        var store = new InMemoryEidetStore();
+        var entry = Entry("converge", echo: 0, fizzle: 5, importance: 0.6f);
+        await store.StoreAsync(entry);
+
+        var prev = entry.Importance;
+        for (var i = 0; i < 20; i++)
+        {
+            await RunStageAsync(store);
+            Assert.True(entry.Importance <= prev + 1e-6f,
+                $"run {i}: importance {entry.Importance} should not rise above prior {prev}");
+            Assert.True(entry.Importance >= FadeMemCurve.Floor,
+                $"run {i}: importance {entry.Importance} must stay at/above floor {FadeMemCurve.Floor}");
+            prev = entry.Importance;
+        }
+
+        // Eventually it lands at the floor and a further run is a no-op (no change ≥ 1%).
+        Assert.Equal(FadeMemCurve.Floor, entry.Importance);
+        var finalOutcome = await RunStageAsync(store);
+        Assert.Equal(0, finalOutcome.Affected);
+    }
+
+    // ─── Repo-active gate ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Inactive_repo_is_a_no_op()
+    {
+        var store = new InMemoryEidetStore();
+        var entry = Entry("bad", echo: 0, fizzle: 5, importance: 0.6f);
+        await store.StoreAsync(entry);
+
+        var outcome = await RunStageAsync(store, isRepoActive: false);
+
+        Assert.Equal(0, outcome.Affected);
+        Assert.Equal(0.6f, entry.Importance, 0.0001f);
+    }
+
+    /// <summary>Counts UpdateAsync calls — the write path BulkMutationCtx.WriteAsync routes through.</summary>
+    private sealed class CountingStore : InMemoryEidetStore
+    {
+        public int UpdateCount { get; private set; }
+
+        public override Task UpdateAsync(MemoryEntry entry, CancellationToken ct = default)
+        {
+            UpdateCount++;
+            return base.UpdateAsync(entry, ct);
+        }
+    }
+}

--- a/tests/Eidet.Core.Tests/Memory/ContextProcedureCapTests.cs
+++ b/tests/Eidet.Core.Tests/Memory/ContextProcedureCapTests.cs
@@ -1,0 +1,77 @@
+using Eidet.Core.Domain;
+using Eidet.Core.Services;
+using Eidet.Core.Tests.Services;
+
+namespace Eidet.Core.Tests.Memory;
+
+/// <summary>
+/// The L1 wake-up hard-caps procedures at 3 (issue #35) — a wrongly-recalled procedure is
+/// net-negative, so procedure pollution in the &lt;600-token wake-up is bounded regardless of the
+/// soft 30% type budget. Seeds many high-importance Procedures (which would otherwise dominate the
+/// top-K) and asserts at most three <c>[P]</c> lines come back from
+/// <see cref="MemoryService.GetContextAsync"/>.
+/// </summary>
+public class ContextProcedureCapTests
+{
+    private static MemoryEntry Entry(string id, MemoryType type, float importance) => new()
+    {
+        Id = $"memories/repo-a/{type.ToString().ToLowerInvariant()}/{id}",
+        RepoId = "repo-a",
+        Type = type,
+        Content = $"{type} memory {id}",
+        CreatedAt = DateTime.UtcNow,
+        Validity = new Validity { ValidFrom = DateTime.UtcNow },
+        IsLatest = true,
+        Importance = importance,
+    };
+
+    [Fact]
+    public async Task GetContext_caps_procedures_at_three_even_when_many_are_top_scored()
+    {
+        var store = new InMemoryEidetStore();
+        // 10 procedures, all higher importance than the knowledge entries — without the hard cap
+        // they would crowd out the wake-up. A handful of insights/heuristics fill the rest.
+        for (var i = 0; i < 10; i++)
+            await store.StoreAsync(Entry($"p{i}", MemoryType.Procedure, importance: 0.95f));
+        for (var i = 0; i < 5; i++)
+            await store.StoreAsync(Entry($"i{i}", MemoryType.Insight, importance: 0.5f));
+        for (var i = 0; i < 5; i++)
+            await store.StoreAsync(Entry($"h{i}", MemoryType.Heuristic, importance: 0.5f));
+
+        // Generous token budget so truncation can't be what limits the procedure count.
+        var context = await new MemoryService(store).GetContextAsync("repo-a", maxTokens: 4000);
+
+        var procedureLines = context
+            .Split('\n')
+            .Count(l => l.TrimStart().StartsWith("[P]"));
+
+        Assert.True(procedureLines <= 3, $"wake-up should cap procedures at 3, got {procedureLines}:\n{context}");
+    }
+
+    [Fact]
+    public async Task GetContext_freed_procedure_slots_backfill_insights_not_heuristics()
+    {
+        var store = new InMemoryEidetStore();
+        // Plenty of every type at equal high importance so the per-type budgets — not scarcity or
+        // token truncation — decide the wake-up mix.
+        for (var i = 0; i < 15; i++)
+            await store.StoreAsync(Entry($"i{i}", MemoryType.Insight, importance: 0.9f));
+        for (var i = 0; i < 10; i++)
+            await store.StoreAsync(Entry($"p{i}", MemoryType.Procedure, importance: 0.9f));
+        for (var i = 0; i < 10; i++)
+            await store.StoreAsync(Entry($"h{i}", MemoryType.Heuristic, importance: 0.9f));
+
+        var context = await new MemoryService(store).GetContextAsync("repo-a", maxTokens: 4000);
+        var lines = context.Split('\n');
+        var insights = lines.Count(l => l.TrimStart().StartsWith("[I]"));
+        var procedures = lines.Count(l => l.TrimStart().StartsWith("[P]"));
+        var heuristics = lines.Count(l => l.TrimStart().StartsWith("[H]"));
+
+        Assert.Equal(3, procedures); // hard cap
+        // The cap must NOT inflate heuristics (also action-shaped / net-negative-if-wrong); they keep
+        // their uncapped 20% share. The 3 freed slots flow to fully-trusted insights (10 -> 13).
+        Assert.True(heuristics <= 4, $"heuristics must keep their uncapped share (<=4), got {heuristics}:\n{context}");
+        Assert.Equal(13, insights);
+        Assert.Equal(20, insights + procedures + heuristics); // total item count unchanged
+    }
+}

--- a/tests/Eidet.Core.Tests/Memory/RoiFeedbackTests.cs
+++ b/tests/Eidet.Core.Tests/Memory/RoiFeedbackTests.cs
@@ -1,0 +1,171 @@
+using Eidet.Core.Domain;
+using Eidet.Core.Services;
+using Eidet.Core.Tests.Services;
+
+namespace Eidet.Core.Tests.Memory;
+
+/// <summary>
+/// Tests for the tiered fizzle penalty (issue #35) on <see cref="MemoryService.FeedbackAsync"/>.
+/// A fizzle optionally carries a <see cref="FizzleReason"/>: content-invalidating reasons
+/// (VersionDrift/Incorrect) cut Importance -0.2 / Confidence -0.3; everything else (WrongContext,
+/// Other, null) cuts -0.1 / -0.15. Echo is unchanged (+0.05/+0.1) and ignores the reason. The
+/// reason is recorded on <see cref="MemoryEntry.LastFizzleReason"/>. Driven through the shared
+/// <see cref="InMemoryEidetStore"/> like the boundary tests.
+/// </summary>
+public class RoiFeedbackTests
+{
+    private static MemoryEntry Entry(string id, float importance = 0.6f, float confidence = 0.6f, double? lastLexShare = null) => new()
+    {
+        Id = id,
+        RepoId = "repo-a",
+        Type = MemoryType.Procedure,
+        Content = id,
+        CreatedAt = DateTime.UtcNow,
+        Validity = new Validity { ValidFrom = DateTime.UtcNow },
+        IsLatest = true,
+        Importance = importance,
+        Confidence = confidence,
+        LastLexShare = lastLexShare,
+    };
+
+    private static async Task<MemoryEntry> SeedAsync(InMemoryEidetStore store, MemoryEntry entry)
+    {
+        await store.StoreAsync(entry);
+        return entry;
+    }
+
+    // ─── Content-invalidating fizzle → steeper penalty ────────────────────────
+
+    [Theory]
+    [InlineData(FizzleReason.VersionDrift)]
+    [InlineData(FizzleReason.Incorrect)]
+    public async Task ContentInvalidating_fizzle_cuts_importance_by_point_two_and_confidence_by_point_three(FizzleReason reason)
+    {
+        var store = new InMemoryEidetStore();
+        var entry = await SeedAsync(store, Entry("m1", importance: 0.6f, confidence: 0.6f));
+
+        var ok = await new MemoryService(store).FeedbackAsync("m1", wasUsed: false, reason);
+
+        Assert.True(ok);
+        Assert.Equal(0.4f, entry.Importance, 0.0001f);   // 0.6 - 0.2
+        Assert.Equal(0.3f, entry.Confidence, 0.0001f);   // 0.6 - 0.3
+        Assert.Equal(reason, entry.LastFizzleReason);
+        Assert.Equal(1, entry.FizzleCount);
+    }
+
+    // ─── Plain fizzle (WrongContext / Other / null) → shallow penalty ─────────
+
+    [Theory]
+    [InlineData(FizzleReason.WrongContext)]
+    [InlineData(FizzleReason.Other)]
+    public async Task NonContentInvalidating_fizzle_cuts_importance_by_point_one_and_confidence_by_point_one_five(FizzleReason reason)
+    {
+        var store = new InMemoryEidetStore();
+        var entry = await SeedAsync(store, Entry("m1", importance: 0.6f, confidence: 0.6f));
+
+        await new MemoryService(store).FeedbackAsync("m1", wasUsed: false, reason);
+
+        Assert.Equal(0.5f, entry.Importance, 0.0001f);    // 0.6 - 0.1
+        Assert.Equal(0.45f, entry.Confidence, 0.0001f);   // 0.6 - 0.15
+        Assert.Equal(reason, entry.LastFizzleReason);
+    }
+
+    [Fact]
+    public async Task Null_reason_fizzle_uses_the_shallow_penalty_and_records_null()
+    {
+        var store = new InMemoryEidetStore();
+        var entry = await SeedAsync(store, Entry("m1", importance: 0.6f, confidence: 0.6f));
+
+        await new MemoryService(store).FeedbackAsync("m1", wasUsed: false, reason: null);
+
+        Assert.Equal(0.5f, entry.Importance, 0.0001f);
+        Assert.Equal(0.45f, entry.Confidence, 0.0001f);
+        Assert.Null(entry.LastFizzleReason);
+    }
+
+    // ─── Echo is unchanged by the new contract; reason ignored ────────────────
+
+    [Fact]
+    public async Task Echo_raises_importance_and_confidence_and_ignores_reason()
+    {
+        var store = new InMemoryEidetStore();
+        var entry = await SeedAsync(store, Entry("m1", importance: 0.6f, confidence: 0.6f));
+
+        // A reason on an echo must be a no-op for the reason field — echo isn't a fizzle.
+        await new MemoryService(store).FeedbackAsync("m1", wasUsed: true, reason: FizzleReason.Incorrect);
+
+        Assert.Equal(0.65f, entry.Importance, 0.0001f);   // 0.6 + 0.05
+        Assert.Equal(0.7f, entry.Confidence, 0.0001f);    // 0.6 + 0.1
+        Assert.Equal(1, entry.EchoCount);
+        Assert.Equal(0, entry.FizzleCount);
+        Assert.Null(entry.LastFizzleReason); // echo path never sets LastFizzleReason
+    }
+
+    // ─── Clamps ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Importance_never_falls_below_floor_of_point_zero_five()
+    {
+        var store = new InMemoryEidetStore();
+        // Start at the lowest legal importance; a content-invalidating fizzle (-0.2) must clamp at 0.05.
+        var entry = await SeedAsync(store, Entry("m1", importance: 0.1f, confidence: 0.5f));
+
+        await new MemoryService(store).FeedbackAsync("m1", wasUsed: false, FizzleReason.VersionDrift);
+
+        Assert.Equal(0.05f, entry.Importance, 0.0001f);
+    }
+
+    [Fact]
+    public async Task Confidence_never_falls_below_zero()
+    {
+        var store = new InMemoryEidetStore();
+        var entry = await SeedAsync(store, Entry("m1", importance: 0.6f, confidence: 0.1f));
+
+        await new MemoryService(store).FeedbackAsync("m1", wasUsed: false, FizzleReason.Incorrect);
+
+        Assert.Equal(0.0f, entry.Confidence, 0.0001f); // 0.1 - 0.3 clamps to 0
+    }
+
+    // ─── Regression guard: tiered penalty must not break #33 alpha learning ───
+
+    /// <summary>
+    /// A fizzle on a memory that carries <see cref="MemoryEntry.LastLexShare"/> (was surfaced under v2)
+    /// must STILL run the #33 alpha-learning EWMA step after the tiered penalty. Uses the same
+    /// <see cref="AlphaLearningStore"/> harness as <see cref="AlphaLearningTests"/> so the fold is
+    /// observable; a high-lexShare fizzle pushes the learned alpha DOWN (the lexical mix misled).
+    /// </summary>
+    [Fact]
+    public async Task Fizzle_with_lexShare_still_triggers_alpha_learning_and_records_reason()
+    {
+        var store = new AlphaLearningStore();
+        store.Seed(new MemoryEntry
+        {
+            Id = "m1",
+            RepoId = "repo-a",
+            Type = MemoryType.Procedure,
+            Content = "m1",
+            CreatedAt = DateTime.UtcNow,
+            Validity = new Validity { ValidFrom = DateTime.UtcNow },
+            IsLatest = true,
+            Importance = 0.6f,
+            Confidence = 0.6f,
+            LastLexShare = 0.9,
+        });
+
+        Assert.Null(await store.GetRepoAlphaAsync("repo-a"));
+
+        await new MemoryService(store).FeedbackAsync("m1", wasUsed: false, FizzleReason.VersionDrift);
+
+        // Alpha-learning step ran exactly once and moved alpha below the 0.5 default (high lexShare fizzle).
+        Assert.Equal(1, store.AlphaUpdateCalls);
+        var alpha = await store.GetRepoAlphaAsync("repo-a");
+        Assert.NotNull(alpha);
+        Assert.True(alpha < 0.5, $"high-lexShare fizzle should pull alpha below default, got {alpha}");
+
+        // And the tiered penalty + reason still applied to the entry.
+        var entry = store.GetEntry("m1")!;
+        Assert.Equal(FizzleReason.VersionDrift, entry.LastFizzleReason);
+        Assert.Equal(0.4f, entry.Importance, 0.0001f);
+        Assert.Equal(0.3f, entry.Confidence, 0.0001f);
+    }
+}

--- a/tests/Eidet.Core.Tests/Memory/RoiGatingTests.cs
+++ b/tests/Eidet.Core.Tests/Memory/RoiGatingTests.cs
@@ -1,0 +1,202 @@
+using Eidet.Core.Domain;
+using Eidet.Core.Memory;
+using Eidet.Core.Services;
+using Eidet.Core.Storage;
+
+namespace Eidet.Core.Tests.Memory;
+
+/// <summary>
+/// Tests for the realized-benefit ROI gate (issue #35) — the demotion lever ORTHOGONAL to
+/// <see cref="MemoryTrust"/>. <see cref="MemoryRoi.Factor"/> is pure math: 1.0 everywhere except a
+/// proven net-negative Procedure/Heuristic (<c>FizzleCount &gt; EchoCount</c>), where it is
+/// <c>(echo + 3)/(fizzle + 3)</c>. The recall-time half mirrors <see cref="RecallTrustGatingTests"/>:
+/// driven through the scripted-arm <see cref="InMemoryScoredStore"/> so identical raw scores isolate
+/// the ROI multiplier, asserting <see cref="MemorySearchResult.RoiFactor"/> and the gated Score.
+/// </summary>
+public class RoiGatingTests
+{
+    private static readonly DateTime Now = new(2026, 6, 20, 0, 0, 0, DateTimeKind.Utc);
+
+    private static MemoryEntry Entry(
+        string id,
+        MemoryType type = MemoryType.Procedure,
+        int echo = 0,
+        int fizzle = 0) => new()
+    {
+        Id = id,
+        RepoId = "repo-a",
+        Type = type,
+        Content = id,
+        CreatedAt = Now,
+        Validity = new Validity { ValidFrom = Now },
+        EchoCount = echo,
+        FizzleCount = fizzle,
+        IsLatest = true,
+        Importance = 0.5f,
+    };
+
+    // ════════════════════════════════════════════════════════════════════════
+    // Pure MemoryRoi.Factor — only action-shaped, net-negative memories are penalized
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Theory]
+    [InlineData(MemoryType.Insight)]
+    [InlineData(MemoryType.Observation)]
+    public void Knowledge_types_are_never_penalized_even_with_many_fizzles(MemoryType type)
+    {
+        Assert.Equal(1.0, MemoryRoi.Factor(Entry("x", type, echo: 0, fizzle: 50)));
+    }
+
+    [Theory]
+    [InlineData(MemoryType.Procedure)]
+    [InlineData(MemoryType.Heuristic)]
+    public void ActionTypes_with_no_feedback_are_neutral(MemoryType type)
+    {
+        Assert.Equal(1.0, MemoryRoi.Factor(Entry("x", type, echo: 0, fizzle: 0)));
+    }
+
+    [Theory]
+    [InlineData(MemoryType.Procedure)]
+    [InlineData(MemoryType.Heuristic)]
+    public void ActionTypes_at_parity_are_neutral(MemoryType type)
+    {
+        // echo == fizzle is NOT net-negative (FizzleCount <= EchoCount) → no penalty.
+        Assert.Equal(1.0, MemoryRoi.Factor(Entry("x", type, echo: 5, fizzle: 5)));
+    }
+
+    [Theory]
+    [InlineData(MemoryType.Procedure)]
+    [InlineData(MemoryType.Heuristic)]
+    public void ActionTypes_net_positive_are_neutral(MemoryType type)
+    {
+        // echo > fizzle → the positive side is handled by UCB/trust, not ROI.
+        Assert.Equal(1.0, MemoryRoi.Factor(Entry("x", type, echo: 10, fizzle: 3)));
+    }
+
+    /// <summary>
+    /// Exact penalty values for a net-negative Procedure: <c>(echo + 3)/(fizzle + 3)</c>.
+    ///   0e/1f → 6/... wait: (0+3)/(1+3) = 0.75
+    ///   0e/3f → 3/6   = 0.5
+    ///   0e/5f → 3/8   = 0.375
+    ///   2e/5f → 5/8   = 0.625  (echoes lift the factor back toward 1.0)
+    /// </summary>
+    [Theory]
+    [InlineData(0, 1, 0.75)]
+    [InlineData(0, 3, 0.5)]
+    [InlineData(0, 5, 0.375)]
+    [InlineData(2, 5, 0.625)]
+    public void NetNegative_procedure_uses_exact_smoothed_ratio(int echo, int fizzle, double expected)
+    {
+        Assert.Equal(expected, MemoryRoi.Factor(Entry("x", MemoryType.Procedure, echo, fizzle)), precision: 12);
+    }
+
+    [Fact]
+    public void NetNegative_heuristic_uses_the_same_ratio_as_procedure()
+    {
+        var proc = MemoryRoi.Factor(Entry("p", MemoryType.Procedure, echo: 1, fizzle: 4));
+        var heur = MemoryRoi.Factor(Entry("h", MemoryType.Heuristic, echo: 1, fizzle: 4));
+        Assert.Equal(proc, heur, precision: 12);
+        Assert.Equal((1 + 3.0) / (4 + 3.0), heur, precision: 12);
+    }
+
+    [Fact]
+    public void Factor_decreases_monotonically_as_fizzles_grow_and_stays_in_open_unit_interval()
+    {
+        var prev = MemoryRoi.Factor(Entry("x", MemoryType.Procedure, echo: 0, fizzle: 1));
+        Assert.True(prev is > 0.0 and <= 1.0);
+        for (var fizzle = 2; fizzle <= 200; fizzle++)
+        {
+            var roi = MemoryRoi.Factor(Entry("x", MemoryType.Procedure, echo: 0, fizzle));
+            Assert.True(roi < prev, $"roi at fizzle={fizzle} ({roi}) should be below fizzle={fizzle - 1} ({prev})");
+            Assert.True(roi is > 0.0 and <= 1.0, $"roi {roi} must be in (0, 1]");
+            prev = roi;
+        }
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // FizzleReasons.IsContentInvalidating — the steeper-penalty predicate
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Theory]
+    [InlineData(FizzleReason.VersionDrift)]
+    [InlineData(FizzleReason.Incorrect)]
+    public void ContentInvalidating_reasons_are_true(FizzleReason reason)
+    {
+        Assert.True(FizzleReasons.IsContentInvalidating(reason));
+    }
+
+    [Theory]
+    [InlineData(FizzleReason.WrongContext)]
+    [InlineData(FizzleReason.Other)]
+    public void NonContentInvalidating_reasons_are_false(FizzleReason reason)
+    {
+        Assert.False(FizzleReasons.IsContentInvalidating(reason));
+    }
+
+    [Fact]
+    public void Null_reason_is_not_content_invalidating()
+    {
+        Assert.False(FizzleReasons.IsContentInvalidating(null));
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // Recall-time: ROI de-boosts a proven net-negative Procedure below an unfizzled clone
+    // ════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Two Procedures with identical raw arm scores: one net-negative (fizzles &gt; echoes), one clean.
+    /// The net-negative one gets <c>RoiFactor &lt; 1.0</c> and a strictly lower final Score; the clean
+    /// one gets <c>RoiFactor == 1.0</c>. Trust is equal (both fresh Procedures), so ROI alone moves it.
+    /// </summary>
+    [Fact]
+    public async Task NetNegative_procedure_scores_below_clean_clone_via_roi()
+    {
+        var store = new InMemoryScoredStore();
+        store.SetArm(SearchArm.Lexical, ("clean", 7.0), ("badproc", 7.0));
+        store.SetArm(SearchArm.Vector, ("clean", 7.0), ("badproc", 7.0));
+        store.Seed(
+            Entry("clean", MemoryType.Procedure, echo: 0, fizzle: 0),
+            Entry("badproc", MemoryType.Procedure, echo: 0, fizzle: 5));
+
+        var results = await new MemoryService(store).RecallAsync("repo-a", "query");
+
+        var clean = results.Single(r => r.Id == "clean");
+        var bad = results.Single(r => r.Id == "badproc");
+
+        Assert.Equal(1.0f, clean.RoiFactor);
+        Assert.True(bad.RoiFactor < 1.0f, $"net-negative proc RoiFactor ({bad.RoiFactor}) should be < 1.0");
+        Assert.Equal(0.375f, bad.RoiFactor, precision: 5); // (0+3)/(5+3)
+        Assert.True(bad.Score < clean.Score, $"bad score ({bad.Score}) should be below clean ({clean.Score})");
+    }
+
+    /// <summary>
+    /// An Insight is never ROI-penalized: even with heavy fizzles its <see cref="MemorySearchResult.RoiFactor"/>
+    /// stays 1.0 (the gate only fires for action-shaped types).
+    /// </summary>
+    [Fact]
+    public async Task Insight_keeps_roi_factor_of_one_regardless_of_fizzles()
+    {
+        var store = new InMemoryScoredStore();
+        store.SetArm(SearchArm.Lexical, ("ins", 7.0));
+        store.SetArm(SearchArm.Vector, ("ins", 7.0));
+        store.Seed(Entry("ins", MemoryType.Insight, echo: 0, fizzle: 20));
+
+        var result = (await new MemoryService(store).RecallAsync("repo-a", "query")).Single();
+
+        Assert.Equal(1.0f, result.RoiFactor);
+    }
+
+    /// <summary>A net-NONNEGATIVE Procedure (echoes ≥ fizzles) carries RoiFactor 1.0 at recall.</summary>
+    [Fact]
+    public async Task NetNonnegative_procedure_keeps_roi_factor_of_one()
+    {
+        var store = new InMemoryScoredStore();
+        store.SetArm(SearchArm.Lexical, ("proc", 7.0));
+        store.SetArm(SearchArm.Vector, ("proc", 7.0));
+        store.Seed(Entry("proc", MemoryType.Procedure, echo: 4, fizzle: 4));
+
+        var result = (await new MemoryService(store).RecallAsync("repo-a", "query")).Single();
+
+        Assert.Equal(1.0f, result.RoiFactor);
+    }
+}

--- a/tests/Eidet.Service.Tests/Tools/FeedbackToolHandlerTests.cs
+++ b/tests/Eidet.Service.Tests/Tools/FeedbackToolHandlerTests.cs
@@ -35,6 +35,63 @@ public class FeedbackToolHandlerTests
         Assert.Contains("Fizzle feedback", result.HumanSummary);
     }
 
+    // ─── snake_case reason → FizzleReason mapping (issue #35) ────────────────
+    // The FakeStore's UpdateAsync is a no-op and GetAsync hands back the same instance, so the
+    // reason that FeedbackAsync stamped onto LastFizzleReason is observable on the seeded entry.
+
+    [Theory]
+    [InlineData("version_drift", FizzleReason.VersionDrift)]
+    [InlineData("wrong_context", FizzleReason.WrongContext)]
+    [InlineData("incorrect", FizzleReason.Incorrect)]
+    [InlineData("other", FizzleReason.Other)]
+    public async Task Fizzle_KnownReason_MapsToEnum(string wire, FizzleReason expected)
+    {
+        var handler = NewHandler(out var store);
+        var entry = new MemoryEntry { Id = "memories/r/insight/abc", RepoId = "r", Type = MemoryType.Insight, Content = "x" };
+        store.Entries.Add(entry);
+
+        await Invoke(handler, new { id = entry.Id, used = false, reason = wire });
+
+        Assert.Equal(expected, entry.LastFizzleReason);
+    }
+
+    [Fact]
+    public async Task Fizzle_UnknownReason_FallsBackToOther()
+    {
+        var handler = NewHandler(out var store);
+        var entry = new MemoryEntry { Id = "memories/r/insight/abc", RepoId = "r", Type = MemoryType.Insight, Content = "x" };
+        store.Entries.Add(entry);
+
+        await Invoke(handler, new { id = entry.Id, used = false, reason = "garbage-not-a-reason" });
+
+        Assert.Equal(FizzleReason.Other, entry.LastFizzleReason);
+    }
+
+    [Fact]
+    public async Task Echo_IgnoresReason_LeavesLastFizzleReasonNull()
+    {
+        var handler = NewHandler(out var store);
+        var entry = new MemoryEntry { Id = "memories/r/insight/abc", RepoId = "r", Type = MemoryType.Insight, Content = "x" };
+        store.Entries.Add(entry);
+
+        // A reason on an echo is meaningless — it must not reach FeedbackAsync (stays null).
+        await Invoke(handler, new { id = entry.Id, used = true, reason = "version_drift" });
+
+        Assert.Null(entry.LastFizzleReason);
+    }
+
+    [Fact]
+    public async Task Fizzle_NoReasonArgument_LeavesLastFizzleReasonNull()
+    {
+        var handler = NewHandler(out var store);
+        var entry = new MemoryEntry { Id = "memories/r/insight/abc", RepoId = "r", Type = MemoryType.Insight, Content = "x" };
+        store.Entries.Add(entry);
+
+        await Invoke(handler, new { id = entry.Id, used = false });
+
+        Assert.Null(entry.LastFizzleReason);
+    }
+
     [Fact]
     public async Task UnknownMemory_ReturnsNotFound()
     {


### PR DESCRIPTION
## What

Implements **issue #35** — ROI tracking + reversible auto-demote for action memories (Procedure/Heuristic). A new `MemoryRoi` gate is **orthogonal to** `MemoryTrust` (#34): trust resists poisoning and never drops below its floor; ROI tracks *realized benefit* and **can** push a proven net-negative memory below that floor.

`Factor(entry)` = `1.0` except a Procedure/Heuristic with `FizzleCount > EchoCount`, which scales to `(echo+3)/(fizzle+3)`. Reversible by design — never forgets, never touches content; one echo back to parity restores full ROI.

## How it lands (4 of 5 items in code; item 5 reused)

1. **Recall de-boost** — `score = Fused × trust × roi`, then existing non-local de-boost. `MemorySearchResult.RoiFactor` surfaces it.
2. **Maintenance `RoiDecayStage`** — Importance-only, reversible FadeMem demotion; ordered after `ImportanceDecay`, before `Consolidation` (a demoted procedure can't seed an insight). `MinFeedback=3`; honors `IsRepoActive`; skips <1% changes. Pipeline 10 → 11 stages.
3. **`reason` enum on feedback** — optional `FizzleReason { WrongContext, Incorrect, VersionDrift, Other }`; content-invalidating reasons (`Incorrect`/`VersionDrift`) take a steeper penalty tier at fizzle time. Threaded through MCP `eidet_feedback`, REST `/api/eidet/feedback`, and the C# SDK. **No** coupling to nightly DriftReview/Ollama.
4. **Wake-up procedure hard-cap (3)** — a wrongly-recalled procedure is net-negative, so procedure pollution in the <600-token wake-up is bounded regardless of the soft 30% budget. The freed slots **backfill insights** (fully trusted), not heuristics (also action-shaped) — total item count unchanged at 20.
5. **Within-repo narrowness** — covered by #33's existing non-local de-boost; no new term added.

## Benchmark

No scorecard movement **by design** — every ROI lever sits outside pure `RecallScoring.Fuse` (trust/ROI/de-boost are production-only; `BenchmarkRunner.RankFused` calls `Fuse` directly), exactly like #34's trust gate.

## Tests

48 new (`RoiGatingTests`, `RoiFeedbackTests`, `RoiDecayStageTests`, `ContextProcedureCapTests`, `FeedbackToolHandlerTests` +7) plus `MaintenanceOrchestratorTests` 10 → 11. **Core 645 / 0 green.**

## Review

Ran through the implement → test → review ∥ verify pipeline. Verify: fully spec-conformant. Review: no blocking. One should-fix applied (cap's freed slots backfill insights, not heuristics) + two doc nits + an anti-inflation regression test.

Closes #35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9A49o4h6HJS6Ab42Sxhyd
