### PR TITLE
chore(release): v0.8.0

### DIFF
--- a/src/Eidet.Core/EidetVersion.cs
+++ b/src/Eidet.Core/EidetVersion.cs
@@ -2,5 +2,5 @@ namespace Eidet.Core;
 
 public static class EidetVersion
 {
-    public const string Current = "0.7.0";
+    public const string Current = "0.8.0";
 }


### PR DESCRIPTION
## Release v0.8.0

Single-line bump of `EidetVersion.Current` `0.7.0 → 0.8.0`. Merging this lands the version on `main`; pushing the `v0.8.0` tag afterward triggers `release.yml` (GitHub Release + binaries, NuGet, npm, PyPI, Docker). The CI gate enforces tag == `EidetVersion.Current`.

### What's shipping since v0.7.0 (16 commits)

**Features**
- **Loose Ends** — park/resolve open-work via `eidet_park` / `eidet_resolve` (#42); atomic resolve(Promoted) via claim-before-promote (#46)
- **Recall v2** — hybrid fusion + rerank-before-truncate + dual-clock recency (#47); per-repo alpha-learning + graph-neighbor expansion (#33/#52)
- **Retrieval benchmark** — deterministic scorecard, v2 fusion vs flat baseline (#36)

**Security**
- Memory provenance/trust tier + consolidation carry-through (#34) — anti-poisoning (T-7/T-8)
- Procedure/Heuristic ROI tracking + reversible auto-demote + STRIDE T-9 (#35)

**Fixes**
- RavenDB 7.2 `OptimisticConcurrencyMode` migration (#50)
- Quiet HttpListener client-disconnect noise
- Windows update-trampoline retry

### Verification
- Build + full suite green on this branch (single-const change; no behavior impact).
- No code touched beyond the version constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9A49o4h6HJS6Ab42Sxhyd
