### PR TITLE
ci: type-check the TypeScript SDK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,3 +49,24 @@ jobs:
         with:
           name: test-results-${{ matrix.os }}
           path: ./test-results/*.trx
+
+  typescript-sdk:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: sdk/typescript/package-lock.json
+
+      - name: Install
+        run: npm ci
+        working-directory: sdk/typescript
+
+      - name: Type-check
+        run: npx tsc --noEmit
+        working-directory: sdk/typescript


### PR DESCRIPTION
## Why

CI only builds/tests the .NET solution — `sdk/typescript` was never compiled, so dependency PRs touching the SDK (like #58, TypeScript v7) showed green regardless of whether the SDK still built.

## What

New `typescript-sdk` job in `ci.yml` (ubuntu-latest): `npm ci` + `npx tsc --noEmit` in `sdk/typescript`, with npm cache keyed on the SDK lock file.

Verified the exact commands locally against the TS 7.0.2 lock file — clean type-check. This PR's own checks exercise the new job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cy7ngCe11dRUTpag7MYLAM